### PR TITLE
Tweak dependency for `rake test`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/Gemfile.lock

--- a/bitclust-core.gemspec
+++ b/bitclust-core.gemspec
@@ -27,6 +27,7 @@ EOD
   # s.add_runtime_dependency "rest-client"
   s.add_development_dependency "test-unit", ">= 2.3.0"
   s.add_development_dependency "test-unit-notify"
+  s.add_development_dependency "terminal-notifier"
   s.add_development_dependency "test-unit-rr"
   s.add_runtime_dependency "rack"
   s.add_runtime_dependency "progressbar"


### PR DESCRIPTION
After invoking `rake test`, I got following error message with rbenv.

```
rbenv: terminal-notifier: command not found
```

It caused by implicitly dependency for `test-unit-notify`. I added missing dependency.