### PR TITLE
Fix h5 not to be red

### DIFF
--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -91,8 +91,15 @@ h4 {
     margin-bottom: 0.5em;
 }
 
+h5 {
+    font-size: 110%;
+    text-align: left;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+}
+
 /* never use */
-h5, h6 {
+h6 {
     background-color: red;
 }
 


### PR DESCRIPTION
It's in use.
https://docs.ruby-lang.org/ja/latest/class/Benchmark.html

![screenshot from 2017-11-21 22-39-13](https://user-images.githubusercontent.com/3138447/33075459-e4123f78-cf0c-11e7-8e0c-14affc8e4538.png)
