### PR TITLE
Add ruby version to each page title

### DIFF
--- a/data/bitclust/template.epub/layout
+++ b/data/bitclust/template.epub/layout
@@ -6,7 +6,7 @@
   <meta http-equiv="Content-Language" content="ja-JP">
   <link rel="stylesheet" type="text/css" href="<%=h css_url() %>">
   <link rel="icon" type="image/png" href="<%=h favicon_url() %>">
-  <title><%=h @title %></title>
+  <title><%=h @title %> (Ruby <%=h ruby_version %>)</title>
 </head>
 <body>
 <%= yield %>

--- a/data/bitclust/template.lillia/layout
+++ b/data/bitclust/template.lillia/layout
@@ -6,7 +6,7 @@
   <link rel="stylesheet" type="text/css" href="<%=h css_url() %>">
   <script type="text/javascript" src="<%=h js_url() %>"></script>
   <link rel="icon" type="image/png" href="<%=h favicon_url() %>">
-  <title><%=h @title %></title>
+  <title><%=h @title %> (Ruby <%=h ruby_version %>)</title>
 </head>
 <body>
 <%= yield %>

--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -5,7 +5,7 @@
   <meta http-equiv="Content-Language" content="ja-JP">
   <link rel="stylesheet" type="text/css" href="<%=h css_url() %>">
   <link rel="icon" type="image/png" href="<%=h favicon_url() %>">
-  <title><%=h @title %></title>
+  <title><%=h @title %> (Ruby <%=h ruby_version %>)</title>
 </head>
 <body>
 <%= yield %>

--- a/data/bitclust/template/layout
+++ b/data/bitclust/template/layout
@@ -5,7 +5,7 @@
   <meta http-equiv="Content-Language" content="ja-JP">
   <link rel="stylesheet" type="text/css" href="<%=h css_url() %>">
   <link rel="icon" type="image/png" href="<%=h favicon_url() %>">
-  <title><%=h @title %></title>
+  <title><%=h @title %> (Ruby <%=h ruby_version %>)</title>
   <link rel="search" type="application/opensearchdescription+xml" title="<%= _('Ruby %s Reference Manual', ruby_version()) %>" href="<%=h opensearchdescription_url() %>">
 </head>
 <body>


### PR DESCRIPTION
for example:
- /2.1.0/index
  - => `Ruby 2.1.0 リファレンスマニュアル > オブジェクト指向スクリプト言語 Ruby`
- /2.1.0/spec/intro
  - => `Ruby 2.1.0 リファレンスマニュアル > はじめに`
- /1.9.3/class/String
  - => `Ruby 1.9.3 リファレンスマニュアル > class String`

タイトルにRubyのバージョン等を追加することで、Google等の検索結果が見やすくなったり、SNS等への投稿時にどのバージョンなのか分かりやすくなるメリットがあると思います。
