### PR TITLE
Fix random failures

### DIFF
--- a/lib/bitclust/classentry.rb
+++ b/lib/bitclust/classentry.rb
@@ -39,6 +39,7 @@ module BitClust
     attr_reader :id
 
     def ==(other)
+      return false if self.class != other.class
       @id == other.id
     end
 

--- a/lib/bitclust/completion.rb
+++ b/lib/bitclust/completion.rb
@@ -499,6 +499,7 @@ $cm_comb_m += 1
       end
 
       def ==(other)
+        return false if self.class != other.class
         @idstring == other.idstring
       end
 

--- a/lib/bitclust/docentry.rb
+++ b/lib/bitclust/docentry.rb
@@ -28,6 +28,7 @@ module BitClust
     attr_reader :id
 
     def ==(other)
+      return false if self.class != other.class
       @id == other.id
     end
 

--- a/lib/bitclust/libraryentry.rb
+++ b/lib/bitclust/libraryentry.rb
@@ -42,6 +42,7 @@ module BitClust
     alias label name
 
     def ==(other)
+      return false if self.class != other.class
       @id == other.id
     end
 

--- a/lib/bitclust/methodentry.rb
+++ b/lib/bitclust/methodentry.rb
@@ -29,6 +29,7 @@ module BitClust
     attr_reader :id
 
     def ==(other)
+      return false if self.class != other.class
       @id == other.id
     end
 

--- a/lib/bitclust/methodid.rb
+++ b/lib/bitclust/methodid.rb
@@ -93,6 +93,7 @@ module BitClust
     end
 
     def ==(other)
+      return false if self.class != other.class
       @klass == other.klass and
       @type == other.type and
       @method == other.method

--- a/lib/bitclust/ridatabase.rb
+++ b/lib/bitclust/ridatabase.rb
@@ -71,6 +71,7 @@ class Ent
   attr_reader :entry
 
   def ==(other)
+    return false if self.class != other.class
     @name == other.name
   end
 


### PR DESCRIPTION
`c.superclass` is nil when c is for BasicObject class at https://github.com/rurema/bitclust/blob/068c5c6ab2a669dbce2e033ca1b278c7c56ba851/lib/bitclust/screen.rb#L536
So sometimes NoMethodError happens at https://github.com/rurema/bitclust/blob/068c5c6ab2a669dbce2e033ca1b278c7c56ba851/lib/bitclust/classentry.rb#L42

I add checking class to every `def ==`.