### PR TITLE
Drop EOL version and add newest version.

### DIFF
--- a/lib/bitclust/subcommands/setup_command.rb
+++ b/lib/bitclust/subcommands/setup_command.rb
@@ -19,7 +19,7 @@ module BitClust
         @prepare = nil
         @cleanup = nil
         @purge = nil
-        @versions = ["2.1.0", "2.2.0", "2.3.0", "2.4.0"]
+        @versions = ["2.4.0", "2.5.0", "2.6.0"]
         @update = true
         @parser.banner = "Usage: #{File.basename($0, '.*')} setup [options]"
         @parser.on('--prepare', 'Prepare config file and checkout repository. Do not create database.') {

--- a/test/test_functionreferenceparser.rb
+++ b/test/test_functionreferenceparser.rb
@@ -33,12 +33,12 @@ HERE
          :version   => "1.9.3",
          :expected  => ["some text 2\n"],
        },
-       "2.0.0" => {
-         :version   => "2.0.0",
+       "2.5.0" => {
+         :version   => "2.5.0",
          :expected  => ["some text 1\n"],
        },
-       "2.1.0" => {
-         :version   => "2.1.0",
+       "2.6.0" => {
+         :version   => "2.6.0",
          :expected  => ["some text 1\n"],
        })
   def test_parse_file(data)


### PR DESCRIPTION
Hi. I want to create reference manual with epub version.
Then I found `bitclust setup` create old versions.
I want to create it only in active maintainance versions.

Thanks.