### PR TITLE
Fix test failing

### DIFF
--- a/test/test_syntax_highlighter.rb
+++ b/test/test_syntax_highlighter.rb
@@ -8,14 +8,14 @@ class TestSyntaxHighlighter < Test::Unit::TestCase
   sub_test_case "syntax error" do
     test "single line" do
       src = "foo(\n"
-      assert_raise(BitClust::SyntaxHighlighter::ParseError.new("-", 1, 5, "syntax error, unexpected end-of-input, expecting ')'")) do
+      assert_raise(BitClust::SyntaxHighlighter::ParseError.new("-", 1, 5, "syntax error, unexpected end-of-input, expecting ')'\n#{src}")) do
         highlight(src)
       end
     end
 
     test "multiple line" do
       src = "a = 1\nfoo(\n"
-      assert_raise(BitClust::SyntaxHighlighter::ParseError.new("-", 2, 5, "syntax error, unexpected end-of-input, expecting ')'")) do
+      assert_raise(BitClust::SyntaxHighlighter::ParseError.new("-", 2, 5, "syntax error, unexpected end-of-input, expecting ')'\n#{src}")) do
         highlight(src)
       end
     end


### PR DESCRIPTION
Follow up d92b7e754f5864d77e6a2fffd2549c64758b117c

`BitClust::SyntaxHighlighter::ParserError`のメッセージにsrcが含まれるようになったので、テストの方も修正しています。