### PR TITLE
Drop 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 rvm:
-  - 1.9.3
   - 2.0.0
 #  - ruby-head
 notifications:


### PR DESCRIPTION
Ruby 1.9.3 のサボートが終了したためTravis CIの設定から削除しました。