### PR TITLE
Add feedback link to footer

### DIFF
--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -20,6 +20,8 @@
   <a rel="license" href="https://creativecommons.org/licenses/by/3.0/">
     <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" />
   </a>
+
+  フィードバックは<a href="https://github.com/rurema/doctree">こちら</a>
 </div>
 </body>
 </html>


### PR DESCRIPTION
https://github.com/rurema/doctree へのリンクをフッターに追加します。

目的
===


「るりまの間違いを見つけたけどどこにPull Requestをしたらいいかわからない…」という人を減らすために、各ページのフッタにGitHubリポジトリへのリンクを追加します。
これによってるりまのドキュメントを書いてくれる人が増えたら嬉しいなと思っています。

実際にフィードバック先がわからないという例もあるようでした。

> そういえば、フィードバック先がわからないという声を聞いたことがあり、とても良いアイデアに思えました！
> https://mobile.twitter.com/koic/status/1120974955238137856

表示方法
===

現在はシンプルに、「フィードバックはこちら」とだけ表示しています。

![190424182019](https://user-images.githubusercontent.com/4361134/56648451-53f69880-66be-11e9-8865-1f6db8ba5ddf.png)


最初はRails Guideを参考に少し長い文を書いていたのですが、ちょっと違和感があったので短くしました。

![190424181555](https://user-images.githubusercontent.com/4361134/56648492-6a045900-66be-11e9-8c7b-6d00311b2412.png)


文字は書かずにGitHubのアイコンだけをライセンス表示と並べるのもありかなと思ったのですが、画像をどう配置したらいいかがよくわからなかったので試していません。


どう表示するかは結構議論の余地があるところだと思うので、アドバイスをもらえたら嬉しいです。
あまりデザイン力がないのでいい感じのスタイルをあててもらえたりするととても助かります…！


