### PR TITLE
Update progressbar gem

### DIFF
--- a/bitclust-core.gemspec
+++ b/bitclust-core.gemspec
@@ -25,5 +25,5 @@ EOD
   s.add_development_dependency "test-unit-notify"
   s.add_development_dependency "test-unit-rr"
   s.add_runtime_dependency "rack"
-  s.add_runtime_dependency "progressbar", "= 0.21.0"
+  s.add_runtime_dependency "progressbar", ">= 1.9.0", "< 2.0"
 end

--- a/bitclust-dev.gemspec
+++ b/bitclust-dev.gemspec
@@ -16,7 +16,7 @@ EOD
 
   s.rubyforge_project = ""
 
-  s.files         = Dir["tools/*", "lib/bitclust.rb"]
+  s.files         = Dir["tools/*"]
   s.executables   = Dir["tools/*"].
     map {|v| File.basename(v) }.
     reject {|f| %w(ToDoHistory check-signature.rb).include?(f) }

--- a/lib/bitclust/silent_progress_bar.rb
+++ b/lib/bitclust/silent_progress_bar.rb
@@ -3,13 +3,17 @@ module BitClust
   # Null-object version of ProgressBar.
   class SilentProgressBar
 
-    attr_reader :title
+    attr_accessor :title
 
-    def initialize(title, total, out = $stderr)
-      @title, @total, @out = title, total, out
+    def self.create(output: $stderr, title:, total:)
+      self.new(output: output, title: title, total: total)
     end
 
-    def inc(step = 1)
+    def initialize(output:, title:, total:)
+      @title, @total, @output = title, total, output
+    end
+
+    def increment
     end
 
     def finish

--- a/lib/bitclust/subcommand.rb
+++ b/lib/bitclust/subcommand.rb
@@ -52,6 +52,15 @@ module BitClust
     def srcdir_root
       Pathname.new(__FILE__).realpath.dirname.parent.parent
     end
+
+    def align_progress_bar_title(title)
+      size = title.size
+      if size > 14
+        title[0..13]
+      else
+        title + ' ' * (14 - size)
+      end
+    end
   end
 end
 

--- a/lib/bitclust/subcommands/chm_command.rb
+++ b/lib/bitclust/subcommands/chm_command.rb
@@ -176,7 +176,7 @@ EOS
           end
 
           entries = db.docs + db.libraries.sort + db.classes.sort + methods.values.sort
-          pb = ProgressBar.new('entry', entries.size)
+          pb = ProgressBar.create(title: 'entry', total: entries.size)
           entries.each do |c|
             filename = create_html_file(c, manager, @outputdir, db)
             @html_files << filename
@@ -206,8 +206,8 @@ EOS
                   Sitemap::Content.new("#{e.klass.name}#{e.typemark}#{name} (#{e.library.name})", filename)
               end
             end
-            pb.title.replace(e.name)
-            pb.inc
+            pb.title = align_progress_bar_title(e.name)
+            pb.increment
           end
           pb.finish
         end

--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -165,7 +165,6 @@ module BitClust
         end
 
         fdb.transaction do
-          functions = {}
           create_html_entries("capi", fdb.functions, manager, fdb)
         end
 

--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -218,34 +218,36 @@ module BitClust
       end
 
       def create_html_entries(title, entries, manager, db)
+        title = align_progress_bar_title(title)
         original_title = title.dup
         if @verbose
-          progressbar = ProgressBar.new(title, entries.size)
+          progressbar = ProgressBar.create(title: title, total: entries.size)
         else
-          progressbar = SilentProgressBar.new(title, entries.size)
+          progressbar = SilentProgressBar.create(title: title, total: entries.size)
         end
         entries.each do |entry|
           create_html_file(entry, manager, @outputdir, db)
-          progressbar.title.replace([entry].flatten.first.name)
-          progressbar.inc
+          progressbar.title = align_progress_bar_title([entry].flatten.first.name)
+          progressbar.increment
         end
-        progressbar.title.replace(original_title)
+        progressbar.title = original_title
         progressbar.finish
       end
 
       def create_html_methods(title, methods, manager, db)
