### PR TITLE
Display ancestor's method in class page

### DIFF
--- a/data/bitclust/catalog/ja_JP.UTF-8
+++ b/data/bitclust/catalog/ja_JP.UTF-8
@@ -10,6 +10,10 @@ All Functions
 関数一覧
 All Libraries
 ライブラリ一覧
+Ancestor Methods
+親クラスで定義されているメソッド
+Ancestor Methods %s
+%sで定義されているメソッド
 Builtin
 組み込み
 Builtin Library

--- a/data/bitclust/catalog/ja_JP.UTF-8
+++ b/data/bitclust/catalog/ja_JP.UTF-8
@@ -11,9 +11,9 @@ All Functions
 All Libraries
 ライブラリ一覧
 Ancestor Methods
-親クラスで定義されているメソッド
+継承しているメソッド
 Ancestor Methods %s
-%sで定義されているメソッド
+%sから継承しているメソッド
 Builtin
 組み込み
 Builtin Library

--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -82,6 +82,30 @@
 </dl>
 
 <%
+_myself, *ancestors = @entry.ancestors.reject { |c| %w[Object Kernel BasicObject].include?(c.name) }
+displayed_methods = Set.new(ents.instance_methods.map(&:name))
+%>
+
+<% unless ancestors.empty? %>
+  <%= headline(_("Ancestor Methods")) %>
+<dl>
+  <% ancestors.each do |c|
+       methods = c.partitioned_entries(@alevel).instance_methods
+         .reject { |m| displayed_methods.include?(m.name) }
+       next if methods.empty? %>
+<dt><%= _('Ancestor Methods %s', c.name) %></dt>
+<dd>
+    <% methods.each do |m| %>
+      <%= method_link(m.spec_string, m.name) %>
+      <% displayed_methods << m.name %>
+    <% end %>
+</dd>
+<%
+  end
+end %>
+</dl>
+
+<%
     items.each do |label, entries|
       unless entries.empty? %>
 <%=     headline(label) %>


### PR DESCRIPTION
#72 を実装してみました。


たとえばArrayでは次のような感じで表示します。

![191002230437](https://user-images.githubusercontent.com/4361134/66050942-09c8eb80-e569-11e9-84b4-eee7f1738829.png)



## 仕様とか

* オーバーライドされているメソッドは表示しません。
  * `Array#include?`はArrayに定義されているので、Enumerableのメソッドとしては表示しません。
* `Object`, `Kernel`, `BasicObject`で定義されているメソッドは表示しません
  * 試しに表示してみたら結構場所を取る割にあまり意味がないかなと思ったためです。
* メソッドが定義されていないクラスはスキップします
* `Object`以下のクラスを継承していない場合には、このセクションをまるごとスキップします

