### PR TITLE
Change breadcrumb markup from paragraph to ordered list

### DIFF
--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -2,12 +2,24 @@
  @title = "#{@entry.type} #{@entry.name}"
  @description = @entry.description
 %>
-<p>
-<%= manual_home_link() %>
-&gt; <a href="<%= library_index_url() %>"><%= _('All Libraries') %></a>
-&gt; <%= friendly_library_link(@entry.library.name) %>
-&gt; <%=h _(@entry.type.to_s + ' %s', @entry.name) %>
-</p>
+<header>
+  <nav>
+    <ol>
+      <li>
+        <%= manual_home_link() %>
+      </li>
+      <li>
+        <a href="<%= library_index_url() %>"><%= _('All Libraries') %></a>
+      </li>
+      <li>
+        <%= friendly_library_link(@entry.library.name) %>
+      </li>
+      <li>
+        <%=h _(@entry.type.to_s + ' %s', @entry.name) %>
+      </li>
+    </ol>
+  </nav>
+</header>
 
 <%
     headline_init
@@ -125,4 +137,3 @@ end %>
     end
     headline_pop
 %>
-

--- a/data/bitclust/template.offline/class-index
+++ b/data/bitclust/template.offline/class-index
@@ -2,10 +2,19 @@
   @title = _('Class Index')
   @description = _('Class Index')
 %>
-<p>
-<%= manual_home_link() %>
-&gt; <%= _('All Classes') %>
-</p>
+<header>
+  <nav>
+    <ol>
+      <li>
+        <%= manual_home_link() %>
+      </li>
+      <li>
+        <%= _('All Classes') %>
+      </li>
+    </ol>
+  </nav>
+</header>
+
 <%
     headline_init
 %>

--- a/data/bitclust/template.offline/doc
+++ b/data/bitclust/template.offline/doc
@@ -2,14 +2,25 @@
   @title = @entry.title
   @description = @entry.description
 %>
-<p>
-<% if @entry.name == 'index' %>
-<%= _('Ruby %s Reference Manual', ruby_version()) %>
-<% else %>
-<%= manual_home_link() %>
-&gt; <%=h breadcrumb_title %>
-<% end %>
-</p>
+<header>
+  <nav>
+    <ol>
+      <% if @entry.name == 'index' %>
+        <li>
+          <%= _('Ruby %s Reference Manual', ruby_version()) %>
+        </li>
+      <% else %>
+        <li>
+          <%= manual_home_link() %>
+        </li>
+        <li>
+          <%=h breadcrumb_title %>
+        </li>
+      <% end %>
+    </ol>
+  </nav>
+</header>
+
 <% headline_init %>
 <%= headline(@entry.title) %>
 <% headline_push %>

--- a/data/bitclust/template.offline/function
+++ b/data/bitclust/template.offline/function
@@ -3,12 +3,21 @@
     @title = "#{entry.type_label} #{entry.label}"
     @description = @entry.description
 %>
-<p>
-<%= manual_home_link() %>
-&gt; <a href="<%= function_index_url() %>"><%= _('All Functions') %></a>
-&gt; <%=h entry.name %>
-<% unless entry.public? %>(static)<% end %>
-</p>
+<header>
+  <nav>
+    <ol>
+      <li>
+        <%= manual_home_link() %>
+      </li>
+      <li>
+        <a href="<%= function_index_url() %>"><%= _('All Functions') %></a>
+      </li>
+      <li>
+        <%=h entry.name %> <% unless entry.public? %>(static)<% end %>
+      </li>
+    </ol>
+  </nav>
+</header>
 
 <% headline_init %>
 <%= headline("#{entry.type_label} #{entry.label}") %>
@@ -20,4 +29,3 @@
 <%= compile_function(entry) %>
 </dd>
 </dl>
-

--- a/data/bitclust/template.offline/function-index
+++ b/data/bitclust/template.offline/function-index
@@ -2,10 +2,19 @@
   @title = _('Function Index')
   @description = _('Function Index')
 %>
-<p>
-<%= manual_home_link() %>
-&gt; <%= _('All Functions') %>
-</p>
+<header>
+  <nav>
+    <ol>
+      <li>
+        <%= manual_home_link() %>
+      </li>
+      <li>
+        <%= _('All Functions') %>
+      </li>
+    </ol>
+  </nav>
+</header>
+
 <%
     headline_init
 %>
