### PR TITLE
Implement "このマニュアルを編集する"

### DIFF
--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -22,7 +22,10 @@
     <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" />
   </a>
 
-  フィードバックは<a href="https://github.com/rurema/doctree/issues/new" id="feedback-link">こちら</a>
+  <a href="https://github.com/rurema/doctree/issues/new" id="feedback-link">フィードバックを送る</a>
+  <% if @edit_url %>
+    / <a href="<%= @edit_url %>">このマニュアルを編集する</a>
+  <% end %>
   <script>if (window.URLSearchParams) { document.getElementById("feedback-link").search = new URLSearchParams({'body': document.location}); }</script>
 </footer>
 </body>

--- a/data/bitclust/template.offline/method
+++ b/data/bitclust/template.offline/method
@@ -2,6 +2,7 @@
     entry = @entries.sort.first
     @title = entry.label
     @description = entry.description
+    @edit_url = edit_url(entry.source_location) if @conf[:edit_base_url]
 %>
 <% if @conf[:canonical_base_url] %>
 <script type="application/ld+json">

--- a/lib/bitclust/entry.rb
+++ b/lib/bitclust/entry.rb
@@ -98,6 +98,7 @@ module BitClust
         when '[LibraryEntry]' then "[]"
         when '[ClassEntry]'   then "[]"
         when '[MethodEntry]'  then "[]"
+        when 'Location'       then "nil"
         else
           raise "must not happen: @type=#{@type.inspect}"
         end
@@ -115,6 +116,7 @@ module BitClust
         when '[LibraryEntry]' then "restore_libraries(h['#{@name}'])"
         when '[ClassEntry]'   then "restore_classes(h['#{@name}'])"
         when '[MethodEntry]'  then "restore_methods(h['#{@name}'])"
+        when 'Location'       then "Location.new(*h['#@name'].split(?:))"
         else
           raise "must not happen: @type=#{@type.inspect}"
         end
@@ -132,6 +134,7 @@ module BitClust
         when '[LibraryEntry]' then "serialize_entries(@#{@name})"
         when '[ClassEntry]'   then "serialize_entries(@#{@name})"
         when '[MethodEntry]'  then "serialize_entries(@#{@name})"
+        when 'Location'       then "@#@name.to_s"
         else
           raise "must not happen: @type=#{@type.inspect}"
         end

--- a/lib/bitclust/methodentry.rb
+++ b/lib/bitclust/methodentry.rb
@@ -99,7 +99,7 @@ module BitClust
       property :visibility,      'Symbol'   # :public | :private | :protected
       property :kind,            'Symbol'   # :defined | :added | :redefined
       property :source,          'String'
-      property :source_location, 'String'
+      property :source_location, 'Location'
     }
 
     def inspect
@@ -207,11 +207,5 @@ module BitClust
     def description
       source.split(/\n\n+/, 3)[1]
     end
-
-    prepend Module.new {
-      def source_location
-        Location.new(*super.split(':'))
-      end
-    }
   end
 end

--- a/lib/bitclust/methodentry.rb
+++ b/lib/bitclust/methodentry.rb
@@ -95,10 +95,11 @@ module BitClust
     attr_writer :klass
 
     persistent_properties {
-      property :names,      '[String]'
-      property :visibility, 'Symbol'   # :public | :private | :protected
-      property :kind,       'Symbol'   # :defined | :added | :redefined
-      property :source,     'String'
+      property :names,           '[String]'
+      property :visibility,      'Symbol'   # :public | :private | :protected
+      property :kind,            'Symbol'   # :defined | :added | :redefined
+      property :source,          'String'
+      property :source_location, 'String'
     }
 
     def inspect
@@ -206,5 +207,11 @@ module BitClust
     def description
       source.split(/\n\n+/, 3)[1]
     end
+
+    prepend Module.new {
+      def source_location
+        Location.new(*super.split(':'))
+      end
+    }
   end
 end

--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -393,6 +393,10 @@ module BitClust
         string a_href(@urlmapper.method_url(methodid2specstring(@method.id)), "permalink")
         string ']['
         string rdoc_link(@method.id, @option[:database].properties["version"])
