### PR TITLE
クラス一覧、メソッド一覧のリンクのスタイルを改善

### DIFF
--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -215,6 +215,7 @@ td.signature a {
     display: block;
     padding: 0.3em;
     height: 100%;
+    box-sizing: border-box;
 }
 
 td.description {


### PR DESCRIPTION
リストの一番下のリンクに hover したとき、枠をはみ出していた。

![overflowed-a](https://user-images.githubusercontent.com/294125/47294469-1b5eff00-d648-11e8-8477-f7135f00e480.png)

padding をつけているのに height: 100% としていたのが原因。
box-sizing を指定していないので、padding のぶんだけはみ出す。