### PR TITLE
template.offline のレイアウトファイルを若干シンプルに

### DIFF
--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="ja-JP">
+<head>
 <%= google_tag_manager %>
 <%= meta_robots %>
 <meta charset="<%=h charset() %>">
@@ -13,6 +14,7 @@
 <title><%=h @title %> (Ruby <%=h ruby_version %> リファレンスマニュアル)</title>
 <meta name="description" content="<%=h @description %>">
 <script src="<%=h custom_js_url('script.js') %>"></script>
+</head>
 <body>
 <%= yield %>
 <div id="footer">

--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -1,20 +1,18 @@
 <!DOCTYPE html>
 <html lang="ja-JP">
-<head>
-  <%= google_tag_manager %>
-  <%= meta_robots %>
-  <meta http-equiv="Content-Type" content="text/html; charset=<%=h charset() %>">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" type="text/css" href="<%=h css_url() %>">
-  <link rel="stylesheet" type="text/css" href="<%=h custom_css_url("syntax-highlight.css") %>">
-  <link rel="icon" type="image/png" href="<%=h favicon_url() %>">
-  <% if @conf[:canonical_base_url] %>
-  <link rel="canonical" href="<%= canonical_url() %>">
-  <% end %>
-  <title><%=h @title %> (Ruby <%=h ruby_version %> リファレンスマニュアル)</title>
-  <meta name="description" content="<%=h @description %>">
-  <script src="<%=h custom_js_url('script.js') %>"></script>
-</head>
+<%= google_tag_manager %>
+<%= meta_robots %>
+<meta charset="<%=h charset() %>">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="<%=h css_url() %>">
+<link rel="stylesheet" href="<%=h custom_css_url("syntax-highlight.css") %>">
+<link rel="icon" type="image/png" href="<%=h favicon_url() %>">
+<% if @conf[:canonical_base_url] %>
+<link rel="canonical" href="<%= canonical_url() %>">
+<% end %>
+<title><%=h @title %> (Ruby <%=h ruby_version %> リファレンスマニュアル)</title>
+<meta name="description" content="<%=h @description %>">
+<script src="<%=h custom_js_url('script.js') %>"></script>
 <body>
 <%= yield %>
 <div id="footer">


### PR DESCRIPTION
HTML5 では

- `<head>`, `</head>` タグは不要
  （省略できる条件を厳密に書くとややこしいが，ともかく今の場合は不要）
- stylesheet のリンクに `type="text/css"` は不要
- charset 指定は `<meta charset="...">` で OK

なので，レイアウトファイル（template.offline/layout）を簡素化します。

これにより削減されるファイルサイズは 1 HTML あたり 120 バイト程度で，1 Ruby バージョンの総サイズにしても 1.6 MB 程度しか減りません。
なので大した改善にはならないのですが，無駄な記述は省きたいと思いました。