### PR TITLE
グローバル変数などのエイリアスをライブラリの一覧にすべて表示

### DIFF
--- a/data/bitclust/template.offline/library
+++ b/data/bitclust/template.offline/library
@@ -97,12 +97,16 @@
   end
 %>
 <%
-    ents = @entry.methods.sort
+    ents = @entry.methods.flat_map do |m|
+      c, t, n, = methodid2specparts(m.id)
+      prefix = (t == '$' ? '' : c) + t
+      m.names.map { |name| [prefix + name, c + t + n] }
+    end.sort
     unless ents.empty? %>
 <%= headline(_("Added/Redefined Methods")) %>
 <p><code>
-<%    ents.each do |m| %>
-<%= link_to_method(m, true) %>
+<%    ents.each do |label, spec| %>
+<%= method_link(spec, label) %>
 <%    end %>
 </code></p>
 <%  end %>


### PR DESCRIPTION
fix #56

この修正で以下のように English ライブラリの `$FS` などの変数も表示できるようになります。

![2020-04-28](https://user-images.githubusercontent.com/3143443/80457224-ebde3080-8969-11ea-9797-ee7621e56513.png)
