### PR TITLE
body の子要素を header, main, footer とし，h1 を header に入れる

### DIFF
--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -45,12 +45,11 @@
       </li>
     </ol>
   </nav>
+<% headline_init %>
+<%= headline("#{@entry.type} #{@entry.name}" + @entry.ancestors[1..@alevel].map{|c| " + #{c.name}" }.join) %>
 </header>
 
-<%
-    headline_init
-%>
-<%= headline("#{@entry.type} #{@entry.name}" + @entry.ancestors[1..@alevel].map{|c| " + #{c.name}" }.join) %>
+<main>
 <%
     myself, *supers = @entry.ancestors
     n = 0
@@ -190,3 +189,4 @@ end %>
     end
     headline_pop
 %>
+</main>

--- a/data/bitclust/template.offline/class-index
+++ b/data/bitclust/template.offline/class-index
@@ -31,12 +31,11 @@
       </li>
     </ol>
   </nav>
+<% headline_init %>
+<%= headline(_("Class Index")) %>
 </header>
 
-<%
-    headline_init
-%>
-<%= headline(_("Class Index")) %>
+<main>
 <p>
 <%= @entries.size %> classes/modules in database
 </p>
@@ -56,3 +55,4 @@
     headline_pop
 %>
 </ul>
+</main>

--- a/data/bitclust/template.offline/doc
+++ b/data/bitclust/template.offline/doc
@@ -38,9 +38,11 @@
       <% end %>
     </ol>
   </nav>
-</header>
-
 <% headline_init %>
 <%= headline(@entry.title) %>
+</header>
+
+<main>
 <% headline_push %>
 <%= compile_rd(@entry.source) %>
+</main>

--- a/data/bitclust/template.offline/function
+++ b/data/bitclust/template.offline/function
@@ -39,10 +39,11 @@
       </li>
     </ol>
   </nav>
-</header>
-
 <% headline_init %>
 <%= headline("#{entry.type_label} #{entry.label}") %>
+</header>
+
+<main>
 <dl class="functionlist">
 <dt>
   <code><%= entry.header %></code>
@@ -51,3 +52,4 @@
 <%= compile_function(entry) %>
 </dd>
 </dl>
+</main>

--- a/data/bitclust/template.offline/function-index
+++ b/data/bitclust/template.offline/function-index
@@ -31,12 +31,11 @@
       </li>
     </ol>
   </nav>
+<% headline_init %>
+<%= headline(_("Function Index")) %>
 </header>
 
-<%
-    headline_init
-%>
-<%= headline(_("Function Index")) %>
+<main>
 <table class="entries functions">
 <%
     headline_push
@@ -51,3 +50,4 @@
     headline_pop
 %>
 </table>
+</main>

--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -17,12 +17,13 @@
 </head>
 <body>
 <%= yield %>
-<div id="footer">
+<footer id="footer">
   <a rel="license" href="https://creativecommons.org/licenses/by/3.0/">
     <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" />
   </a>
 
   フィードバックは<a href="https://github.com/rurema/doctree/issues/new" id="feedback-link">こちら</a>
-  <script>if (window.URLSearchParams) { document.getElementById("feedback-link").search = new URLSearchParams({'body': document.location}); }</script></div>
+  <script>if (window.URLSearchParams) { document.getElementById("feedback-link").search = new URLSearchParams({'body': document.location}); }</script>
+</footer>
 </body>
 </html>

--- a/data/bitclust/template.offline/library
+++ b/data/bitclust/template.offline/library
@@ -38,13 +38,11 @@
       </li>
     </ol>
   </nav>
+<% headline_init %>
+<%= headline(@entry.id == '_builtin' ? _('Builtin Library') : "library #{@entry.name}") %>
 </header>
 
-<%
-    headline_init
-%>
-<%= headline(@entry.id == '_builtin' ? _('Builtin Library') : "library #{@entry.name}") %>
-
+<main>
 <%
     headline_push
     all_classes = @entry.all_classes
@@ -108,3 +106,4 @@
 <%    end %>
 </code></p>
 <%  end %>
+</main>

--- a/data/bitclust/template.offline/library-index
+++ b/data/bitclust/template.offline/library-index
@@ -31,12 +31,11 @@
       </li>
     </ol>
   </nav>
+<% headline_init %>
+<%= headline(_("Library Index")) %>
 </header>
 
-<%
-    headline_init
-%>
-<%= headline(_("Library Index")) %>
+<main>
 <%
     headline_push
     weight = {"Builtin" => "", "" => "\x7f\x7f"}
@@ -75,3 +74,4 @@
     end
     headline_pop
 %>
+</main>

--- a/data/bitclust/template.offline/method
+++ b/data/bitclust/template.offline/method
@@ -53,10 +53,11 @@
       </li>
     </ol>
   </nav>
-</header>
-
 <% headline_init %>
 <%= headline("#{entry.type_label} #{entry.label}") %>
+</header>
+
+<main>
 <dl class="methodlist">
 <%
     headline_push
@@ -68,3 +69,4 @@
     headline_pop
 %>
 </dl>
+</main>


### PR DESCRIPTION
現在の template.offline では，`header` 要素の次にページタイトルの `h1` が置かれ，フッター部（ライセンスとフィードバック）は `div#footer` でマークアップされ，`main` 要素は用いられていません。
これを以下のように変えます。

- `h1` は `header` に入れる
- フッターは `footer` 要素にする
- `header` と `footer` に挟まれた部分全体を `main` 要素に入れる

この修正は，見た目はとくに変えませんが，HTML5 として自然なマークアップになりますし，また，こうすることでスタイルが当てやすくなります。
たとえば，フッター部を左右と下端にぴったり付けたデザインにしたいとき，現状では `body` のマージンがありますが，これをゼロにするとページコンテンツもマージン無しになってしまいます。
`header`, `main`, `footer` の構成だとそれぞれの `margin`, `padding` がコントロールできます。
つまり，見た目の改善のための準備という意図があります。