### PR TITLE
Change class hierarchy markup to ordered-list

### DIFF
--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -30,7 +30,7 @@
 <% end %>
 <header>
   <nav>
-    <ol>
+    <ol class="inline-breadcrumb-list">
       <li>
         <%= manual_home_link() %>
       </li>
@@ -51,40 +51,62 @@
     headline_init
 %>
 <%= headline("#{@entry.type} #{@entry.name}" + @entry.ancestors[1..@alevel].map{|c| " + #{c.name}" }.join) %>
-<p>
 <%
     myself, *supers = @entry.ancestors
     n = 0
 %>
+
 <% unless @entry.alias? %>
-<%= _('ancestors') %>: <%= escape_html(myself.name) %>
-<%  supers.each do |c| %>
-      <%= @conf[:tochm_mode] ? "&lt;" : a_href("?a=#{n}", "<")  %> <%= class_link(c.name) %>
-      <% n += 1 %>
-<%  end %>
+  <nav>
+    <%= _('ancestors') %>:
+    <ol class="inline-breadcrumb-list">
+      <% supers.reverse_each do |c| %>
+        <li>
+          <%= class_link(c.name) %>
+        </li>
+        <% n += 1 %>
+      <% end %>
+      <li>
+        <%= escape_html(myself.name) %>
+      </li>
+    </ol>
+  </nav>
 <% end %>
 
 <% unless @entry.extended.empty? %>
-<br>extend: <%= @entry.extended.map {|c| class_link(c.name) }.join(', ') %>
-<% end %>
-<% unless @entry.aliases.empty? %>
-<br>aliases: <%=h @entry.aliases.map{|c| c.name}.join(', ') %>
-<% end %>
-<% unless @entry.dynamically_included.empty? %>
-<br> dynamic include:
- <%= @entry.dynamically_included.map{|m|
-       class_link(m.name) + " (by " + library_link(m.library.name) + ")"
-     }.join(", ")
- %>
-<% end %>
-<% unless @entry.dynamically_extended.empty? %>
-<br> dynamic extend:
- <%= @entry.dynamically_extended.map{|m|
-       class_link(m.name) + " (by " + library_link(m.library.name) + ")"
-     }.join(", ")
- %>
-<% end %>
+<p>
+  extend: <%= @entry.extended.map {|c| class_link(c.name) }.join(', ') %>
 </p>
+<% end %>
+
+<% unless @entry.aliases.empty? %>
+<p>
+  aliases: <%=h @entry.aliases.map{|c| c.name}.join(', ') %>
+</p>
+<% end %>
+
+<% unless @entry.dynamically_included.empty? %>
+<p>
+  dynamic include:
+  <%=
+    @entry.dynamically_included.map {|m|
+      class_link(m.name) + " (by " + library_link(m.library.name) + ")"
+    }.join(", ")
+  %>
+</p>
+<% end %>
+
+<% unless @entry.dynamically_extended.empty? %>
+<p>
+  dynamic extend:
+  <%=
+    @entry.dynamically_extended.map {|m|
+      class_link(m.name) + " (by " + library_link(m.library.name) + ")"
+    }.join(", ")
+  %>
+</p>
+<% end %>
+
 <%
     headline_push
 %>

--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -59,7 +59,7 @@
 <% unless @entry.alias? %>
   <nav>
     <%= _('ancestors') %>:
-    <ol class="inline-breadcrumb-list">
+    <ol class="inline-ancestors-list">
       <% supers.reverse_each do |c| %>
         <li>
           <%= class_link(c.name) %>

--- a/data/bitclust/template.offline/class-index
+++ b/data/bitclust/template.offline/class-index
@@ -22,7 +22,7 @@
 <% end %>
 <header>
   <nav>
-    <ol>
+    <ol class="inline-breadcrumb-list">
       <li>
         <%= manual_home_link() %>
       </li>

--- a/data/bitclust/template.offline/doc
+++ b/data/bitclust/template.offline/doc
@@ -23,7 +23,7 @@
 <% end %>
 <header>
   <nav>
-    <ol>
+    <ol class="inline-breadcrumb-list">
       <% if @entry.name == 'index' %>
         <li>
           <%= manual_home_name %>

