### PR TITLE
support version branching in BitClust::FunctionReferenceParser::parse_file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2014-03-16  Sho Hashimoto  <sho.hsmt@gmail.com>
+
+	* lib/bitclust/functionreferenceparser.rb
+	  (BitClust::FunctionReferenceParser::parse_file): support version
+	  branching.
+
 2014-03-08  Sho Hashimoto  <sho.hsmt@gmail.com>
 
 	* lib/bitclust/rdcompiler.rb (BitClust::RDCompiler::rdoc_url):

--- a/lib/bitclust/functionreferenceparser.rb
+++ b/lib/bitclust/functionreferenceparser.rb
@@ -28,13 +28,14 @@ module BitClust
 
     def parse_file(path, filename, properties)
       fopen(path, 'r:UTF-8') {|f|
-        return parse(f, filename)
+        return parse(f, filename, properties)
       }
     end
 
-    def parse(f, filename)
+    def parse(f, filename, params = {})
       @filename = filename
-      file_entries LineInput.new(f)
+      s = Preprocessor.read(f, params)
+      file_entries LineInput.for_string(s)
       @db.functions
     end
 

--- a/test/test_functionreferenceparser.rb
+++ b/test/test_functionreferenceparser.rb
@@ -1,0 +1,51 @@
+require 'test/unit'
+require 'bitclust'
+require 'bitclust/functionreferenceparser'
+
+class TestFunctionReferenceParser < Test::Unit::TestCase
+  def setup
+    prefix = 'db'
+    src = "test.rd"
+
+    @pwd = Dir.pwd
+    Dir.chdir(@tmpdir = Dir.mktmpdir)
+    File.open(src, 'w') do |file|
+      file.puts <<'HERE'
+--- VALUE func()
+#@since 2.0.0
+some text 1
+#@else
+some text 2
+#@end
+HERE
+    end
+    @path = File.join(@tmpdir, src)
+    @db = BitClust::FunctionDatabase.new(prefix)
+    @parser = BitClust::FunctionReferenceParser.new(@db)
+  end
+
+  def teardown
+    Dir.chdir @pwd
+    FileUtils.rm_r(@tmpdir, :force => true)
+  end
+
+  data("1.9.3" => {
+         :version   => "1.9.3",
+         :expected  => ["some text 2\n"],
+       },
+       "2.0.0" => {
+         :version   => "2.0.0",
+         :expected  => ["some text 1\n"],
+       },
+       "2.1.0" => {
+         :version   => "2.1.0",
+         :expected  => ["some text 1\n"],
+       })
+  def test_parse_file(data)
+    @db.transaction {
+      result =
+        @parser.parse_file(@path, "test.c", {"version" => data[:version]})
+      assert_equal data[:expected], result.collect(&:source)
+    }
+  end
+end


### PR DESCRIPTION
PreProcessor を使っていないようだったので使うようにしてみました。
