### PR TITLE
Refine HTML title for SEO 2

### DIFF
--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -12,7 +12,7 @@
   <% if @conf[:canonical_base_url] %>
   <link rel="canonical" href="<%= canonical_url() %>">
   <% end %>
-  <title><%=h @title %> (Ruby <%=h ruby_version %>)</title>
+  <title><%=h @title %> (Ruby <%=h ruby_version %> リファレンスマニュアル)</title>
   <meta name="description" content="<%=h @description %>">
 </head>
 <body>


### PR DESCRIPTION
offlineのテンプレートのほうが使われていそうに見えるので

https://github.com/ruby/docs.ruby-lang.org/blob/67fcf9c9945adc4419c7e372ce6b1210f6f98bff/system/bc-static-all#L15

関連: https://github.com/rurema/bitclust/pull/78 https://github.com/rurema/doctree/issues/2036