--- a/data/bitclust/template.offline/function
+++ b/data/bitclust/template.offline/function
@@ -27,7 +27,7 @@
 <% end %>
 <header>
   <nav>
-    <ol>
+    <ol class="inline-breadcrumb-list">
       <li>
         <%= manual_home_link() %>
       </li>

--- a/data/bitclust/template.offline/function-index
+++ b/data/bitclust/template.offline/function-index
@@ -22,7 +22,7 @@
 <% end %>
 <header>
   <nav>
-    <ol>
+    <ol class="inline-breadcrumb-list">
       <li>
         <%= manual_home_link() %>
       </li>

--- a/data/bitclust/template.offline/library
+++ b/data/bitclust/template.offline/library
@@ -26,7 +26,7 @@
 <% end %>
 <header>
   <nav>
-    <ol>
+    <ol class="inline-breadcrumb-list">
       <li>
         <%= manual_home_link() %>
       </li>

--- a/data/bitclust/template.offline/library-index
+++ b/data/bitclust/template.offline/library-index
@@ -22,7 +22,7 @@
 <% end %>
 <header>
   <nav>
-    <ol>
+    <ol class="inline-breadcrumb-list">
       <li>
         <%= manual_home_link() %>
       </li>

--- a/data/bitclust/template.offline/method
+++ b/data/bitclust/template.offline/method
@@ -35,7 +35,7 @@
 <% end %>
 <header>
   <nav>
-    <ol>
+    <ol class="inline-breadcrumb-list">
       <li>
         <%= manual_home_link() %>
       </li>

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -285,19 +285,20 @@ hr {
     height: 1px;
 }
 
-header nav ol {
+.inline-breadcrumb-list {
+    display: inline-block;
     list-style-type: none;
-    margin-bottom: 0.5rem;
-    margin-top: 0.5rem;
+    margin-bottom: 0;
+    margin-top: 0;
     padding-left: 0;
 }
 
-header nav ol li {
+.inline-breadcrumb-list li {
     display: inline-block;
     margin-bottom: 0;
 }
 
-header nav ol li + li::before {
+.inline-breadcrumb-list li + li::before {
     content: ">";
     padding-left: 0.1rem;
     padding-right: 0.1rem;

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -304,6 +304,24 @@ hr {
     padding-right: 0.1rem;
 }
 
+.inline-ancestors-list {
+    display: inline-flex;
+    flex-direction: row-reverse;
+    list-style-type: none;
+    margin-bottom: 0;
+    margin-top: 0;
+    padding-left: 0;
+}
+
+.inline-ancestors-list li {
+    margin-bottom: 0;
+}
+
+.inline-ancestors-list li + li::after {
+    content: "<";
+    padding-right: 0.3rem;
+}
+
 @media print {
     body {
         font-family: osaka,'MS Mincho',serif;


### PR DESCRIPTION
## 変更内容

#88 を承けて、継承リストを順序付きリストで記述するように変更してみました。ただし、**これまでと比べて記述順序が逆になっています。**

それと、これは些細な変更ですが、dynamic include等の継承リスト以降に続く可能性がある情報について、これまでbr要素とテキストノードで表現されていたのを、それぞれp要素で囲むようにしました。これは、その方が構造的に適切で、かつそうした方がデザインが崩れにくく、結果的に実装しやすかったためです。

## 順序変更の理由

- Rubyのコードで継承のコードを書くときは、左が子、右が親になる
    - それ故にこれまではこういう記述順になっていたのではないかと思います
- [Googleのドキュメント](https://developers.google.com/search/docs/data-types/breadcrumb?hl=ja)等を見る限り、パンくずリストを順序付きリストで表現するときは、根から順に記述していくのが一般的に見える
- ウェブサイト内の2つのパンくずリストが構造的に別の順序で表記されていると、混乱を招く
- 実装が楽
    - グローバルナビゲーションと同じものを使い回せるため

ということを踏まえて考えた結果、これまでの継承リストと記述順序を逆にした方が良いのでは、と思い変更しています。

## 変更前

![image](https://user-images.githubusercontent.com/111689/70317037-50381080-1860-11ea-896d-86cc982a5339.png)

## 変更後

![image](https://user-images.githubusercontent.com/111689/70316998-3dbdd700-1860-11ea-9d5b-adf7afca3374.png)
