### PR TITLE
Fix RDCompiler#rdoc_url for ARGF.class

### DIFF
--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -528,6 +528,7 @@ module BitClust
     def rdoc_url(method_id, version)
       cname, tmark, mname, libname = methodid2specparts(method_id)
       tchar = typemark2char(tmark) == 'i' ? 'i' : 'c'
+      cname = cname.split(".").first
       cname = cname.gsub('::', '/')
       id = "method-#{tchar}-#{encodename_rdocurl(mname)}"
 

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -736,6 +736,11 @@ HERE
           :method_id => "Net=HTTP/i.get.net.http",
           :version   => "2.0.0",
           :expected  => "http://docs.ruby-lang.org/en/2.0.0/Net/HTTP.html#method-i-get"
+       },
+       "ARGF.class#binmode" => {
+          :method_id => "ARGF.class/i.binmode.argf._builtin",
+          :version   => "2.0.0",
+          :expected  => "http://docs.ruby-lang.org/en/2.0.0/ARGF.html#method-i-binmode"
        })
   def test_rdoc_url(data)
     assert_equal(data[:expected], @c.rdoc_url(data[:method_id], data[:version]))


### PR DESCRIPTION
https://github.com/rurema/doctree/pull/598 の作業中に ARGF 関連のるりまの記事から
rdoc へのリンクが軒並み404エラーになっていることをみつけました。

https://docs.ruby-lang.org/ja/2.4.0/method/ARGF=2eclass/i/binmode.html

上記ページから rdoc リンクを押すと 404 エラーが再現します。

るりまからrdocへの遷移は `ClassName` or `NameSpace1::NameSpace2::ClassName` のパターンはサポートしているが、 `ARGF.class` は想定外の形式だったため404になっていた。

例えば binmode へのリンクの場合、
修正前は

https://docs.ruby-lang.org/en/2.4.0/ARGF.class.html#method-i-binmode

修正後は

https://docs.ruby-lang.org/en/2.4.0/ARGF.html#method-i-binmode

にリンクする。
