### PR TITLE
Preprocessor の next_line を高速に

### DIFF
--- a/lib/bitclust/preprocessor.rb
+++ b/lib/bitclust/preprocessor.rb
@@ -76,6 +76,11 @@ module BitClust
     def next_line(f)
       while line = f.gets
         case line
+        when /\A(?!\#@)/
+          if current_cond.processing?
+            @buf.push line
+            break
+          end
         when /\A\#@\#/   # preprocessor comment
           ;
         when /\A\#@todo/i
@@ -107,13 +112,8 @@ module BitClust
             parse_error "no matching \#@if", line  if cond_toplevel?
             cond_pop
           end
-        when /\A\#@/
-          parse_error "unknown preprocessor directive", line
         else
-          if current_cond.processing?
-            @buf.push line
-            break
-          end
+          parse_error "unknown preprocessor directive", line
         end
       end
       if @buf.empty?


### PR DESCRIPTION
現在の `Preprocessor#next_line` の実装では，多数の `when` 節を持った `case` 式で preprocessor directive を処理しています。

数の上で圧倒している「preprocessor directive ではない行」（`#@` で始まらない行）が，10 個の正規表現マッチングを経ないと処理されません。

`Regexp#===` はそれなりに重いので，この `next_line` がいくらか律速になっているようです。

そこで，「`#@` で始まらない行」を `case` 式の先頭で分岐させてみたところ，若干速くなりました。

手許の環境（SSD，macOS，Ruby 2.7.0）で，doctree の `rake generate:2.7.0` が

- real 時間：16 秒程度
- user 時間：8 秒程度

だったのが，この変更により

- real 時間：15 秒程度
- user 時間：7 秒程度

と，real で数 %，user で 1 割以上削減できました。
（大した改善ではありませんが）

なお，Ruby 2.4 以上では，キャプチャーが不要なマッチングで `Regexp#===` の代わりに `Regexp#match?` を使うことができ，こちらのほうが高速です。
この場合，`case` 式の簡潔な記述をあきらめ，

```rb
elsif /\A\#@since\b/.match?(line)
```

みたいなのを並べることになりますが。
いま手許にベンチマークテストの結果がありませんが，以前実験したときは有意な差が出たと記憶しています。