### PR TITLE
Change syntax error example for Ruby 2.7

### DIFF
--- a/test/test_syntax_highlighter.rb
+++ b/test/test_syntax_highlighter.rb
@@ -7,15 +7,15 @@ class TestSyntaxHighlighter < Test::Unit::TestCase
 
   sub_test_case "syntax error" do
     test "single line" do
-      src = "...\n"
-      assert_raise(BitClust::SyntaxHighlighter::ParseError.new("-", 1, 3, "syntax error, unexpected ...")) do
+      src = "foo(\n"
+      assert_raise(BitClust::SyntaxHighlighter::ParseError.new("-", 1, 5, "syntax error, unexpected end-of-input, expecting ')'")) do
         highlight(src)
       end
     end
 
     test "multiple line" do
-      src = "a = 1\n...\n"
-      assert_raise(BitClust::SyntaxHighlighter::ParseError.new("-", 2, 3, "syntax error, unexpected ..., expecting end-of-input")) do
+      src = "a = 1\nfoo(\n"
+      assert_raise(BitClust::SyntaxHighlighter::ParseError.new("-", 2, 5, "syntax error, unexpected end-of-input, expecting ')'")) do
         highlight(src)
       end
     end


### PR DESCRIPTION
# Problem


Ruby 2.7ではbitclustのテストが通らなくなっています。


```bash
$ bundle exec rake
Loaded suite test
Started
...............................................................................
(snip)
........F
===============================================================================
Failure: test: multiple line(TestSyntaxHighlighter::syntax error)
/home/pocke/ghq/github.com/rurema/bitclust/test/test_syntax_highlighter.rb:18:in `block (2 levels) in <class:TestSyntaxHighlighter>'
     15: 
     16:     test "multiple line" do
     17:       src = "a = 1\n...\n"
  => 18:       assert_raise(BitClust::SyntaxHighlighter::ParseError.new("-", 2, 3, "syntax error, unexpected ..., expecting end-of-input")) do
     19:         highlight(src)
     20:       end
     21:     end

<BitClust::SyntaxHighlighter::ParseError(<-:2:3 syntax error, unexpected ..., expecting end-of-input (BitClust::SyntaxHighlighter::ParseError)>)> expected but was
<BitClust::SyntaxHighlighter::ParseError(<-:2:4 syntax error, unexpected end-of-input (BitClust::SyntaxHighlighter::ParseError)>)>

diff:
? BitClust::SyntaxHighlighter::ParseError(<-:2:3 syntax error, unexpected ..., expecting end-of-input (BitClust::SyntaxHighlighter::ParseError)>)
?                                              4                                                                                                 
===============================================================================
F
===============================================================================
Failure: test: single line(TestSyntaxHighlighter::syntax error)
/home/pocke/ghq/github.com/rurema/bitclust/test/test_syntax_highlighter.rb:11:in `block (2 levels) in <class:TestSyntaxHighlighter>'
      8:   sub_test_case "syntax error" do
      9:     test "single line" do
     10:       src = "...\n"
  => 11:       assert_raise(BitClust::SyntaxHighlighter::ParseError.new("-", 1, 3, "syntax error, unexpected ...")) do
     12:         highlight(src)
     13:       end
     14:     end

<BitClust::SyntaxHighlighter::ParseError(<-:1:3 syntax error, unexpected ... (BitClust::SyntaxHighlighter::ParseError)>)> expected but was
<BitClust::SyntaxHighlighter::ParseError(<-:1:4 syntax error, unexpected end-of-input (BitClust::SyntaxHighlighter::ParseError)>)>

diff:
? BitClust::SyntaxHighlighter::ParseError(<-:1:3 syntax error, unexpected ...          (BitClust::SyntaxHighlighter::ParseError)>)
?                                              4                          end-of-input                                            
===============================================================================
..
Finished in 0.723398051 seconds.
-------------------------------------------------------------------------------
16997 tests, 17070 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
99.9882% passed
-------------------------------------------------------------------------------
23496.05 tests/s, 23596.97 assertions/s
```

このテストではsyntax errorになるサンプルコードをパースしたときにエラーが出ることをテストしていますが、Ruby 2.7からはこのエラーメッセージが変わっています。
syntax errorとなるコードとして`...\n`というコードを使っていますが、おそらくRuby 2.7からのbegin-less rangeの影響でこのコードに対するsyntax errorのメッセージが変わるようです。



# Solution



よりメッセージが変化しなさそうなエラー例に変えてみました。