+        if @option[:edit_base_url]
+          string ']['
+          string a_href(@urlmapper.edit_url(@method.source_location), 'edit')
+        end
         string ']</span>'
       end
       if @method and not @method.defined?

--- a/lib/bitclust/rrdparser.rb
+++ b/lib/bitclust/rrdparser.rb
@@ -448,10 +448,11 @@ module BitClust
       def define_method(chunk)
         id = method_id(chunk)
         @db.open_method(id) {|m|
-          m.names      = chunk.names.sort
-          m.kind       = @kind
-          m.visibility = @visibility || :public
-          m.source     = chunk.source
+          m.names           = chunk.names.sort
+          m.kind            = @kind
+          m.visibility      = @visibility || :public
+          m.source          = chunk.source
+          m.source_location = chunk.source.location
           case @kind
           when :added, :redefined
             @library.add_method m

--- a/lib/bitclust/screen.rb
+++ b/lib/bitclust/screen.rb
@@ -368,6 +368,10 @@ module BitClust
       @urlmapper.canonical_url(current_url)
     end
 
+    def edit_url(location)
+      @urlmapper.edit_url(location)
+    end
+
     def opensearchdescription_url
       @urlmapper.opensearchdescription_url
     end

--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -28,6 +28,7 @@ module BitClust
           @suffix = h[:suffix]
           @fs_casesensitive = h[:fs_casesensitive]
           @canonical_base_url = h[:canonical_base_url]
+          @edit_base_url = h[:edit_base_url]
         end
 
         def library_url(name)
@@ -87,6 +88,10 @@ module BitClust
           (@canonical_base_url + "/#{current_url}").sub(@bitclust_html_base, "").sub(/([^:])\/\/+/, "\\1/")
         end
 
+        def edit_url(location)
+          "#{@edit_base_url}/#{location.file}#L#{location.line}"
+        end
+
         def encodename_package(str)
           if @fs_casesensitive
             encodename_url(str)
@@ -140,6 +145,9 @@ module BitClust
         end
         @parser.on('--canonical-base-url=URL', 'Canonical base URL') do |url|
           @canonical_base_url = url
+        end
+        @parser.on('--edit-base-url=URL', 'Edit base URL') do |url|
+          @edit_base_url = url
         end
         @parser.on('--tracking-id=ID', 'Google Tag Manager Tracking ID') do |id|
           @gtm_tracking_id = id
@@ -225,6 +233,7 @@ module BitClust
           :tochm_mode  => true,
           :fs_casesensitive => @fs_casesensitive,
           :canonical_base_url => @canonical_base_url,
+          :edit_base_url => @edit_base_url,
           :gtm_tracking_id => @gtm_tracking_id,
           :meta_robots_content => @meta_robots_content,
           :stop_on_syntax_error => @stop_on_syntax_error,


### PR DESCRIPTION
`--edit-base-url` オプションを付け `statichtml` を実行すると編集用のリンクが表示されます

```
% bundle exec bitclust --database=/tmp/db-2.5.0 statichtml --outputdir=/tmp/html/2.5.0 --templatedir=/home/sei/src/github.com/rurema/bitclust/data/bitclust/template.offline --catalog=/home/sei/src/github.com/rurema/bitclust/data/bitclust/catalog --fs-casesensitive --canonical-base-url=https://docs.ruby-lang.org/ja/latest/ --edit-base-url=https://github.com/rurema/doctree/edit/master/
```

- [x] メソッドの個別ページに編集用のリンクを表示
- [x] メソッドを一覧表示している場所でも各メソッドごとに編集用のリンクを表示

---

メソッドの個別ページに編集用のリンク
![Screenshot_2020-07-27 Object new (Ruby 2 5 0 リファレンスマニュアル)](https://user-images.githubusercontent.com/167012/88494391-e1771580-cff0-11ea-8c3d-477a4e3718fb.png)

---

メソッド一覧のpermalink, rdocの横に編集用のリンク
![Screenshot_2020-07-27 class Object (Ruby 2 5 0 リファレンスマニュアル)(1)](https://user-images.githubusercontent.com/167012/88494393-e340d900-cff0-11ea-95e2-fe85a6568918.png)

