### PR TITLE
外部リンクは別タブで開くようにした

### DIFF
--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -461,7 +461,7 @@ module BitClust
     end
 
     def direct_url(url)
-      %Q(<a class="external" href="#{escape_html(url)}">#{escape_html(url)}</a>)
+      %Q(<a class="external" target="_blank" rel="noopener" href="#{escape_html(url)}">#{escape_html(url)}</a>)
     end
 
     def reference_link(arg)
@@ -498,14 +498,14 @@ module BitClust
 
     def blade_link(ml, num)
       url = sprintf(BLADE_URL, ml, num)
-      %Q(<a class="external" href="#{escape_html(url)}">[#{escape_html("#{ml}:#{num}")}]</a>)
+      %Q(<a class="external" target="_blank" rel="noopener" href="#{escape_html(url)}">[#{escape_html("#{ml}:#{num}")}]</a>)
     end
 
     RFC_URL = 'https://tools.ietf.org/html/rfc%s'
 
     def rfc_link(num)
       url = sprintf(RFC_URL, num)
-      %Q(<a class="external" href="#{escape_html(url)}">[RFC#{escape_html(num)}]</a>)
+      %Q(<a class="external" target="_blank" rel="noopener" href="#{escape_html(url)}">[RFC#{escape_html(num)}]</a>)
     end
 
     opengroup_url = 'http://www.opengroup.org/onlinepubs/009695399'
@@ -535,14 +535,14 @@ module BitClust
     def man_link(spec)
       m = /([\w\.\/]+)\((\w+)\)/.match(spec) or return escape_html(spec)
       url = man_url(m[2], escape_html(m[1])) or return escape_html(spec)
-      %Q(<a class="external" href="#{escape_html(url)}">#{escape_html("#{m[1]}(#{m[2]})")}</a>)
+      %Q(<a class="external" target="_blank" rel="noopener" href="#{escape_html(url)}">#{escape_html("#{m[1]}(#{m[2]})")}</a>)
     end
 
     BUGS_URL = "https://bugs.ruby-lang.org/issues/%s"
 
     def bugs_link(type, id)
       url = sprintf(BUGS_URL, id)
-      %Q(<a class="external" href="#{escape_html(url)}">[#{type}##{id}]</a>)
+      %Q(<a class="external" target="_blank" rel="noopener" href="#{escape_html(url)}">[#{type}##{id}]</a>)
     end
 
     def rdoc_url(method_id, version)

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -655,20 +655,20 @@ HERE
        "C API root"          => ['[[f:/]]',           '<a href="dummy/function/">All C API</a>'],
        "C API index"         => ['[[f:_index]]',      '<a href="dummy/function/">All C API</a>'],
        "standard library"    => ['[[lib:jcode]]',     '<a href="dummy/library/jcode">jcode</a>'],
-       "man command"         => ['[[man:tr(1)]]',     '<a class="external" href="http://www.opengroup.org/onlinepubs/009695399/utilities/tr.html">tr(1)</a>'],
-       "man header"          => ['[[man:sys/socket.h(header)]]', '<a class="external" href="http://www.opengroup.org/onlinepubs/009695399/basedefs/sys/socket.h.html">sys/socket.h(header)</a>'],
-       "man system call"     => ['[[man:fopen(3linux)]]', '<a class="external" href="http://man7.org/linux/man-pages/man3/fopen.3.html">fopen(3linux)</a>'],
-       "RFC"                 => ['[[RFC:2822]]',      '<a class="external" href="https://tools.ietf.org/html/rfc2822">[RFC2822]</a>'],
+       "man command"         => ['[[man:tr(1)]]',     '<a class="external" target="_blank" rel="noopener" href="http://www.opengroup.org/onlinepubs/009695399/utilities/tr.html">tr(1)</a>'],
+       "man header"          => ['[[man:sys/socket.h(header)]]', '<a class="external" target="_blank" rel="noopener" href="http://www.opengroup.org/onlinepubs/009695399/basedefs/sys/socket.h.html">sys/socket.h(header)</a>'],
+       "man system call"     => ['[[man:fopen(3linux)]]', '<a class="external" target="_blank" rel="noopener" href="http://man7.org/linux/man-pages/man3/fopen.3.html">fopen(3linux)</a>'],
+       "RFC"                 => ['[[RFC:2822]]',      '<a class="external" target="_blank" rel="noopener" href="https://tools.ietf.org/html/rfc2822">[RFC2822]</a>'],
        "special var $~"      => ['[[m:$~]]',          '<a href="dummy/method/Kernel/v/=7e">$~</a>'],
        "special var $,"      => ['[[m:$,]]',          '<a href="dummy/method/Kernel/v/=2c">$,</a>'],
        "extra close bracket" => ['[[c:String]]]', '<a href="dummy/class/String">String</a>]'],
        "continuity"          => ['[[c:String]][[c:String]]', '<a href="dummy/class/String">String</a><a href="dummy/class/String">String</a>'],
        "constant"            => ['[[m:File::SEPARATOR]]', '<a href="dummy/method/File/c/SEPARATOR">File::SEPARATOR</a>'],
-       "url"                 => ['[[url:http://i.loveruby.net]]', '<a class="external" href="http://i.loveruby.net">http://i.loveruby.net</a>'],
-       "ruby-list"           => ['[[ruby-list:12345]]', '<a class="external" href="http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/12345">[ruby-list:12345]</a>'],
-       "bugs.r-l.o feature"  => ['[[feature:12345]]', '<a class="external" href="https://bugs.ruby-lang.org/issues/12345">[feature#12345]</a>'],
-       "bugs.r-l.o bug"      => ['[[bug:12345]]', '<a class="external" href="https://bugs.ruby-lang.org/issues/12345">[bug#12345]</a>'],
-       "bugs.r-l.o misc"     => ['[[misc:12345]]', '<a class="external" href="https://bugs.ruby-lang.org/issues/12345">[misc#12345]</a>'])
+       "url"                 => ['[[url:http://i.loveruby.net]]', '<a class="external" target="_blank" rel="noopener" href="http://i.loveruby.net">http://i.loveruby.net</a>'],
+       "ruby-list"           => ['[[ruby-list:12345]]', '<a class="external" target="_blank" rel="noopener" href="http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/12345">[ruby-list:12345]</a>'],
+       "bugs.r-l.o feature"  => ['[[feature:12345]]', '<a class="external" target="_blank" rel="noopener" href="https://bugs.ruby-lang.org/issues/12345">[feature#12345]</a>'],
+       "bugs.r-l.o bug"      => ['[[bug:12345]]', '<a class="external" target="_blank" rel="noopener" href="https://bugs.ruby-lang.org/issues/12345">[bug#12345]</a>'],
+       "bugs.r-l.o misc"     => ['[[misc:12345]]', '<a class="external" target="_blank" rel="noopener" href="https://bugs.ruby-lang.org/issues/12345">[misc#12345]</a>'])
   def test_bracket_link(data)
     target, expected = data
     assert_equal(expected, @c.send(:compile_text, target), target)


### PR DESCRIPTION
doctreeの方にIssueを書く予定ですが、外部リンクは別タブで開かれるべきだと思ったので別タブで開くよう修正しました。
別タブで開きそうなアイコンが外部リンクのメタファーなのでミスリードを誘っています。

Gitbook [例:redux](https://redux.js.org/) がデフォルトで内部リンクは同じタブ、外部リンクは別タブで開くような挙動になっているのでそれに合わせています。

外部リンクにしない選択肢を取る場合、リンクの横のアイコンを削除する選択をしていいかもしれません