### PR TITLE
Remove rake dependency from gemspecs

### DIFF
--- a/bitclust-dev.gemspec
+++ b/bitclust-dev.gemspec
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
-require 'rake'
 require "bitclust/version"
 
 Gem::Specification.new do |s|
@@ -18,10 +17,10 @@ EOD
 
   s.rubyforge_project = ""
 
-  s.files         = FileList["tools/*", "lib/bitclust.rb"]
-  s.executables   = FileList["tools/*"].
-    exclude("ToDoHistory", "check-signature.rb").
-    map{|v| File.basename(v) }
+  s.files         = Dir["tools/*", "lib/bitclust.rb"]
+  s.executables   = Dir["tools/*"].
+    map{|v| File.basename(v) }.
+    select{|f| !%w(ToDoHistory check-signature.rb).include? f}
   s.require_paths = ["lib"]
   s.bindir        = "tools"
 

--- a/bitclust.gemspec
+++ b/bitclust.gemspec
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
-require 'rake'
 require "bitclust/version"
 
 Gem::Specification.new do |s|
@@ -17,9 +16,9 @@ EOD
 
   s.rubyforge_project = ""
 
-  s.files         = FileList["ChangeLog", "Gemfile", "README", "Rakefile", "bitclust.gemspec",
-                             "data/**/*", "lib/**/*.rb", "theme/**/*"].exclude("*~")
-  s.test_files    = FileList["test/**/*.rb"].exclude("*~")
+  s.files         = Dir["ChangeLog", "Gemfile", "README", "Rakefile", "bitclust.gemspec",
+                             "data/**/*", "lib/**/*.rb", "theme/**/*"].select{|f| !(f =~ /.*~/)}
+  s.test_files    = Dir["test/**/*.rb"].select{|f| !(f =~ /.*~/)}
   s.executables   = ["bitclust"]
   s.require_paths = ["lib"]
 

--- a/refe2.gemspec
+++ b/refe2.gemspec
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
-require 'rake'
 require "bitclust/version"
 
 Gem::Specification.new do |s|
@@ -17,7 +16,7 @@ This is tools for Rubyists.
 EOD
 
   s.rubyforge_project = ""
-  s.files         = FileList["bin/refe", "lib/bitclust.rb"]
+  s.files         = Dir["bin/refe", "lib/bitclust.rb"]
   s.executables   = ["refe"]
   s.require_paths = ["lib"]
 


### PR DESCRIPTION
I tried to use HEAD revision of rurema-search. But it shows dependency error when I invoke `bundle install`

```
(snip)
 DEBUG [8cd53a1a] Command: cd /var/rubydoc/rurema-search/releases/20160514003652 && ( export RBENV_ROOT="/home/rurema/.rbenv" RBENV_VERSION="2.3.1" ; /home/rurema/.rbenv/bin/rbenv exec bundle install --path /var/rubydoc/rurema-search/shared/bundle --without development test --deployment --quiet )
 DEBUG [8cd53a1a]       There was a LoadError while loading bitclust-dev.gemspec:
cannot load such file -- rake from
/var/rubydoc/rurema-search/shared/bundle/ruby/2.3.0/bundler/gems/bitclust-6db8204b56cb/bitclust-dev.gemspec:3:in
`<main>'

Does it try to require a relative path? That's been removed in Ruby 1.9.
```

It caused that `rake` is removed from stdlib at Ruby 2.3. I removed rake depend from gemspecs.