### PR TITLE
samplecode 内の HTML エスケープ漏れを修正

### DIFF
--- a/lib/bitclust/syntax_highlighter.rb
+++ b/lib/bitclust/syntax_highlighter.rb
@@ -132,7 +132,8 @@ module BitClust
     def on_default(event, token, data)
       event_name = event.to_s.sub(/\Aon_/, "")   # :on_event --> "event"
       style = COLORS[event_name.to_sym]
-      data << (style ? "<span class=\"#{style}\">#{escape_html(token)}</span>" : token)
+      escaped_token = escape_html(token)
+      data << (style ? "<span class=\"#{style}\">#{escaped_token}</span>" : escaped_token)
       data
     end
 

--- a/test/test_syntax_highlighter.rb
+++ b/test/test_syntax_highlighter.rb
@@ -64,4 +64,10 @@ class TestSyntaxHighlighter < Test::Unit::TestCase
       assert_equal(expected, highlight(source))
     end
   end
+
+  test 'htmlescape' do
+    source = 'puts /<a>/'
+    expected = '<span class="nb">puts</span> <span class="sr">/&lt;a&gt;/</span>'
+    assert_equal(expected, highlight(source))
+  end
 end


### PR DESCRIPTION
fix #97

これによって、`String#slice(regexp, name)` 等で正しく表示されていなかったコードが正しく表示されるようになりました。

before
![before](https://user-images.githubusercontent.com/3143443/76594788-62031100-653d-11ea-9177-ab37e582779a.png)

---

after
![after](https://user-images.githubusercontent.com/3143443/76594824-71825a00-653d-11ea-894a-7900e7c387a4.png)