+        title = align_progress_bar_title(title)
         original_title = title.dup
         if @verbose
-          progressbar = ProgressBar.new(title, methods.size)
+          progressbar = ProgressBar.create(title: title, total: methods.size)
         else
-          progressbar = SilentProgressBar.new(title, methods.size)
+          progressbar = SilentProgressBar.create(title: title, total: methods.size)
         end
         methods.each do |method_name, method_entries|
           create_html_method_file(method_name, method_entries, manager, @outputdir, db)
-          progressbar.title.replace(method_name)
-          progressbar.inc
+          progressbar.title = align_progress_bar_title(method_name)
+          progressbar.increment
         end
-        progressbar.title.replace(original_title)
+        progressbar.title = original_title
         progressbar.finish
       end
 

--- a/refe2.gemspec
+++ b/refe2.gemspec
@@ -15,7 +15,7 @@ This is tools for Rubyists.
 EOD
 
   s.rubyforge_project = ""
-  s.files         = Dir["bin/refe", "lib/bitclust.rb"]
+  s.files         = Dir["bin/refe"]
   s.executables   = ["refe"]
   s.require_paths = ["lib"]
 


### PR DESCRIPTION
目的
===

progressbar gemのバージョンを最新のものに上げます。
https://github.com/rurema/bitclust/commit/948504703caf48509cd50c0a143f3bec544f406a でこのgemのバージョンはpinされていますが、コミットメッセージを見る限りだと積極的にpinをしたいわけではないように見えます。
バージョンを上げておくことによって、将来progressbar gemでなにか問題が発生したときにも最新バージョンに追従しやすいようにします。


やったこと
===


## 最新のインターフェイスに追従

https://github.com/rurema/bitclust/commit/dae13343239811f6f3e379e4796b5cdcc80c9fb2

* `ProgressBar.new`ではなく`ProgressBar.create`を使うようになっていたので修正
* `ProgressBar.create`のときにキーワード引数を使うようになっていたので修正
* `SilentProgressBar`の実装を最新の`ProgressBar`に合わせた
* `inc`メソッドを`increment`メソッドにリネーム
* `title.replace`を`title=`メソッドを使用するように修正
* バージョンを上げたことにより、タイトルの長さが自動で調節されなくなっていたので、`align_progress_bar_title`メソッドを追加して修正
    * これがないと、下の動画のようになってしまいます。

`align_progress_bar_title`なし
![bad](https://user-images.githubusercontent.com/4361134/48550114-1b83af00-e915-11e8-8522-0b63d45eb457.gif)

`align_progress_bar_title`あり
![good](https://user-images.githubusercontent.com/4361134/48550117-1f173600-e915-11e8-9380-23e835215739.gif)


## 未使用変数を削除

https://github.com/rurema/bitclust/commit/53e4fee04a98f8f7dfdadeded2b0fe9d62665ab6
warningが気になったので、消しただけです。

## refe2, bitclust-dev gemに `lib/bitclust.rb`が含まれないように修正

https://github.com/rurema/bitclust/commit/e0f470d2a1f39b7187c596966671f6e1c8214b30
rurema/doctreeの`rake statichtml`がうまく動かなかったので、修正しています。
このタスクは`gem which`を呼んで`lib/bitclust.rb`が存在するディレクトリ(== bitclust-core gemがインストールされているディレクトリ)を取得していますが、refe2及びbitclust-devにこのファイルが存在すると、意図しない結果となってしまいます。
そのため、`lib/bitclust.rb`がbitclust-core gemにのみ含まれるように修正しました。
refe2とbitclust-devは両方ともbitclust-coreに依存しているので、このファイルが直接gemに含まれなくても問題はないと思います。

今までなぜ動いていたのかは正直わかってないのですが、手元で試したときに動かなかったので修正しました。


---


rurema/doctreeで`rake statichtml`が動くこと、及び`bitclust --database=/tmp/db-2.6.0 chm -o /tmp/test`コマンドが動くことを確認しています。