### PR TITLE
Add JSON-LD metadata for breadcrumb navigation

### DIFF
--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -2,6 +2,32 @@
  @title = "#{@entry.type} #{@entry.name}"
  @description = @entry.description
 %>
+<% if @conf[:canonical_base_url] %>
+<script type="application/ld+json">
+<%=
+  breadcrumb_json_ld(
+    [
+      {
+        name: manual_home_name,
+        url: absolute_url_to(@urlmapper.document_url('index'))
+      },
+      {
+        name: _('All Libraries'),
+        url: absolute_url_to(library_index_url)
+      },
+      {
+        name: friendly_library_name(@entry.library.name),
+        url: absolute_url_to(@urlmapper.library_url(@entry.library.name))
+      },
+      {
+        name: _("#{@entry.type} %s", @entry.name),
+        url: canonical_url
+      }
+    ]
+  )
+%>
+</script>
+<% end %>
 <header>
   <nav>
     <ol>

--- a/data/bitclust/template.offline/class-index
+++ b/data/bitclust/template.offline/class-index
@@ -2,6 +2,24 @@
   @title = _('Class Index')
   @description = _('Class Index')
 %>
+<% if @conf[:canonical_base_url] %>
+<script type="application/ld+json">
+<%=
+  breadcrumb_json_ld(
+    [
+      {
+        name: manual_home_name,
+        url: absolute_url_to(@urlmapper.document_url('index'))
+      },
+      {
+        name: _('All Classes'),
+        url: canonical_url
+      }
+    ]
+  )
+%>
+</script>
+<% end %>
 <header>
   <nav>
     <ol>

--- a/data/bitclust/template.offline/doc
+++ b/data/bitclust/template.offline/doc
@@ -2,12 +2,31 @@
   @title = @entry.title
   @description = @entry.description
 %>
+<% if @conf[:canonical_base_url] %>
+<script type="application/ld+json">
+<%=
+  items = [
+    {
+      name: manual_home_name,
+      url: absolute_url_to(@urlmapper.document_url('index'))
+    }
+  ]
+  if @entry.name != 'index'
+    items << {
+      name: breadcrumb_title,
+      url: canonical_url
+    }
+  end
+  breadcrumb_json_ld(items)
+%>
+</script>
+<% end %>
 <header>
   <nav>
     <ol>
       <% if @entry.name == 'index' %>
         <li>
-          <%= _('Ruby %s Reference Manual', ruby_version()) %>
+          <%= manual_home_name %>
         </li>
       <% else %>
         <li>

--- a/data/bitclust/template.offline/function
+++ b/data/bitclust/template.offline/function
@@ -3,6 +3,28 @@
     @title = "#{entry.type_label} #{entry.label}"
     @description = @entry.description
 %>
+<% if @conf[:canonical_base_url] %>
+<script type="application/ld+json">
+<%=
+  breadcrumb_json_ld(
+    [
+      {
+        name: manual_home_name,
+        url: absolute_url_to(@urlmapper.document_url('index'))
+      },
+      {
+        name: _('All Functions'),
+        url: absolute_url_to(function_index_url)
+      },
+      {
+        name: "#{entry.name}#{' (static)' unless entry.public?}",
+        url: canonical_url
+      }
+    ]
+  )
+%>
+</script>
+<% end %>
 <header>
   <nav>
     <ol>

--- a/data/bitclust/template.offline/function-index
+++ b/data/bitclust/template.offline/function-index
@@ -2,6 +2,24 @@
   @title = _('Function Index')
   @description = _('Function Index')
 %>
+<% if @conf[:canonical_base_url] %>
+<script type="application/ld+json">
+<%=
+  breadcrumb_json_ld(
+    [
+      {
+        name: manual_home_name,
+        url: absolute_url_to(@urlmapper.document_url('index'))
+      },
+      {
+        name: _('All Functions'),
+        url: canonical_url
+      }
+    ]
+  )
+%>
+</script>
+<% end %>
 <header>
   <nav>
     <ol>

--- a/data/bitclust/template.offline/library
+++ b/data/bitclust/template.offline/library
@@ -2,6 +2,28 @@
  @title = "library #{@entry.name}"
  @description = @entry.description
 %>
+<% if @conf[:canonical_base_url] %>
+<script type="application/ld+json">
+<%=
+  breadcrumb_json_ld(
+    [
+      {
+        name: manual_home_name,
+        url: absolute_url_to(@urlmapper.document_url('index'))
+      },
+      {
+        name: _('All Libraries'),
+        url: absolute_url_to(library_index_url),
+      },
+      {
+        name: friendly_library_name(@entry.name),
+        url: canonical_url
+      }
+    ]
+  )
+%>
+</script>
+<% end %>
 <header>
   <nav>
     <ol>

