### PR TITLE
normalize Pathname from ENV['HOME']

### DIFF
--- a/lib/bitclust/subcommands/setup_command.rb
+++ b/lib/bitclust/subcommands/setup_command.rb
@@ -64,7 +64,7 @@ module BitClust
       end
 
       def prepare
-        home_directory = Pathname(ENV["HOME"])
+        home_directory = Pathname(ENV["HOME"]).expand_path
         config_dir = home_directory + ".bitclust"
         config_dir.mkpath
         config_path = config_dir + "config"


### PR DESCRIPTION
Hi.
I'm try to use refe2 with windows and my ENV['HOME'] is "C:\\home", contains backslash
to divide file path components.

With such environment, refe2 is fail because BitClust::Searcher parse `config[:detabase_prefix]',
 contains a value of ENV['HOME'] by default, as part of URI.
So I couldn't use refe2 without editing `~/.bitclust/config' at first.

In this patch, when creating default config file, apply Pathname#expand_path in order to normalize
"backslashed-filepath".