### PR TITLE
Fix nested conditional preprocessors

### DIFF
--- a/lib/bitclust/preprocessor.rb
+++ b/lib/bitclust/preprocessor.rb
@@ -149,7 +149,7 @@ module BitClust
     end
 
     def cond_init
-      @state_stack = [State.new(nil, :toplevel)]
+      @state_stack = [State.new(true, :toplevel)]
     end
 
     def cond_toplevel?
@@ -158,13 +158,13 @@ module BitClust
 
     def cond_push(bool)
       last = @state_stack.last
-      @state_stack.push(State.new(last.current, bool))
+      @state_stack.push(last.next(bool, :condition))
     end
 
     def cond_invert
       b = @state_stack.pop.processing?
       last = @state_stack.last
-      @state_stack.push(State.new(last.current, !b))
+      @state_stack.push(last.next(!b, :condition))
     end
 
     def cond_pop
@@ -254,7 +254,7 @@ module BitClust
 
     def samplecode_push(description)
       last = @state_stack.last
-      @state_stack.push(State.new(last.current, :samplecode))
+      @state_stack.push(last.next(true, :samplecode))
     end
 
     def samplecode_pop
@@ -276,24 +276,25 @@ module BitClust
     class State
       attr_reader :current
 
-      def initialize(previous, current)
-        @previous = previous
-        @current = current
+      def initialize(is_processing, label)
+        @is_processing = is_processing
+        @label = label
+      end
+
+      def next(is_processing, label)
+        State.new(@is_processing && is_processing, label)
       end
 
       def toplevel?
-        @current == :toplevel
+        @label == :toplevel
       end
 
       def processing?
-        toplevel? ||
-          (@current == true && @previous != false) ||
-          (@current == :samplecode && @previous == true) ||
-          (@current == :samplecode && @previous == :toplevel)
+        @is_processing
       end
 
       def samplecode?
-        @current == :samplecode
+        @label == :samplecode
       end
     end
   end

--- a/test/test_preprocessor.rb
+++ b/test/test_preprocessor.rb
@@ -109,6 +109,27 @@ HERE
     assert_equal(expected, ret.join)
   end
 
+  def test_nested_condition
+    params = { 'version' => '2.4.0' }
+    src = <<~'HERE'
+      #@until 2.4.0
+      #@since 1.8.7
+      #@since 1.9.3
+      #@since 2.0.0
+      Not display here!
+      #@end
+      #@end
+      #@end
+      #@end
+      Display here!
+    HERE
+    expected = <<~HERE
+      Display here!
+    HERE
+    ret = Preprocessor.wrap(StringIO.new(src), params).to_a
+    assert_equal(expected, ret.join)
+  end
+
   sub_test_case("samplecode") do
 
     def test_samplecode


### PR DESCRIPTION
`#@since`などのpreprocessorがネストした時に条件文の評価結果がおかしくなってしまっていたので修正します。


# Problem

`State#processing?`で1つ前までの条件しか見ていなかったために、条件が3つ以上重なると最初の条件が見られなくなってしまっていました。
これにより、例えばバージョンが2.4.0のときに次のようなコードの`#@until 2.4.0`が無視されて、`Not display here!`が評価されてしまいます。

```
#@until 2.4.0
#@since 1.8.7
#@since 1.9.3
Not display here!
#@end
#@end
#@end
```


実際にこれと同じような現象がるりまの`LIBRARIES`ファイルのtkライブラリについて起きていました。
https://github.com/rurema/doctree/blob/95032ee45837734b0f3a1f8e59f45dec6c17e11e/refm/api/src/LIBRARIES#L656
656行目で`#@until 2.4.0`、679行目で`#@since 1.8.2`、762行目で`#@since 1.8.4`が始まっていて、ネストしているため、最初の`#@until 2.4.0`が無視されていました。

これは`#@since 1.8.x`を消すなかで差分の確認をしていたら、何故かいじっていないはずのtkライブラリの差分が出ていて気が付きました。


# Solution


https://github.com/rurema/bitclust/pull/32 の以前はstateは`前のstate && 次のstate`を取っていたようなので、それと同じような挙動をするように修正しました。
https://github.com/rurema/bitclust/pull/32/files#diff-4d60bb90db26cd19051f3a8699ec0437L154 この辺のコードを参考にしています。