### PR TITLE
COPY ボタンの要素を div から span へ

### DIFF
--- a/theme/default/script.js
+++ b/theme/default/script.js
@@ -18,9 +18,8 @@
         elem.appendChild(copyText)
 
         // COPY button
-        const btn = document.createElement('div')
+        const btn = document.createElement('span')
         btn.setAttribute('class', 'highlight__copy-button')
-        // btn.textContent = "COPY"
         elem.insertBefore(btn, elem.firstChild)
 
         btn.onclick = function(){


### PR DESCRIPTION
私のミスですが，サンプルコードの「COPY」ボタンを div 要素で実装していました。
pre 要素に div を入れてはいけないので，これを span 要素に変えます。
修正しなくても見た目や動作に支障はありませんが。

また，不要な行をコメントアウトした個所があり，削除するのを忘れていたので，ついでに削除します。