### PR TITLE
Fix preprocessor state

### DIFF
--- a/lib/bitclust/preprocessor.rb
+++ b/lib/bitclust/preprocessor.rb
@@ -292,8 +292,7 @@ module BitClust
       end
 
       def samplecode?
-        @current == :samplecode ||
-          (@current == true && @previous == :samplecode)
+        @current == :samplecode
       end
     end
   end

--- a/test/test_preprocessor.rb
+++ b/test/test_preprocessor.rb
@@ -231,4 +231,35 @@ HERE
     ret = Preprocessor.wrap(StringIO.new(src), params).to_a
     assert_equal(expected, ret.join)
   end
+
+  def test_samplecode_with_condition4
+    params = { 'version' => '1.9.2' }
+    src = <<HERE
+--- puts(str) -> String
+
+xxx
+
+\#@samplecode description
+puts("xxx")
+puts("yyy")
+\#@since 1.9.2
+puts("zzz")
+\#@end
+\#@end
+HERE
+
+    expected = <<HERE
+--- puts(str) -> String
+
+xxx
+
+//emlist[description][ruby]{
+puts("xxx")
+puts("yyy")
+puts("zzz")
+//}
+HERE
+    ret = Preprocessor.wrap(StringIO.new(src), params).to_a
+    assert_equal(expected, ret.join)
+  end
 end


### PR DESCRIPTION
In previous version, output extra "//}\n" with following input

    #@samplecode
    puts "samplecode for all versions"
    #@since 2.4.0
    puts "samplecode for 2.4.0"
    #@end
    #@end