### PR TITLE
IE において，フィードバックリンクのための JavaScript がエラーを出すのを抑制

### DIFF
--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -22,7 +22,6 @@
   </a>
 
   フィードバックは<a href="https://github.com/rurema/doctree/issues/new" id="feedback-link">こちら</a>
-  <script>document.getElementById("feedback-link").search = new URLSearchParams({'body': document.location});</script>
-</div>
+  <script>if (window.URLSearchParams) { document.getElementById("feedback-link").search = new URLSearchParams({'body': document.location}); }</script></div>
 </body>
 </html>


### PR DESCRIPTION
#98 を解決します。
`URLSearchParams` が使えるブラウザーでのみこれを使うようにします。