### PR TITLE
Support DATA after __END__.

### DIFF
--- a/lib/bitclust/syntax_highlighter.rb
+++ b/lib/bitclust/syntax_highlighter.rb
@@ -118,6 +118,7 @@ module BitClust
 
     def initialize(src, filename = "-", lineno = 1)
       super
+      @src = src
       @stack = []
       @name_buffer = []
       @__lexer.define_singleton_method(:on_parse_error) do |message|
@@ -352,6 +353,12 @@ module BitClust
     def on_embexpr_end(token, data)
       @stack.pop
       on_default(:on_embexpr_end, token, data)
+    end
+
+    def on___end__(token, data)
+      style = COLORS[:__end__]
+      d = @src.each_line.to_a[self.lineno..-1].join
+      data << "<span class=\"#{style}\">#{escape_html(token)}</span>#{escape_html(d)}"
     end
 
     def highlight

--- a/test/test_syntax_highlighter.rb
+++ b/test/test_syntax_highlighter.rb
@@ -20,4 +20,15 @@ class TestSyntaxHighlighter < Test::Unit::TestCase
       end
     end
   end
+
+  test "__END__ support" do
+    src = <<EOS
+p 1
+__END__
+data
+EOS
+
+    html = highlight(src)
+    assert_match(/<span class="k">\s*__END__\s*<\/span>data/m, html)
+  end
 end


### PR DESCRIPTION
以下に対応するために__END__の後の情報も追記するようにon___end__で__END__の部分を処理するようにしました。

* https://github.com/rurema/doctree/issues/1366