### PR TITLE
monospace font display optimization (#51)

### DIFF
--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -119,14 +119,14 @@ code, pre, tt {
 }
 
 pre {
-    line-height: 1.1em;
+    line-height: 1.1;
     background-color: #f2f2f2;
     padding: 1.1em;
     font-weight: normal;
 }
 
 pre.highlight {
-    line-height: 1.1em;
+    line-height: 1.1;
     background-color: #f2f2f2;
     padding: 0px 1.1em 1.1em 1.1em;
     font-weight: normal;

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -113,17 +113,22 @@ span.compileerror {
     font-weight: bold;
 }
 
+code, pre, tt {
+  font-size: 90%;
+  font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+}
+
 pre {
-    line-height: 1.1;
+    line-height: 1.1em;
     background-color: #f2f2f2;
-    padding: 10px;
+    padding: 1.1em;
     font-weight: normal;
 }
 
 pre.highlight {
-    line-height: 1.1;
+    line-height: 1.1em;
     background-color: #f2f2f2;
-    padding: 0px 10px 10px 10px;
+    padding: 0px 1.1em 1.1em 1.1em;
     font-weight: normal;
     position: relative;
 }
@@ -231,10 +236,6 @@ td.library {
     border: 3px solid white;
 }
 
-code {
-    font-family: monospace;
-}
-
 a {
     font-weight: bold;
     text-decoration: none;
@@ -308,6 +309,6 @@ hr {
 
 #top_search {
  position: absolute;
- top: 15px; 
- right: 10px; 
+ top: 15px;
+ right: 10px;
 }


### PR DESCRIPTION
* #51 macOS で等倍フォントが使われない問題への対応
* pre タグの余白が統一されていない問題を修正

lillia テーマに関しては確認する方法がわからず手をつけられていません

macOS 10.14.6 / Google Chrome 76.0.3809.132
<img width="1335" alt="スクリーンショット 2019-09-12 15 08 48" src="https://user-images.githubusercontent.com/5656927/64758822-896a2880-d570-11e9-8956-ff046e697fa9.png">
