### PR TITLE
CI update to 2.3.5 and 2.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 rvm:
-  - 2.3.3
-  - 2.4.0
+  - 2.3.5
+  - 2.4.2
 #  - ruby-head
 notifications:
   recipients:


### PR DESCRIPTION
Rubyの新しいバージョンがリリースされていたので、CIをアップデートします。

https://www.ruby-lang.org/ja/news/2017/09/14/ruby-2-3-5-released/
https://www.ruby-lang.org/ja/news/2017/09/14/ruby-2-4-2-released/
