### PR TITLE
statichtml: add --no-stop-on-syntax-error option

### DIFF
--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -260,6 +260,11 @@ module BitClust
       "<dt>#{s}</dt>"
     end
 
+    def stop_on_syntax_error?
+      return true unless @option.key?(:stop_on_syntax_error)
+      @option[:stop_on_syntax_error]
+    end
+
     def emlist
       command = @f.gets
       if %r!\A//emlist\[(?<caption>[^\[\]]+?)?\]\[(?<lang>\w+?)\]! =~ command
@@ -276,7 +281,11 @@ module BitClust
             string BitClust::SyntaxHighlighter.new(src, filename).highlight
           rescue BitClust::SyntaxHighlighter::Error => ex
             $stderr.puts ex.message
-            exit(false)
+            if stop_on_syntax_error?
+              exit(false)
+            else
+              string src
+            end
           end
         else
           string src

--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -104,6 +104,7 @@ module BitClust
         @suffix = ".html"
         @gtm_tracking_id = nil
         @meta_robots_content = ["noindex"]
+        @stop_on_syntax_error = true
         @parser.banner = "Usage: #{File.basename($0, '.*')} statichtml [options]"
         @parser.on('-o', '--outputdir=PATH', 'Output directory') do |path|
           begin
@@ -136,6 +137,9 @@ module BitClust
         end
         @parser.on('--meta-robots-content=VALUE1,VALUE2,...', Array, 'HTML <meta> element: <meta name="robots" content="VALUE1,VALUE2..."') do |values|
           @meta_robots_content = values
+        end
+        @parser.on('--no-stop-on-syntax-error', 'Do not stop on syntax error') do |boolean|
+          @stop_on_syntax_error = boolean
         end
         @parser.on('--[no-]quiet', 'Be quiet') do |quiet|
           @verbose = !quiet
@@ -212,6 +216,7 @@ module BitClust
           :canonical_base_url => @canonical_base_url,
           :gtm_tracking_id => @gtm_tracking_id,
           :meta_robots_content => @meta_robots_content,
+          :stop_on_syntax_error => @stop_on_syntax_error,
         }
         @manager_config[:urlmapper] = URLMapperEx.new(@manager_config)
         @urlmapper = @manager_config[:urlmapper]


### PR DESCRIPTION
Fix #108

If the option is specified, the statichtml subcommand doesn't stop on
BitClust::SyntaxHighlighter::ParseError.