### PR TITLE
Make statichtml command faster

### DIFF
--- a/lib/bitclust/nameutils.rb
+++ b/lib/bitclust/nameutils.rb
@@ -120,10 +120,14 @@ module BitClust
       "#{cid}/#{typename2char(t)}.#{encodename_url(name)}.#{libid}"
     end
 
+    @@split_method_id = {}
+
     # private module function
     def split_method_id(id)
-      c, rest = id.split("/")
-      return *[c, *rest.split(%r<[/\.]>, 3)]
+      @@split_method_id[id] ||= begin
+        c, rest = id.split("/")
+        [c, *rest.split(%r<[/\.]>, 3)]
+      end
     end
 
     NAME_TO_MARK = {

--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -269,7 +269,6 @@ HERE
           @urlmapper.bitclust_html_base = '..'
           path = outputdir + e.type_id.to_s + html_filename(encodename_package(e.name), @suffix)
           create_html_file_p(entry, manager, path, db)
-          path.relative_path_from(outputdir).to_s
         when :function
           create_html_function_file(entry, manager, outputdir, db)
         else
@@ -286,7 +285,6 @@ HERE
         path = outputdir + e.type_id.to_s + encodename_package(e.klass.name) +
           e.typechar + html_filename(encodename_package(name), @suffix)
         create_html_file_p(entries, manager, path, db)
-        path.relative_path_from(outputdir).to_s
       end
 
       def create_html_function_file(entry, manager, outputdir, db)
@@ -294,7 +292,6 @@ HERE
         @urlmapper.bitclust_html_base = '..'
         path = outputdir + entry.type_id.to_s + html_filename(entry.name, @suffix)
         create_html_file_p(entry, manager, path, db)
-        path.relative_path_from(outputdir).to_s
       end
 
       def create_html_file_p(entry, manager, path, db)


### PR DESCRIPTION
るりまのビルドをしていて結構時間がかかるなーと思っていたので少し速くしてみました。
このPRの高速化ポイントは2つです。

## 必要のない`Pathname#relative_path_from`の呼び出しの削除

2b57707

まず、必要のないメソッド呼び出しが結構な時間を食っていたので削除しました。
`create_html_file`などのメソッドが`Pathname#relative_path_from`の結果を戻り値として返していましたが、これはどこからも使われていませんでした。

これらを削除したところ、doctreeレポジトリでの`rake statichtml:2.6.0`の実行が9秒から8.6秒ぐらいまで縮まりました。
だいたい4%ぐらいの速度改善です。


## `split_method_id` の結果のキャッシュ

c0429c1


次に、NameUtilsでの`split_method_id`がボトルネックになっているようだったのでキャッシュするようにしました。
このメソッドは https://github.com/rurema/bitclust/blob/c0429c15ea34a166a136cfda55ec42fac5a0e6a8/lib/bitclust/nameutils.rb#L69-L107 のようにあちこちから呼ばれるので、相対的に重い処理となっていたようです。
そして同じ引数で何度も呼ばれているようなのでキャッシュの効果もありました。

この変更によって`rake statichtml:2.6.0`の実行が8.6秒が7.9秒まで縮まりました。
だいたい8%ぐらいの速度改善です。


---


このPR全体では、`rake statichtml:2.6.0`の実行が9.15秒から8.3秒ぐらいまで縮んだので、9%ぐらいの速度改善になりました。(各パッチのベンチマークと全体のベンチマークを取った時期がずれているので、実行時間が少しぶれています🙏)

あんまり速くならなかったのでPRを出そうか迷っていたのですが、変なhackを入れているわけでもないのでPRを出してみました。