### PR TITLE
Remove obsolete meta language element

### DIFF
--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -4,7 +4,6 @@
   <%= google_tag_manager %>
   <%= meta_robots %>
   <meta http-equiv="Content-Type" content="text/html; charset=<%=h charset() %>">
-  <meta http-equiv="Content-Language" content="ja-JP">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" type="text/css" href="<%=h css_url() %>">
   <link rel="stylesheet" type="text/css" href="<%=h custom_css_url("syntax-highlight.css") %>">


### PR DESCRIPTION
Slackのruby-jp workspaceのrurema channelで、hanachinさんが

>  Using the meta element to specify the document-wide default language is obsolete. Consider specifying the language on the root element instead.

https://validator.w3.org/nu/?doc=https%3A%2F%2Fdocs.ruby-lang.org%2Fja%2F2.6.0%2Fdoc%2Findex.html (edited) 

のように[発言していた][1]のを見て、修正しようと考えました。

確かに、既にhtml要素にlang属性でja-JPも指定されているし、この要素は必要なさそうです。

---

念のため、doctree側で以下のコマンドで出力されるHTMLを見て、この変更で該当行が取り除かれることを確認しました。

```
bundle exec bitclust htmlfile --ruby=2.6.0 refm/doc/index.rd
```

生成されたHTMLを https://validator.w3.org/nu/#textarea に入力して確認してみると、件のエラーも出なくなりました。

[1]: https://ruby-jp.slack.com/archives/CM3PCPNQ5/p1575528817163100