### PR TITLE
no longer need `lib` for `bin/refe`

### DIFF
--- a/bin/refe
+++ b/bin/refe
@@ -2,9 +2,6 @@
 
 require 'pathname'
 
-bindir = Pathname.new(__FILE__).realpath.dirname
-$LOAD_PATH.unshift((bindir + '../lib').realpath)
-
 unless defined?(::Encoding)
   # Ruby 1.8
   $KCODE = 'UTF-8'


### PR DESCRIPTION
#74 ですが、`$LOAD_PATH` への `lib` の追加をやめるようにしてみました。
空のディレクトリを維持するよりもよいかなと思います。
