### PR TITLE
change rdoc link target.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2014-03-08  Sho Hashimoto  <sho.hsmt@gmail.com>
+
+	* lib/bitclust/rdcompiler.rb (BitClust::RDCompiler::rdoc_url):
+	  change rdoc link target.
+
 2013-09-08  Sho Hashimoto  <sho.hsmt@gmail.com>
 
 	* lib/bitclust/rrdparser.rb (BitClust::RRDParser#read_object_body):

--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -523,11 +523,7 @@ module BitClust
       cname = cname.gsub('::', '/')
       id = "method-#{tchar}-#{encodename_rdocurl(mname)}"
 
-      if libname == '_builtin'
-        "http://ruby-doc.org/core-#{version}/#{cname}.html##{id}"
-      else
-        "http://ruby-doc.org/stdlib-#{version}/libdoc/#{libname}/rdoc/#{cname}.html##{id}"
-      end
+      "http://docs.ruby-lang.org/en/#{version}/#{cname}.html##{id}"
     end
 
     def rdoc_link(method_id, version)

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -187,7 +187,7 @@ bar
  text
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>hoge</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://ruby-doc.org/core-2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>hoge</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <p>
 foo
@@ -211,7 +211,7 @@ text
 //}
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>self &lt;=&gt; </code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://ruby-doc.org/core-2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>self &lt;=&gt; </code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <p>
 abs
@@ -232,7 +232,7 @@ HERE
   dsc
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://ruby-doc.org/core-2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <dl>
 <dt>word1</dt>
@@ -259,7 +259,7 @@ dsc
 @see hoge
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://ruby-doc.org/core-2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <p>
 dsc
@@ -296,7 +296,7 @@ HERE
            dsc3
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://ruby-doc.org/core-2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <dl>
 <dt class='method-param'>[PARAM] arg:</dt>
@@ -324,7 +324,7 @@ dsc3
 //}
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://ruby-doc.org/core-2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <dl>
 <dt class='method-param'>[PARAM] arg:</dt>
@@ -350,7 +350,7 @@ bar
 HERE
     expected = <<'HERE'
 <dl>
-<dt class="method-heading" id="dummy"><code>hoge1</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://ruby-doc.org/core-2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>hoge1</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dt class="method-heading"><code>hoge2</code></dt>
 <dd class="method-description">
 <p>
@@ -589,7 +589,7 @@ HERE
 @see [[m:Array#*]], [[m:$,]]
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>join(sep = $,) -&gt; String</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://ruby-doc.org/core-2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>join(sep = $,) -&gt; String</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <p>
 [SEE_ALSO] <a href="dummy/method/Array/i/=2a">Array#*</a>, <a href="dummy/method/Kernel/v/=2c">$,</a>
@@ -607,7 +607,7 @@ HERE
 description
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>puts(str) -&gt; String</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://ruby-doc.org/core-2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>puts(str) -&gt; String</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <p class="todo">
 [TODO]
@@ -628,7 +628,7 @@ HERE
 description
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>puts(str) -&gt; String</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://ruby-doc.org/core-2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>puts(str) -&gt; String</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <p class="todo">
 [TODO] 1.9.2
@@ -676,42 +676,42 @@ HERE
   data("String#index" => {
           :method_id => "String/i.index._builtin",
           :version   => "2.0.0",
-          :expected  => "http://ruby-doc.org/core-2.0.0/String.html#method-i-index"
+          :expected  => "http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index"
        },
        "String.new" => {
           :method_id => "String/s.new._builtin",
           :version   => "2.0.0",
-          :expected  => "http://ruby-doc.org/core-2.0.0/String.html#method-c-new"
+          :expected  => "http://docs.ruby-lang.org/en/2.0.0/String.html#method-c-new"
        },
        "String#<=>" => {
           :method_id => "String/i.=3c=3d=3e._builtin",
           :version   => "2.0.0",
-          :expected  => "http://ruby-doc.org/core-2.0.0/String.html#method-i-3C-3D-3E"
+          :expected  => "http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-3C-3D-3E"
        },
        "String#empty?" => {
           :method_id => "String/i.empty=3f._builtin",
           :version   => "2.0.0",
-          :expected  => "http://ruby-doc.org/core-2.0.0/String.html#method-i-empty-3F"
+          :expected  => "http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-empty-3F"
        },
        "String#index v1.9.3" => {
           :method_id => "String/i.index._builtin",
           :version   => "1.9.3",
-          :expected  => "http://ruby-doc.org/core-1.9.3/String.html#method-i-index"
+          :expected  => "http://docs.ruby-lang.org/en/1.9.3/String.html#method-i-index"
        },
        "String#index v1.8.7" => {
           :method_id => "String/i.index._builtin",
           :version   => "1.8.7",
-          :expected  => "http://ruby-doc.org/core-1.8.7/String.html#method-i-index"
+          :expected  => "http://docs.ruby-lang.org/en/1.8.7/String.html#method-i-index"
        },
        "File::Stat#file?" => {
           :method_id => "File=Stat/i.file=3f._builtin",
           :version   => "2.0.0",
-          :expected  => "http://ruby-doc.org/core-2.0.0/File/Stat.html#method-i-file-3F"
+          :expected  => "http://docs.ruby-lang.org/en/2.0.0/File/Stat.html#method-i-file-3F"
        },
        "Net::HTTP#get" => {
           :method_id => "Net=HTTP/i.get.net.http",
           :version   => "2.0.0",
-          :expected  => "http://ruby-doc.org/stdlib-2.0.0/libdoc/net/http/rdoc/Net/HTTP.html#method-i-get"
+          :expected  => "http://docs.ruby-lang.org/en/2.0.0/Net/HTTP.html#method-i-get"
        })
   def test_rdoc_url(data)
     assert_equal(data[:expected], @c.rdoc_url(data[:method_id], data[:version]))
@@ -721,7 +721,7 @@ HERE
   data("String#index" => {
           :method_id => "String/i.index._builtin",
           :version   => "2.0.0",
-          :expected  => %Q(<a href="http://ruby-doc.org/core-2.0.0/String.html#method-i-index">rdoc</a>)
+          :expected  => %Q(<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>)
        })
   def test_rdoc_link(data)
     assert_equal(data[:expected], @c.rdoc_link(data[:method_id], data[:version]))


### PR DESCRIPTION
docs.ruby-lang.org/en にドキュメントが用意されたので rdoc のリンク先を変更してみました。

以下については動作する事を確認しています。
- Array#[]
- Tempfile.new
- Net::HTTP#get
