### PR TITLE
Update performance improvements

### DIFF
--- a/lib/bitclust/classentry.rb
+++ b/lib/bitclust/classentry.rb
@@ -260,42 +260,42 @@ module BitClust
 
     def singleton_methods(level = 0)
       # FIXME: inheritance
-      entries(level).select {|m| m.singleton_method? }.sort
+      entries(level).select {|m| m.singleton_method? }.sort_by {|entry| entry.sort_key }
     end
 
     def public_singleton_methods(level = 0)
       # FIXME: inheritance
-      entries(level).select {|m| m.public_singleton_method? }.sort
+      entries(level).select {|m| m.public_singleton_method? }.sort_by {|entry| entry.sort_key }
     end
 
     def instance_methods(level = 0)
       # FIXME: inheritance
-      entries(level).select {|m| m.instance_method? }.sort
+      entries(level).select {|m| m.instance_method? }.sort_by {|entry| entry.sort_key }
     end
 
     def private_singleton_methods(level = 0)
       # FIXME: inheritance
-      entries(level).select {|m| m.private_singleton_method? }.sort
+      entries(level).select {|m| m.private_singleton_method? }.sort_by {|entry| entry.sort_key }
     end
 
     def public_instance_methods(level = 0)
       # FIXME: inheritance
-      entries(level).select {|m| m.public_instance_method? }.sort
+      entries(level).select {|m| m.public_instance_method? }.sort_by {|entry| entry.sort_key }
     end
 
     def private_instance_methods(level = 0)
       # FIXME: inheritance
-      entries(level).select {|m| m.private_instance_method? }.sort
+      entries(level).select {|m| m.private_instance_method? }.sort_by {|entry| entry.sort_key }
     end
 
     alias private_methods   private_instance_methods
 
     def constants(level = 0)
-      entries(level).select {|m| m.constant? }.sort
+      entries(level).select {|m| m.constant? }.sort_by {|entry| entry.sort_key }
     end
 
     def special_variables
-      entries().select {|m| m.special_variable? }.sort
+      entries().select {|m| m.special_variable? }.sort_by {|entry| entry.sort_key }
     end
 
     def singleton_method?(name, inherit = true)


### PR DESCRIPTION
Use Array#sort_by instead of Array#sort.
This change improves update performance.
It is 25% faster than before.
Before: 16min
After: 12min
OS: Ubuntu 13.04 x86
CPU: Intel Core i5 M450 2.4GHz
Memory: 2GB
Ruby: 1.9.3p448
