### PR TITLE
Update theme for smartphone

### DIFF
--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -5,6 +5,7 @@
   <%= meta_robots %>
   <meta http-equiv="Content-Type" content="text/html; charset=<%=h charset() %>">
   <meta http-equiv="Content-Language" content="ja-JP">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" type="text/css" href="<%=h css_url() %>">
   <link rel="stylesheet" type="text/css" href="<%=h custom_css_url("syntax-highlight.css") %>">
   <link rel="icon" type="image/png" href="<%=h favicon_url() %>">

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -249,6 +249,9 @@ td.library {
     td.description {
         display: block;
     }
+    dd {
+        margin: 0.3em 0em 1em 1em;
+    }
 }
 
 a {

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -252,6 +252,9 @@ td.library {
     dd {
         margin: 0.3em 0em 1em 1em;
     }
+    p {
+        overflow-wrap: break-word;
+    }
 }
 
 a {

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -237,6 +237,20 @@ td.library {
     border: 3px solid white;
 }
 
+@media only screen and (max-width:425px) {
+    table.entries tr {
+        display: block;
+    }
+    td.signature {
+        display: block;
+        width: inherit;
+        text-indent: 0em !important;
+    }
+    td.description {
+        display: block;
+    }
+}
+
 a {
     font-weight: bold;
     text-decoration: none;

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -123,6 +123,7 @@ pre {
     background-color: #f2f2f2;
     padding: 1.1em;
     font-weight: normal;
+    overflow: auto;
 }
 
 pre.highlight {

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -237,26 +237,6 @@ td.library {
     border: 3px solid white;
 }
 
-@media only screen and (max-width:425px) {
-    table.entries tr {
-        display: block;
-    }
-    td.signature {
-        display: block;
-        width: inherit;
-        text-indent: 0em !important;
-    }
-    td.description {
-        display: block;
-    }
-    dd {
-        margin: 0.3em 0em 1em 1em;
-    }
-    p {
-        overflow-wrap: break-word;
-    }
-}
-
 a {
     font-weight: bold;
     text-decoration: none;
@@ -332,4 +312,24 @@ hr {
  position: absolute;
  top: 15px;
  right: 10px;
+}
+
+@media only screen and (max-width:425px) {
+    table.entries tr {
+        display: block;
+    }
+    td.signature {
+        display: block;
+        width: inherit;
+        text-indent: 0em !important;
+    }
+    td.description {
+        display: block;
+    }
+    dd {
+        margin: 0.3em 0em 1em 1em;
+    }
+    p {
+        overflow-wrap: break-word;
+    }
 }


### PR DESCRIPTION
## 動機

SEO

<blockquote class="twitter-tweet"><p lang="ja" dir="ltr">Rubyでメソッドの使い方を検索したとき、公式ではない公式風APIドキュメントがしれっと公式よりも上に出てくる問題をなんとかしたい。<br>いや、サイトを運営している人が必ずしも悪いわけじゃないけど、Ruby 1.9時代の情報っぽいので、初心者さん殺しの罠になりかねないんだよね・・・。</p>&mdash; Junichi Ito (伊藤淳一) (@jnchito) <a href="https://twitter.com/jnchito/status/1195201871679344641?ref_src=twsrc%5Etfw">November 15, 2019</a></blockquote>

https://docs.ruby-lang.org/ja/latest/doc/index.html をChrome拡張のLighthouseでテストしました。
https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk?hl=ja

SEOについては以下のような感じでした

![blob_chrome-extension___blipmdconlkpinefehnmjammfjpmpbjk_7934792a-1d48-4331-b9a2-b490049a9ede](https://user-images.githubusercontent.com/167012/69010178-69a41600-09a0-11ea-81a0-151ec042cf7b.png)
[Lighthouse Report.pdf](https://github.com/rurema/bitclust/files/3855777/Lighthouse.Report.pdf)

## 改善したこと

### viewportのmetaタグを追加しました

> Many search engines rank pages based on how mobile-friendly they are. Without a viewport meta tag, mobile devices render pages at typical desktop screen widths and then scale the pages down, making them difficult to read.
https://web.dev/viewport/

### コードがはみ出たときにスクロールバーを表示するようにしました

viewportの設定をしてはみ出すようになったので、スクロールバーを出しました

### ライブラリ等のページの一覧のテーブル表示をやめて継承に基づいたインデントをなくした

テーブル表示はモバイルだと横にはみ出て読みづらくなるのでやめてみました。
テーブル表示をやめると継承に基づいたインデントの表示の意味がなくなるのでやめました。

### リンクがはみ出るのを直しました

viewportの設定をしてはみ出すようになったので、適切な位置で改行するようにしました

## 結果

![localhost_9292_latest_library__builtin html(iPhone X)](https://user-images.githubusercontent.com/167012/69010216-e1724080-09a0-11ea-85a1-2b80777ea008.png)
![localhost_9292_latest_class_BasicObject html(iPhone X)](https://user-images.githubusercontent.com/167012/69010210-d7e8d880-09a0-11ea-8ec2-1f9b4a2975f0.png)