### PR TITLE
Use https for docs.ruby-lang.org

### DIFF
--- a/bitclust-core.gemspec
+++ b/bitclust-core.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version     = BitClust::VERSION
   s.authors     = ["https://github.com/rurema"]
   s.email       = [""]
-  s.homepage    = "http://docs.ruby-lang.org/ja/"
+  s.homepage    = "https://docs.ruby-lang.org/ja/"
   s.summary     = %Q!BitClust is a rurema document processor.!
   s.description =<<EOD
 Rurema is a Japanese ruby documentation project, and

--- a/bitclust-dev.gemspec
+++ b/bitclust-dev.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version     = BitClust::VERSION
   s.authors     = ["https://github.com/rurema"]
   s.email       = [""]
-  s.homepage    = "http://docs.ruby-lang.org/ja/"
+  s.homepage    = "https://docs.ruby-lang.org/ja/"
   s.summary     = %Q!BitClust is a rurema document processor.!
   s.description =<<EOD
 Rurema is a Japanese ruby documentation project, and

--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -532,7 +532,7 @@ module BitClust
       cname = cname.gsub('::', '/')
       id = "method-#{tchar}-#{encodename_rdocurl(mname)}"
 
-      "http://docs.ruby-lang.org/en/#{version}/#{cname}.html##{id}"
+      "https://docs.ruby-lang.org/en/#{version}/#{cname}.html##{id}"
     end
 
     def rdoc_link(method_id, version)

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -187,7 +187,7 @@ bar
  text
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>hoge</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>hoge</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <p>
 foo
@@ -211,7 +211,7 @@ text
 //}
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>self &lt;=&gt; </code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>self &lt;=&gt; </code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <p>
 abs
@@ -232,7 +232,7 @@ HERE
   dsc
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <dl>
 <dt>word1</dt>
@@ -259,7 +259,7 @@ dsc
 @see hoge
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <p>
 dsc
@@ -296,7 +296,7 @@ HERE
            dsc3
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <dl>
 <dt class='method-param'>[PARAM] arg:</dt>
@@ -324,7 +324,7 @@ dsc3
 //}
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>method</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <dl>
 <dt class='method-param'>[PARAM] arg:</dt>
@@ -350,7 +350,7 @@ bar
 HERE
     expected = <<'HERE'
 <dl>
-<dt class="method-heading" id="dummy"><code>hoge1</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>hoge1</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dt class="method-heading"><code>hoge2</code></dt>
 <dd class="method-description">
 <p>
@@ -613,7 +613,7 @@ HERE
 @see [[m:Array#*]], [[m:$,]]
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>join(sep = $,) -&gt; String</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>join(sep = $,) -&gt; String</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <p>
 [SEE_ALSO] <a href="dummy/method/Array/i/=2a">Array#*</a>, <a href="dummy/method/Kernel/v/=2c">$,</a>
@@ -631,7 +631,7 @@ HERE
 description
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>puts(str) -&gt; String</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>puts(str) -&gt; String</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <p class="todo">
 [TODO]
@@ -652,7 +652,7 @@ HERE
 description
 HERE
     expected = <<'HERE'
-<dt class="method-heading" id="dummy"><code>puts(str) -&gt; String</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading" id="dummy"><code>puts(str) -&gt; String</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
 <dd class="method-description">
 <p class="todo">
 [TODO] 1.9.2
@@ -700,47 +700,47 @@ HERE
   data("String#index" => {
           :method_id => "String/i.index._builtin",
           :version   => "2.0.0",
-          :expected  => "http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index"
+          :expected  => "https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index"
        },
        "String.new" => {
           :method_id => "String/s.new._builtin",
           :version   => "2.0.0",
-          :expected  => "http://docs.ruby-lang.org/en/2.0.0/String.html#method-c-new"
+          :expected  => "https://docs.ruby-lang.org/en/2.0.0/String.html#method-c-new"
        },
        "String#<=>" => {
           :method_id => "String/i.=3c=3d=3e._builtin",
           :version   => "2.0.0",
-          :expected  => "http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-3C-3D-3E"
+          :expected  => "https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-3C-3D-3E"
        },
        "String#empty?" => {
           :method_id => "String/i.empty=3f._builtin",
           :version   => "2.0.0",
-          :expected  => "http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-empty-3F"
+          :expected  => "https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-empty-3F"
        },
        "String#index v1.9.3" => {
           :method_id => "String/i.index._builtin",
           :version   => "1.9.3",
-          :expected  => "http://docs.ruby-lang.org/en/1.9.3/String.html#method-i-index"
+          :expected  => "https://docs.ruby-lang.org/en/1.9.3/String.html#method-i-index"
        },
        "String#index v1.8.7" => {
           :method_id => "String/i.index._builtin",
           :version   => "1.8.7",
-          :expected  => "http://docs.ruby-lang.org/en/1.8.7/String.html#method-i-index"
+          :expected  => "https://docs.ruby-lang.org/en/1.8.7/String.html#method-i-index"
        },
        "File::Stat#file?" => {
           :method_id => "File=Stat/i.file=3f._builtin",
           :version   => "2.0.0",
-          :expected  => "http://docs.ruby-lang.org/en/2.0.0/File/Stat.html#method-i-file-3F"
+          :expected  => "https://docs.ruby-lang.org/en/2.0.0/File/Stat.html#method-i-file-3F"
        },
        "Net::HTTP#get" => {
           :method_id => "Net=HTTP/i.get.net.http",
           :version   => "2.0.0",
-          :expected  => "http://docs.ruby-lang.org/en/2.0.0/Net/HTTP.html#method-i-get"
+          :expected  => "https://docs.ruby-lang.org/en/2.0.0/Net/HTTP.html#method-i-get"
        },
        "ARGF.class#binmode" => {
           :method_id => "ARGF.class/i.binmode.argf._builtin",
           :version   => "2.0.0",
-          :expected  => "http://docs.ruby-lang.org/en/2.0.0/ARGF.html#method-i-binmode"
+          :expected  => "https://docs.ruby-lang.org/en/2.0.0/ARGF.html#method-i-binmode"
        })
   def test_rdoc_url(data)
     assert_equal(data[:expected], @c.rdoc_url(data[:method_id], data[:version]))
@@ -750,7 +750,7 @@ HERE
   data("String#index" => {
           :method_id => "String/i.index._builtin",
           :version   => "2.0.0",
-          :expected  => %Q(<a href="http://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>)
+          :expected  => %Q(<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>)
        })
   def test_rdoc_link(data)
     assert_equal(data[:expected], @c.rdoc_link(data[:method_id], data[:version]))

--- a/tools/insert-canonical.rb
+++ b/tools/insert-canonical.rb
@@ -4,7 +4,7 @@ require "fileutils"
 require "tempfile"
 require "strscan"
 
-canonical_base_url = "http://docs.ruby-lang.org/ja/latest/"
+canonical_base_url = "https://docs.ruby-lang.org/ja/latest/"
 base_dir = nil
 
 parser = OptionParser.new


### PR DESCRIPTION
https://github.com/rurema/bitclust/pull/29/files をみて気づいたのですが、http のままになっていたようなので、https に変更した方が良いのではないかと思いました。