### PR TITLE
Add current url to feedback link

### DIFF
--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -21,7 +21,8 @@
     <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" />
   </a>
 
-  フィードバックは<a href="https://github.com/rurema/doctree">こちら</a>
+  フィードバックは<a href="https://github.com/rurema/doctree/issues/new" id="feedback-link">こちら</a>
+  <script>document.getElementById("feedback-link").search = new URLSearchParams({'permalink': document.location});</script>
 </div>
 </body>
 </html>

--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -22,7 +22,7 @@
   </a>
 
   フィードバックは<a href="https://github.com/rurema/doctree/issues/new" id="feedback-link">こちら</a>
-  <script>document.getElementById("feedback-link").search = new URLSearchParams({'permalink': document.location});</script>
+  <script>document.getElementById("feedback-link").search = new URLSearchParams({'body': document.location});</script>
 </div>
 </body>
 </html>


### PR DESCRIPTION
https://help.github.com/en/github/managing-your-work-on-github/opening-an-issue-from-code のように issue 作成を試そうとすると、 permalink というパラメーターがつくようなので、同様につければ良さそうかと思ったのですが、
https://help.github.com/en/github/managing-your-work-on-github/about-automation-for-issues-and-pull-requests-with-query-parameters
にはなかったので、 body に変更したコミットを積んでから pull request を作成しました。