### PR TITLE
template.offline の class の目次を改善

### DIFF
--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -134,7 +134,7 @@
     .sort_by{ |_, mname| mname.gsub(/(?=[^\da-zA-Z])/, "\t") }
     .each do |index_id, mname|
 %>
-<a href="#<%= index_id %>"><%= "#{prefix}#{mname}" %></a>
+<a href="#<%= index_id %>"><%= escape_html "#{prefix}#{mname}" %></a>
 <%
   end
 %>

--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -128,16 +128,18 @@
 <% items.each do |label, entries, prefix| next if entries.empty? %>
 <dt><%= label %></dt>
 <dd>
+<ul class="class-toc">
 <%
   entries.inject([]){ |ary, m| ary.concat(m.names.map{ |mname| [m.index_id, mname] }) }
     .uniq
     .sort_by{ |_, mname| mname.gsub(/(?=[^\da-zA-Z])/, "\t") }
     .each do |index_id, mname|
 %>
-<a href="#<%= index_id %>"><%= escape_html "#{prefix}#{mname}" %></a>
+<li><a href="#<%= index_id %>"><%= escape_html "#{prefix}#{mname}" %></a></li>
 <%
   end
 %>
+</ul>
 </dd>
 <% end %>
 </dl>
@@ -156,10 +158,12 @@ displayed_methods = Set.new(ents.instance_methods.map(&:name))
        next if methods.empty? %>
 <dt><%= _('Ancestor Methods %s', c.name) %></dt>
 <dd>
+  <ul class="class-toc">
     <% methods.each do |m| %>
-      <%= method_link(m.spec_string, m.name) %>
+      <li><%= method_link(m.spec_string, m.name) %></li>
       <% displayed_methods << m.name %>
     <% end %>
+  </ul>
 </dd>
 <%
   end

--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -129,12 +129,12 @@
 <dt><%= label %></dt>
 <dd>
 <%
-  entries.each do |m|
-    m.names.each do |mname|
+  entries.inject([]){ |ary, m| ary.concat(m.names.map{ |mname| [m, mname] }) }
+    .sort_by{ |_, mname| mname.gsub(/(?=[^\da-zA-Z])/, "\t") }
+    .each do |m, mname|
 %>
 <a href="#<%= m.index_id %>"><%= "#{prefix}#{mname}" %></a>
 <%
-    end
   end
 %>
 </dd>

--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -129,11 +129,12 @@
 <dt><%= label %></dt>
 <dd>
 <%
-  entries.inject([]){ |ary, m| ary.concat(m.names.map{ |mname| [m, mname] }) }
+  entries.inject([]){ |ary, m| ary.concat(m.names.map{ |mname| [m.index_id, mname] }) }
+    .uniq
     .sort_by{ |_, mname| mname.gsub(/(?=[^\da-zA-Z])/, "\t") }
-    .each do |m, mname|
+    .each do |index_id, mname|
 %>
-<a href="#<%= m.index_id %>"><%= "#{prefix}#{mname}" %></a>
+<a href="#<%= index_id %>"><%= "#{prefix}#{mname}" %></a>
 <%
   end
 %>

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -114,8 +114,8 @@ span.compileerror {
 }
 
 code, pre, tt {
-  font-size: 90%;
-  font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+    font-size: 90%;
+    font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
 }
 
 pre {
@@ -323,19 +323,19 @@ hr {
 }
 
 .class-toc {
-	list-style: none;
-	margin: 0.5em 0;
-	padding: 0;
-	column-gap: 1em;
-	column-width: 10em;
-	column-rule: 1px dotted #BBB;
+    list-style: none;
+    margin: 0.5em 0;
+    padding: 0;
+    column-gap: 1em;
+    column-width: 10em;
+    column-rule: 1px dotted #BBB;
 }
 
 .class-toc > li {
-	padding-left: 1em;
-	text-indent: -1em;
-  word-break: break-all;
-  break-inside: avoid;
+    padding-left: 1em;
+    text-indent: -1em;
+    word-break: break-all;
+    break-inside: avoid;
 }
 
 @media print {

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -322,6 +322,22 @@ hr {
     padding-right: 0.3rem;
 }
 
+.class-toc {
+	list-style: none;
+	margin: 0.5em 0;
+	padding: 0;
+	column-gap: 1em;
+	column-width: 10em;
+	column-rule: 1px dotted #BBB;
+}
+
+.class-toc > li {
+	padding-left: 1em;
+	text-indent: -1em;
+  word-break: break-all;
+  break-inside: avoid;
+}
+
 @media print {
     body {
         font-family: osaka,'MS Mincho',serif;


### PR DESCRIPTION
template.offline の class の目次を改善します。スタイルは default を前提とします。
ポイントは以下のとおりです。

- エイリアスを分離してソート<br>例）[Enumerable](https://docs.ruby-lang.org/ja/2.7.0/class/Enumerable.html) で，`inject` の次に `reduce` が掲載され（その次が `lazy`），ABC 順になっていなかった。
- 記号が英数字より前になるようソート<br>例）[Integer](https://docs.ruby-lang.org/ja/2.7.0/class/Integer.html) で `|` と `~` が `upto` のあとに来ていた。
- 重複を排除<br>例）[Kernel](https://docs.ruby-lang.org/ja/2.7.0/class/Kernel.html) で `open` は二つのエントリーに分かれていたので目次にも二つ掲載されていた。
- メソッド名を HTML エスケープ<br>例）[Kernel](https://docs.ruby-lang.org/ja/2.7.0/class/Kernel.html)  の `$<` などのところで正しい HTML になっていなかった。
- 多段組に<br>#102 を解決します。

なお，ソーティングについてはまだ改善の余地があるかも知れません。
例えば `Kernel` の `$0`〜`$11` など数字列だけが異なるものは数の大小順になっていたほうがいいかもしれません。
また，[Encoding](https://docs.ruby-lang.org/ja/2.7.0/class/Encoding.html) で `WINDOWS_31J` と `Windows_31J` は隣り合っていてほしいかもしれません。こちらについては，Kernel で `Array` などの大文字始まりのメソッドが先頭にかたまっていてほしい，という私の考えで，あえて大文字／小文字を区別してソートしています。