### PR TITLE
Remove type_label, such as "instance method", from <title> for methods

### DIFF
--- a/data/bitclust/template.offline/method
+++ b/data/bitclust/template.offline/method
@@ -1,6 +1,6 @@
 <%
     entry = @entries.sort.first
-    @title = "#{entry.type_label} #{entry.label}"
+    @title = entry.label
     @description = entry.description
 %>
 <% if @conf[:canonical_base_url] %>


### PR DESCRIPTION
Close #93 

インスタンスメソッドやクラスメソッドの個別のページの`<title>`タグから、"instance method"や"singleton method"という表記を取り除きます。
これによって`Class#method`のような表記が`<title>`の先頭に来るので、検索結果を見た時やブラウザのタブでの表示が見やすくなるのではと思います。



なお、このPRでは`<body>`の中には変更がありません。
たとえば、青い帯の中のタイトルは変更しておらず、従来どおり"instance method"などが表示されています。

![200108201516](https://user-images.githubusercontent.com/4361134/71973970-a7604500-3253-11ea-99d5-c232e9ea22ef.png)


また、メソッド以外のページ(クラス、モジュール、Cの関数など)は変更していません。
これらは文字が充分短い(`class`, `module`, `function`, `macro`)ですし、取り除いてしまうと例えばクラスとモジュールの区別がつかなくなってしまいます。
対してメソッドの場合は`Array.[]`と`Array#[]`のように記号で区別がつくようになっています。
まあこの記号の意味を知らないと区別がつかないのですが、ページにアクセスすれば区別できるし許容できるかなと思っています。







## ブラウザのタブの例

before


![200108201312](https://user-images.githubusercontent.com/4361134/71973864-61a37c80-3253-11ea-8c78-1e4ab796e5fc.png)


after

![200108201326](https://user-images.githubusercontent.com/4361134/71973868-65cf9a00-3253-11ea-923e-80c39bc0c613.png)


