### PR TITLE
Fix uninitialized instance variable warning for `edit_url` ivar

### DIFF
--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -23,7 +23,7 @@
   </a>
 
   <a href="https://github.com/rurema/doctree/issues/new" id="feedback-link">フィードバックを送る</a>
-  <% if @edit_url %>
+  <% if defined?(@edit_url) && @edit_url %>
     / <a href="<%= @edit_url %>">このマニュアルを編集する</a>
   <% end %>
   <script>if (window.URLSearchParams) { document.getElementById("feedback-link").search = new URLSearchParams({'body': document.location}); }</script>


### PR DESCRIPTION
rurema/doctreeのレポジトリで`statichtml` rake taskを -w 付きで実行すると、 `layout.erb:26: warning: instance variable @edit_url not initialized` という警告が出るのを修正します。