### PR TITLE
Removed compatibility hack for old rubies.

### DIFF
--- a/lib/bitclust/compat.rb
+++ b/lib/bitclust/compat.rb
@@ -14,14 +14,6 @@ unless Object.method_defined?(:funcall)
   end
 end
 
-if 0.class != Integer && !Fixnum.method_defined?(:ord)
-  class Fixnum
-    def ord
-      self
-    end
-  end
-end
-
 unless String.method_defined?(:lines)
   class String
     alias lines to_a


### PR DESCRIPTION
I faced deprecated warning with Ruby 2.4.0 on docs.ruby-lang.org. Like

`/var/rubydoc/bitclust/lib/bitclust/compat.rb:17: warning: constant ::Fixnum is deprecated`

`Fixnum.method_defined?(:ord)` is only false before Ruby 1.8.7.  so Ruby 1.8.6 is already EOL. We should remove this code.