### PR TITLE
SyntaxHighlighter の @stack が空になることを確認するテストを追加

### DIFF
--- a/test/test_syntax_highlighter.rb
+++ b/test/test_syntax_highlighter.rb
@@ -5,6 +5,12 @@ class TestSyntaxHighlighter < Test::Unit::TestCase
     BitClust::SyntaxHighlighter.new(src, filename).highlight
   end
 
+  def final_stack(src, filename = "-")
+    highlighter = BitClust::SyntaxHighlighter.new(src, filename)
+    highlighter.highlight
+    highlighter.instance_variable_get("@stack")
+  end
+
   sub_test_case "syntax error" do
     test "single line" do
       src = "foo(\n"
@@ -62,6 +68,12 @@ class TestSyntaxHighlighter < Test::Unit::TestCase
       </span>
       END
       assert_equal(expected, highlight(source))
+    end
+  end
+
+  sub_test_case "final stack is empty" do
+    test "x.!" do
+      assert_equal [], final_stack("x.!")
     end
   end
 end


### PR DESCRIPTION
#101 のバグのせいで，SyntaxHighlighter の `highlight` が終わったとき，空であるべき `@stack` が空にならないことがあります。
そこで，`@stack` が空になることを確認するテストを追加します。

空にならないケースとしては，`x.!` のようなコードしか今のところ見つけられていないので，それのみでテストしています。