### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+Gemfile.lock
+/pkg/
+/.bundle


### PR DESCRIPTION
`.gitignore`ファイルを追加します。

`Gemfile.lock`は現状コミットされていないので、ignoreします。
`/pkg/`はgemをビルドするとディレクトリができてしまうのでignoreします。
`/.bundle`もignoreしたほうが良さそうなのでしています。