@@ -24,4 +33,3 @@
     headline_pop
 %>
 </table>
-

--- a/data/bitclust/template.offline/library
+++ b/data/bitclust/template.offline/library
@@ -2,11 +2,22 @@
  @title = "library #{@entry.name}"
  @description = @entry.description
 %>
-<p>
-<%= manual_home_link() %>
-&gt; <a href="<%= library_index_url() %>"><%= _('All Libraries') %></a>
-&gt; <%= friendly_library_name(@entry.name) %>
-</p>
+<header>
+  <nav>
+    <ol>
+      <li>
+        <%= manual_home_link() %>
+      </li>
+      <li>
+        <a href="<%= library_index_url() %>"><%= _('All Libraries') %></a>
+      </li>
+      <li>
+        <%= friendly_library_name(@entry.name) %>
+      </li>
+    </ol>
+  </nav>
+</header>
+
 <%
     headline_init
 %>
@@ -75,4 +86,3 @@
 <%    end %>
 </code></p>
 <%  end %>
-

--- a/data/bitclust/template.offline/library-index
+++ b/data/bitclust/template.offline/library-index
@@ -2,10 +2,19 @@
  @title = _('Library Index')
  @description = _('Library Index')
 %>
-<p>
-<%= manual_home_link() %>
-&gt; <%= _("All Libraries") %>
-</p>
+<header>
+  <nav>
+    <ol>
+      <li>
+        <%= manual_home_link() %>
+      </li>
+      <li>
+        <%= _("All Libraries") %>
+      </li>
+    </ol>
+  </nav>
+</header>
+
 <%
     headline_init
 %>

--- a/data/bitclust/template.offline/method
+++ b/data/bitclust/template.offline/method
@@ -3,14 +3,27 @@
     @title = "#{entry.type_label} #{entry.label}"
     @description = entry.description
 %>
-<p>
-<%= manual_home_link() %>
-&gt; <a href="<%= library_index_url() %>"><%= _('All Libraries') %></a>
-&gt; <%= friendly_library_link(entry.library.name) %>
-&gt; <%= class_link(entry.klass.name, _(entry.klass.type.to_s + ' %s', entry.klass.name)) %>
-&gt; <% if entry.typename == :special_variable %>$<% end %><%=h entry.name %>
-<% unless entry.really_public? %>(<%= entry.visibility %>)<% end %>
-</p>
+<header>
+  <nav>
+    <ol>
+      <li>
+        <%= manual_home_link() %>
+      </li>
+      <li>
+        <a href="<%= library_index_url() %>"><%= _('All Libraries') %></a>
+      </li>
+      <li>
+        <%= friendly_library_link(entry.library.name) %>
+      </li>
+      <li>
+        <%= class_link(entry.klass.name, _(entry.klass.type.to_s + ' %s', entry.klass.name)) %>
+      </li>
+      <li>
+        <% if entry.typename == :special_variable %>$<% end %><%=h entry.name %> <% unless entry.really_public? %>(<%= entry.visibility %>)<% end %>
+      </li>
+    </ol>
+  </nav>
+</header>
 
 <% headline_init %>
 <%= headline("#{entry.type_label} #{entry.label}") %>
@@ -25,4 +38,3 @@
     headline_pop
 %>
 </dl>
-

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -285,6 +285,24 @@ hr {
     height: 1px;
 }
 
+header nav ol {
+    list-style-type: none;
+    margin-bottom: 0.5rem;
+    margin-top: 0.5rem;
+    padding-left: 0;
+}
+
+header nav ol li {
+    display: inline-block;
+    margin-bottom: 0;
+}
+
+header nav ol li + li::before {
+    content: ">";
+    padding-left: 0.1rem;
+    padding-right: 0.1rem;
+}
+
 @media print {
     body {
         font-family: osaka,'MS Mincho',serif;


### PR DESCRIPTION
HTMLページ上部のパンくずリスト部分のマークアップ方法を、これまでp要素と`>`の文字で1つの段落として表現していたのを、ol要素とli要素を使って順序付きリストで表現するように変えたいのですが、どうでしょうか。

ナビゲーション用の要素であることが機械からもより理解しやすくなるので、検索インデックス生成用のクローラにも優しいし、将来もう少しメタデータを追記することで、例えばGoogleの検索結果にパンくずリストが表示されるようにもできます。
https://developers.google.com/search/docs/data-types/breadcrumb?hl=ja