### PR TITLE
Fix warnings

### DIFF
--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -180,19 +180,19 @@ module BitClust
                     :verbose => @verbose)
         create_index_html(@outputdir)
         FileUtils.cp(@manager_config[:themedir] + @manager_config[:css_url],
-                     @outputdir.to_s, {:verbose => @verbose, :preserve => true})
+                     @outputdir.to_s, verbose: @verbose, preserve: true)
         FileUtils.cp(@manager_config[:themedir] + "syntax-highlight.css",
-                     @outputdir.to_s, {:verbose => @verbose, :preserve => true})
+                     @outputdir.to_s, verbose: @verbose, preserve: true)
         FileUtils.cp(@manager_config[:themedir] + @manager_config[:favicon_url],
-                     @outputdir.to_s, {:verbose => @verbose, :preserve => true})
+                     @outputdir.to_s, verbose: @verbose, preserve: true)
         Dir.mktmpdir do |tmpdir|
           FileUtils.cp_r(@manager_config[:themedir] + 'images', tmpdir,
-                         {:verbose => @verbose, :preserve => true})
+                         verbose: @verbose, preserve: true)
           Dir.glob(File.join(tmpdir, 'images', '/**/.svn')).each do |d|
-            FileUtils.rm_r(d, {:verbose => @verbose})
+            FileUtils.rm_r(d, verbose: @verbose)
           end
           FileUtils.cp_r(File.join(tmpdir, 'images'), @outputdir.to_s,
-                         {:verbose => @verbose, :preserve => true})
+                         verbose: @verbose, preserve: true)
         end
       end
 


### PR DESCRIPTION
ruby 2.7.0 でキーワード引数にハッシュを渡すと警告が出るようになったので、キーワード引数として渡すように変更。

```
/var/rubydoc/bitclust/lib/bitclust/subcommands/statichtml_command.rb:182: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/snap/ruby/172/lib/ruby/2.7.0/fileutils.rb:426: warning: The called method `cp' is defined here
/var/rubydoc/bitclust/lib/bitclust/subcommands/statichtml_command.rb:184: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/snap/ruby/172/lib/ruby/2.7.0/fileutils.rb:426: warning: The called method `cp' is defined here
/var/rubydoc/bitclust/lib/bitclust/subcommands/statichtml_command.rb:186: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/snap/ruby/172/lib/ruby/2.7.0/fileutils.rb:426: warning: The called method `cp' is defined here
/var/rubydoc/bitclust/lib/bitclust/subcommands/statichtml_command.rb:189: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/snap/ruby/172/lib/ruby/2.7.0/fileutils.rb:463: warning: The called method `cp_r' is defined here
/var/rubydoc/bitclust/lib/bitclust/subcommands/statichtml_command.rb:194: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/snap/ruby/172/lib/ruby/2.7.0/fileutils.rb:463: warning: The called method `cp_r' is defined here
```