### PR TITLE
サンプルコードに「COPY」ボタンを付ける

### DIFF
--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -13,6 +13,7 @@
   <% end %>
   <title><%=h @title %> (Ruby <%=h ruby_version %> リファレンスマニュアル)</title>
   <meta name="description" content="<%=h @description %>">
+  <script src="<%=h custom_js_url('script.js') %>"></script>
 </head>
 <body>
 <%= yield %>

--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -67,6 +67,10 @@ module BitClust
           @bitclust_html_base + "/" + filename
         end
 
+        def custom_js_url(filename)
+          @bitclust_html_base + "/" + filename
+        end
+
         def favicon_url
           @bitclust_html_base + "/" + @favicon_url
         end
@@ -182,6 +186,8 @@ module BitClust
         FileUtils.cp(@manager_config[:themedir] + @manager_config[:css_url],
                      @outputdir.to_s, :verbose => @verbose, :preserve => true)
         FileUtils.cp(@manager_config[:themedir] + "syntax-highlight.css",
+                     @outputdir.to_s, :verbose => @verbose, :preserve => true)
+        FileUtils.cp(@manager_config[:themedir] + "script.js",
                      @outputdir.to_s, :verbose => @verbose, :preserve => true)
         FileUtils.cp(@manager_config[:themedir] + @manager_config[:favicon_url],
                      @outputdir.to_s, :verbose => @verbose, :preserve => true)

--- a/theme/default/script.js
+++ b/theme/default/script.js
@@ -1,0 +1,34 @@
+(function() {
+  window.onload = function() {
+    const elems = document.getElementsByClassName('highlight')
+
+    let backet = document.createElement('div')
+
+    Array.prototype.forEach.call(elems,
+      function(elem) {
+        // sample code without caption
+        backet.innerHTML = elem.innerHTML
+        const caption = backet.getElementsByClassName("caption")[0]
+        if (caption) backet.removeChild(caption)
+
+        // textarea for preserving the copy text
+        const copyText = document.createElement('textarea')
+        copyText.setAttribute('class', 'highlight__copy-text')
+        copyText.innerHTML = backet.textContent.replace(/^\n+/, "").replace(/\n{2,}$/, "\n")
+        elem.appendChild(copyText)
+
+        // COPY button
+        const btn = document.createElement('div')
+        btn.setAttribute('class', 'highlight__copy-button')
+        btn.textContent = "COPY"
+        elem.insertBefore(btn, elem.firstChild)
+
+        btn.onclick = function(){
+          copyText.select()
+          document.execCommand("copy")
+          alert("Copied to your Clipboard.")
+        }
+      }
+    )
+  }
+})()

--- a/theme/default/script.js
+++ b/theme/default/script.js
@@ -2,31 +2,32 @@
   window.onload = function() {
     const elems = document.getElementsByClassName('highlight')
 
-    let backet = document.createElement('div')
+    let tempDiv = document.createElement('div')
 
     Array.prototype.forEach.call(elems,
       function(elem) {
         // sample code without caption
-        backet.innerHTML = elem.innerHTML
-        const caption = backet.getElementsByClassName("caption")[0]
-        if (caption) backet.removeChild(caption)
+        tempDiv.innerHTML = elem.innerHTML
+        const caption = tempDiv.getElementsByClassName("caption")[0]
+        if (caption) tempDiv.removeChild(caption)
 
         // textarea for preserving the copy text
         const copyText = document.createElement('textarea')
         copyText.setAttribute('class', 'highlight__copy-text')
-        copyText.innerHTML = backet.textContent.replace(/^\n+/, "").replace(/\n{2,}$/, "\n")
+        copyText.innerHTML = tempDiv.textContent.replace(/^\n+/, "").replace(/\n{2,}$/, "\n")
         elem.appendChild(copyText)
 
         // COPY button
         const btn = document.createElement('div')
         btn.setAttribute('class', 'highlight__copy-button')
-        btn.textContent = "COPY"
+        // btn.textContent = "COPY"
         elem.insertBefore(btn, elem.firstChild)
 
         btn.onclick = function(){
           copyText.select()
           document.execCommand("copy")
-          alert("Copied to your Clipboard.")
+          btn.classList.add("copied")
+          window.setTimeout(function() { btn.classList.remove("copied") }, 1000)
         }
       }
     )

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -134,6 +134,24 @@ pre.highlight {
     position: relative;
 }
 
+/* for COPY */
+.highlight__copy-button {
+  float: right;
+  margin: 0 -1.1em 0.25em 0.5em;
+  padding: 0.25em 0.5em;
+  background: #DDD;
+  opacity: 0.75;
+  cursor: pointer;
+}
+.highlight__copy-button:hover {
+  background: #EE8;
+  opacity: 1;
+}
+.highlight__copy-text {
+  position: fixed;
+  left: -1000px;
+}
+
 pre .caption {
     position: absolute;
     top: 0;

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -147,6 +147,16 @@ pre.highlight {
   background: #EE8;
   opacity: 1;
 }
+.highlight__copy-button::after {
+  content: "COPY"
+}
+.highlight__copy-button.copied {
+  background: #070;
+  color: white;
+}
+.highlight__copy-button.copied::after {
+  content: "COPIED"
+}
 .highlight__copy-text {
   position: fixed;
   left: -1000px;


### PR DESCRIPTION
https://github.com/rurema/doctree/issues/1582 に対する実装です。

`#@samplecode` で記述されたサンプルコードの右上に「COPY」ボタンをつけます。
クリックするとクリップボードにコードがコピーされます。