--- a/data/bitclust/template.offline/library-index
+++ b/data/bitclust/template.offline/library-index
@@ -2,6 +2,24 @@
  @title = _('Library Index')
  @description = _('Library Index')
 %>
+<% if @conf[:canonical_base_url] %>
+<script type="application/ld+json">
+<%=
+  breadcrumb_json_ld(
+    [
+      {
+        name: manual_home_name,
+        url: absolute_url_to(@urlmapper.document_url('index'))
+      },
+      {
+        name: _('All Libraries'),
+        url: canonical_url
+      }
+    ]
+  )
+%>
+</script>
+<% end %>
 <header>
   <nav>
     <ol>
@@ -9,7 +27,7 @@
         <%= manual_home_link() %>
       </li>
       <li>
-        <%= _("All Libraries") %>
+        <%= _('All Libraries') %>
       </li>
     </ol>
   </nav>

--- a/data/bitclust/template.offline/method
+++ b/data/bitclust/template.offline/method
@@ -3,6 +3,36 @@
     @title = "#{entry.type_label} #{entry.label}"
     @description = entry.description
 %>
+<% if @conf[:canonical_base_url] %>
+<script type="application/ld+json">
+<%=
+  breadcrumb_json_ld(
+    [
+      {
+        name: manual_home_name,
+        url: absolute_url_to(@urlmapper.document_url('index'))
+      },
+      {
+        name: _('All Libraries'),
+        url: absolute_url_to(library_index_url),
+      },
+      {
+        name: friendly_library_name(entry.library.name),
+        url: absolute_url_to(@urlmapper.library_url(entry.library.name))
+      },
+      {
+        name: _("#{entry.klass.type} %s", entry.klass.name),
+        url: absolute_url_to(@urlmapper.class_url(entry.klass.name))
+      },
+      {
+        name: %Q<#{'$' if entry.typename == :special_variable}#{entry.name}#{" (#{entry.visibility})" unless entry.really_public?}>,
+        url: canonical_url
+      }
+    ]
+  )
+%>
+</script>
+<% end %>
 <header>
   <nav>
     <ol>

--- a/lib/bitclust/screen.rb
+++ b/lib/bitclust/screen.rb
@@ -13,7 +13,9 @@ require 'bitclust/htmlutils'
 require 'bitclust/nameutils'
 require 'bitclust/messagecatalog'
 require 'erb'
+require 'json'
 require 'stringio'
+require 'uri'
 
 module BitClust
 
@@ -415,8 +417,12 @@ module BitClust
       end
     end
 
+    def manual_home_name
+      _('Ruby %s Reference Manual', ruby_version())
+    end
+
     def manual_home_link
-      document_link('index', _('Ruby %s Reference Manual', ruby_version()))
+      document_link('index', manual_home_name)
     end
 
     def friendly_library_link(id)
@@ -451,6 +457,28 @@ module BitClust
         body = f.break(/\A---/).join.split(/\n\n/, 2).first || ''
         yield sigs, body
       end
+    end
+
+    def breadcrumb_json_ld(items)
+      {
+        '@context': 'http://schema.org',
+        '@type': 'BreadcrumbList',
+        'itemListElement' => items.map.with_index do |item, index|
+          {
+            '@type' => 'ListItem',
+            'item' => item[:url],
+            'name' => item[:name],
+            'position' => index + 1
+          }
+        end
+      }.to_json
+    end
+
+    def absolute_url_to(path)
+      ::URI.join(
+        canonical_url,
+        path
+      )
     end
   end
 

--- a/lib/bitclust/screen.rb
+++ b/lib/bitclust/screen.rb
@@ -463,12 +463,12 @@ module BitClust
       {
         '@context': 'http://schema.org',
         '@type': 'BreadcrumbList',
-        'itemListElement' => items.map.with_index do |item, index|
+        'itemListElement' => items.map.with_index(1) do |item, index|
           {
             '@type' => 'ListItem',
             'item' => item[:url],
             'name' => item[:name],
-            'position' => index + 1
+            'position' => index
           }
         end
       }.to_json


### PR DESCRIPTION
JSON-LDでパンくずリストを記述すれば、Googleの検索結果に適切にパンくずリストを表示させられるし、上手くいけば検索順位を上げてくれるかもしれないと思うのですが、どうでしょうか。

https://developers.google.com/search/docs/data-types/breadcrumb?hl=ja