### PR TITLE
Remove rubyforge_project= from gemspecs

### DIFF
--- a/bitclust-core.gemspec
+++ b/bitclust-core.gemspec
@@ -13,8 +13,6 @@ Rurema is a Japanese ruby documentation project, and
 bitclust is a rurema document processor.
 EOD
 
-  s.rubyforge_project = ""
-
   s.files         = Dir["ChangeLog", "Gemfile", "README", "Rakefile", "bitclust.gemspec",
                         "data/**/*", "lib/**/*.rb", "theme/**/*"].reject {|f| f =~ /.*~/ }
   s.test_files    = Dir["test/**/*.rb"].reject {|f| f =~ /.*~/ }

--- a/bitclust-dev.gemspec
+++ b/bitclust-dev.gemspec
@@ -14,8 +14,6 @@ bitclust is a rurema document processor.
 This is tools for Rurema developpers.
 EOD
 
-  s.rubyforge_project = ""
-
   s.files         = Dir["tools/*"]
   s.executables   = Dir["tools/*"].
     map {|v| File.basename(v) }.

--- a/refe2.gemspec
+++ b/refe2.gemspec
@@ -14,7 +14,6 @@ bitclust is a rurema document processor.
 This is tools for Rubyists.
 EOD
 
-  s.rubyforge_project = ""
   s.files         = Dir["bin/refe"]
   s.executables   = ["refe"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
Gemspecでの`rubyforge_project=`はdeprecatedで消える予定とのことで、gemspecから削除しました。


```bash
$ bundle install
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /home/pocke/ghq/github.com/rurema/bitclust/refe2.gemspec:17.
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /home/pocke/ghq/github.com/rurema/bitclust/bitclust-dev.gemspec:17.
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /home/pocke/ghq/github.com/rurema/bitclust/bitclust-core.gemspec:16.

...
```

