### PR TITLE
Singleton object class を実装

### DIFF
--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -67,7 +67,7 @@
         <% n += 1 %>
       <% end %>
       <li>
-        <%= @entry.type == :object ? class_link(myself.name) : escape_html(myself.name) %>
+        <%= @entry.object? ? class_link(myself.name) : escape_html(myself.name) %>
       </li>
     </ol>
   </nav>

--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -67,7 +67,7 @@
         <% n += 1 %>
       <% end %>
       <li>
-        <%= escape_html(myself.name) %>
+        <%= @entry.type == :object ? class_link(myself.name) : escape_html(myself.name) %>
       </li>
     </ol>
   </nav>

--- a/lib/bitclust/classentry.rb
+++ b/lib/bitclust/classentry.rb
@@ -80,7 +80,6 @@ module BitClust
     persistent_properties {
       property :type,       'Symbol'         # :class | :module | :object
       property :superclass, 'ClassEntry'
-      property :singleton_object_class, 'ClassEntry'
       property :included,   '[ClassEntry]'
       property :extended,   '[ClassEntry]'
       property :dynamically_included, '[ClassEntry]'
@@ -211,10 +210,9 @@ module BitClust
 
     def ancestors
       @ancestors ||=
-        if singleton_object_class()
-          singleton_class, *ancestors = singleton_object_class().ancestors
-          [ singleton_class,
-            included().map {|m| m.ancestors },
+        if self.object? && superclass()
+          myself, *ancestors = superclass().ancestors
+          [ myself, included().map {|m| m.ancestors },
             ancestors ].flatten
         else
           [ self, included().map {|m| m.ancestors },

--- a/lib/bitclust/classentry.rb
+++ b/lib/bitclust/classentry.rb
@@ -80,6 +80,7 @@ module BitClust
     persistent_properties {
       property :type,       'Symbol'         # :class | :module | :object
       property :superclass, 'ClassEntry'
+      property :singleton_object_class, 'ClassEntry'
       property :included,   '[ClassEntry]'
       property :extended,   '[ClassEntry]'
       property :dynamically_included, '[ClassEntry]'
@@ -210,8 +211,15 @@ module BitClust
 
     def ancestors
       @ancestors ||=
+        if singleton_object_class()
+          singleton_class, *ancestors = singleton_object_class().ancestors
+          [ singleton_class,
+            included().map {|m| m.ancestors },
+            ancestors ].flatten
+        else
           [ self, included().map {|m| m.ancestors },
             superclass() ? superclass().ancestors : [] ].flatten
+        end
     end
 
     def included_modules

--- a/lib/bitclust/nameutils.rb
+++ b/lib/bitclust/nameutils.rb
@@ -19,8 +19,8 @@ module BitClust
     LIBNAME_RE     = %r<[\w\-]+(/[\w\-]+)*>
     CONST_RE       = /[A-Z]\w*/
     CONST_PATH_RE  = /#{CONST_RE}(?:::#{CONST_RE})*/
-    CLASS_NAME_RE  = /(?:#{CONST_RE}(?:::compatible)?|fatal|ARGF.class|main)/
-    CLASS_PATH_RE  = /(?:#{CONST_PATH_RE}(?:::compatible)?|fatal|ARGF.class|main)/
+    CLASS_NAME_RE  = /(?:#{CONST_RE}(?:::compatible)?|fatal|ARGF\.class|main)/
+    CLASS_PATH_RE  = /(?:#{CONST_PATH_RE}(?:::compatible)?|fatal|ARGF\.class|main)/
     METHOD_NAME_RE = /\w+[?!=]?|===|==|=~|<=>|<=|>=|!=|!~|!@|!|\[\]=|\[\]|\*\*|>>|<<|\+@|\-@|[~+\-*\/%&|^<>`]/
     TYPEMARK_RE    = /(?:\.|\#|\.\#|::|\$)/
     METHOD_SPEC_RE = /#{CLASS_PATH_RE}#{TYPEMARK_RE}#{METHOD_NAME_RE}/

--- a/lib/bitclust/rrdparser.rb
+++ b/lib/bitclust/rrdparser.rb
@@ -120,11 +120,7 @@ module BitClust
           @context.define_module name
           read_class_body f
         when 'object'
-          if superclass
-            # FIXME
-            tty_warn "#{line.location}: singleton object class not implemented yet"
-          end
-          @context.define_object name
+          @context.define_object name, superclass
           read_object_body f
         when 'reopen'
           @context.reopen_class name
@@ -366,14 +362,15 @@ module BitClust
         register_class :module, name, nil
       end
 
-      def define_object(name)
-        register_class :object, name, nil
+      def define_object(name, singleton_object_class)
+        register_class :object, name, nil, singleton_object_class: singleton_object_class
       end
 
-      def register_class(type, name, superclass)
+      def register_class(type, name, superclass, singleton_object_class: nil)
         @klass = @db.open_class(name) {|c|
           c.type = type
           c.superclass = superclass
+          c.singleton_object_class = @db.get_class(singleton_object_class) if singleton_object_class
           c.library = @library
           @library.add_class c
         }

--- a/lib/bitclust/rrdparser.rb
+++ b/lib/bitclust/rrdparser.rb
@@ -363,14 +363,14 @@ module BitClust
       end
 
       def define_object(name, singleton_object_class)
-        register_class :object, name, nil, singleton_object_class: singleton_object_class
+        singleton_object_class = @db.get_class(singleton_object_class) if singleton_object_class
+        register_class :object, name, singleton_object_class
       end
 
-      def register_class(type, name, superclass, singleton_object_class: nil)
+      def register_class(type, name, superclass)
         @klass = @db.open_class(name) {|c|
           c.type = type
           c.superclass = superclass
-          c.singleton_object_class = @db.get_class(singleton_object_class) if singleton_object_class
           c.library = @library
           @library.add_class c
         }


### PR DESCRIPTION
```
refm/api/src/_builtin/ARGF:1: singleton object class not implemented yet
refm/api/src/webrick/httpproxy/NullReader:1: singleton object class not implemented yet
```
という警告が出ていた singleton object class に対応しました。

db に singleton_object_class として保存するようにしたところ、すべてのクラスで `singleton_object_class=` の行が増えて db のサイズが増えているようなので、 `superclass=` を流用するようにした方が良いかもと思ったので、後で変更します。

クラスの継承リストは singleton object ではなく singleton class から表示するようにしました。

## 変更前

<img width="753" alt="スクリーンショット 2020-03-26 19 39 29" src="https://user-images.githubusercontent.com/11857/77637857-34ab5f80-6f4e-11ea-86fd-91b1b2dbe6df.png">

## 変更後

<img width="750" alt="スクリーンショット 2020-03-26 19 39 35" src="https://user-images.githubusercontent.com/11857/77637899-4260e500-6f4e-11ea-9b1b-f653963cbe60.png">

## 変更前

<img width="962" alt="スクリーンショット 2020-03-26 19 39 44" src="https://user-images.githubusercontent.com/11857/77637915-4ab92000-6f4e-11ea-9236-980fbd93dac2.png">

## 変更後

<img width="956" alt="スクリーンショット 2020-03-26 19 39 52" src="https://user-images.githubusercontent.com/11857/77637928-50166a80-6f4e-11ea-9313-80aa9337faa3.png">
