### PR TITLE
継承したメソッドのエイリアスも一覧に表示

### DIFF
--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -153,14 +153,16 @@ displayed_methods = Set.new(ents.instance_methods.map(&:name))
 <dl>
   <% ancestors.each do |c|
        methods = c.partitioned_entries(@alevel).instance_methods
-         .reject { |m| displayed_methods.include?(m.name) }
+         .flat_map { |m| m.names.map { |n| [n, m] } }
+         .reject { |name,| displayed_methods.include?(name) }
+         .sort
        next if methods.empty? %>
 <dt><%= _('Ancestor Methods %s', c.name) %></dt>
 <dd>
   <ul class="class-toc">
-    <% methods.each do |m| %>
-      <li><%= method_link(m.spec_string, m.name) %></li>
-      <% displayed_methods << m.name %>
+    <% methods.each do |name, m| %>
+      <li><%= method_link(m.spec_string, name) %></li>
+      <% displayed_methods << name %>
     <% end %>
   </ul>
 </dd>


### PR DESCRIPTION
fix https://github.com/rurema/doctree/issues/2125

この修正で以下のように `Enumerable#to_a` などのメソッドも一覧に表示されるようになります。

![image](https://user-images.githubusercontent.com/3143443/82285544-a3e58300-99d6-11ea-856b-a9c1d41d3a1d.png)
