### PR TITLE
Show method names/constant names when a class description is shown

### DIFF
--- a/lib/bitclust/searcher.rb
+++ b/lib/bitclust/searcher.rb
@@ -444,8 +444,23 @@ module BitClust
         puts
         puts @compiler.compile(c.source.strip)
       end
+
+      print_methods(c, :module_function, "* Module functions")
+      print_methods(c, :singleton_method, "* Singleton methods")
+      print_methods(c, :instance_method, "* Instance methods")
+      print_methods(c, :constant, "* Constants")
+      print_methods(c, :special_variable, "* Special variables")
     end
 
+    def print_methods(c, typename, title)
+      methods = c.methods.select{|m| m.typename == typename }
+      return if methods.empty?
+
+      puts
+      puts title
+      print_names methods.map{|m| m.name }
+    end
+    
     def describe_method(rec)
       unless rec.entry.library.name == '_builtin'
         puts "require '#{rec.entry.library.name}'"


### PR DESCRIPTION
refe でクラスを表示したときにメソッドや定数のリストが表示されると便利ではないでしょうか。以下のようになります。

```
$ refe Array 
class Array < Object

include Enumerable

配列クラスです。
配列は任意の Ruby オブジェクトを要素として持つことができます。

一般的には配列は配列式を使って

  [1, 2, 3]

のように生成します。

* Singleton methods
[] new try_convert yaml_tag_subclasses? 

* Instance methods
& * + - << <=> == [] []= abbrev assoc clear clone collect! 
combination compact concat cycle dclone delete delete_at delete_if 
each each_index empty? eql? fetch fill first flatten hash include? 
index insert inspect join keep_if last length pack permutation pop 
product push rassoc repeated_combination repeated_permutation replace 
reverse reverse_each rindex rotate rotate! sample select! shelljoin 
shift shuffle shuffle! slice slice! sort sort_by! taguri taguri= to_a 
to_ary to_yaml transpose uniq unshift values_at yaml_initialize zip |
```
