### PR TITLE
Expand link in td

### DIFF
--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -176,6 +176,7 @@ td {
 
 table.entries {
     width: 100%;
+    height: 100%;
 }
 
 table.entries tr {
@@ -196,6 +197,7 @@ td.signature {
 td.signature a {
     display: block;
     padding: 0.3em;
+    height: 100%;
 }
 
 td.description {


### PR DESCRIPTION
https://docs.ruby-lang.org/ja/latest/library/_builtin.html で
<img width="323" alt="2017-10-08 16 51 00" src="https://user-images.githubusercontent.com/11857/31315005-5c03b354-ac49-11e7-8084-de507774851d.png">
のようにリンクがセルいっぱいになっていなかったのを、
<img width="324" alt="2017-10-08 16 50 31" src="https://user-images.githubusercontent.com/11857/31315015-7d428a40-ac49-11e7-818d-a868b4006861.png">
のようにセルいっぱいになるようにする修正です。

一番最後の行が
<img width="323" alt="2017-10-08 16 50 46" src="https://user-images.githubusercontent.com/11857/31315019-88d00da6-ac49-11e7-8c29-57655070a033.png">
のようにはみ出してしまうようですが、対処方法がわかりませんでした。

多少不恰好な部分があっても、全体がクリックできるようになる方が利便性が上がって良いのではないかと思っています。