### PR TITLE
 allow dot for document_url.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-01-10  Sho Hashimoto  <sho.hsmt@gmail.com>
+
+	* lib/bitclust/screen.rb (BitClust::URLMapper#document_url):
+	  allow dot for document_url.
+
 2014-03-16  Sho Hashimoto  <sho.hsmt@gmail.com>
 
 	* lib/bitclust/functionreferenceparser.rb

--- a/lib/bitclust/screen.rb
+++ b/lib/bitclust/screen.rb
@@ -163,7 +163,7 @@ module BitClust
     end
 
     def document_url(name)
-      raise unless %r!\A[-\w/]+\z! =~ name
+      raise unless %r!\A[-\w/.]+\z! =~ name
       "#{@cgi_url}/#{name}"
     end
   end


### PR DESCRIPTION
[[d:news/2.3.0]] が0.9.1現在はcompile errorとして表示されるため、.も含められるようにしました。2_3_0.rdにすべきという話であればmergeじゃなくてrejectしてもらうつもりです。