### PR TITLE
do not freeze output buffer that can be modified

### DIFF
--- a/lib/bitclust/searcher.rb
+++ b/lib/bitclust/searcher.rb
@@ -403,7 +403,7 @@ module BitClust
 
     def print_packed_names(names)
       max = terminal_column()
-      buf = ''
+      buf = +''
       names.each do |name|
         if buf.size + name.size + 1 > max
           if buf.empty?
@@ -411,7 +411,7 @@ module BitClust
             next
           end
           puts buf
-          buf = ''
+          buf = +''
         end
         buf << name << ' '
       end

--- a/test/test_searcher.rb
+++ b/test/test_searcher.rb
@@ -1,0 +1,21 @@
+require "test/unit"
+require "bitclust"
+require "bitclust/searcher"
+
+class TestTerminalView < Test::Unit::TestCase
+  include BitClust
+
+  def test_show_class
+    view = TerminalView.new(Plain.new, {})
+    db = Database.dummy
+    foo = ClassEntry.new(db, "Foo")
+    bar = ClassEntry.new(db, "Bar")
+    out, err = capture_output do
+      assert_nothing_raised do
+        view.show_class([foo, bar])
+      end
+    end
+    assert_equal %w[Bar Foo], out.split
+    assert_empty err
+  end
+end


### PR DESCRIPTION
以下のように、`refe` コマンドがエラーになっていたので対処しました。

```
$ env RUBYOPT="-I$PWD/lib" bin/refe 
/var/tmp/git/bitclust/lib/bitclust/searcher.rb:416:in `block in print_packed_names': can't modify frozen String: "" (FrozenError)
	from /var/tmp/git/bitclust/lib/bitclust/searcher.rb:407:in `each'
	from /var/tmp/git/bitclust/lib/bitclust/searcher.rb:407:in `print_packed_names'
	from /var/tmp/git/bitclust/lib/bitclust/searcher.rb:400:in `print_names'
	from /var/tmp/git/bitclust/lib/bitclust/searcher.rb:351:in `show_class'
	from /var/tmp/git/bitclust/lib/bitclust/searcher.rb:248:in `show_all_classes'
	from /var/tmp/git/bitclust/lib/bitclust/searcher.rb:231:in `search_pattern'
	from /var/tmp/git/bitclust/lib/bitclust/searcher.rb:98:in `exec'
	from bin/refe:23:in `_main'
	from bin/refe:15:in `main'
	from bin/refe:33:in `<main>'
```

簡単にテストも追加しましたが、`test/test_simplesearcher.rb` との兼ね合いで、`test/test_searcher.rb` に `TestTerminalView` を書いています。
将来的に `BitClust::Searcher` のテストを書くときに解消できればと思います。