### PR TITLE
GitHub Packagesへのgem公開再挑戦

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -36,7 +36,6 @@ jobs:
       env:
         GEM_HOST_API_KEY: ${{secrets.GITHUB_TOKEN}}
         OWNER: rurema
-      if: false # GPR must use same name between repo and gem
 
     - name: Publish to RubyGems
       run: |

--- a/bitclust-core.gemspec
+++ b/bitclust-core.gemspec
@@ -18,6 +18,7 @@ EOD
     "documentation_uri" => "https://github.com/rurema/doctree/wiki",
     "homepage_uri"      => s.homepage,
     "source_code_uri"   => "https://github.com/rurema/bitclust",
+    "github_repo"       => "https://github.com/rurema/bitclust",
     "wiki_uri"          => "https://github.com/rurema/doctree/wiki",
   }
 

--- a/bitclust-dev.gemspec
+++ b/bitclust-dev.gemspec
@@ -19,6 +19,7 @@ EOD
     "documentation_uri" => "https://github.com/rurema/doctree/wiki",
     "homepage_uri"      => s.homepage,
     "source_code_uri"   => "https://github.com/rurema/bitclust",
+    "github_repo"       => "https://github.com/rurema/bitclust",
     "wiki_uri"          => "https://github.com/rurema/doctree/wiki",
   }
 

--- a/refe2.gemspec
+++ b/refe2.gemspec
@@ -19,6 +19,7 @@ EOD
     "documentation_uri" => "https://github.com/rurema/doctree/wiki",
     "homepage_uri"      => s.homepage,
     "source_code_uri"   => "https://github.com/rurema/bitclust",
+    "github_repo"       => "https://github.com/rurema/bitclust",
     "wiki_uri"          => "https://github.com/rurema/doctree/wiki",
   }
 


### PR DESCRIPTION
vim-jp slack で [metadata に github_repo を設定すれば良い](https://docs.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-rubygems-for-use-with-github-packages#publishing-multiple-packages-to-the-same-repository) と教えてもらったので、再挑戦です。