### PR TITLE
継承しているメソッドに重複するメソッド名を表示しない

### DIFF
--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -146,7 +146,7 @@
 
 <%
 _myself, *ancestors = @entry.ancestors.reject { |c| %w[Object Kernel BasicObject].include?(c.name) }
-displayed_methods = Set.new(ents.instance_methods.map(&:name))
+displayed_methods = Set.new(ents.instance_methods.flat_map(&:names))
 %>
 
 <% unless ancestors.empty? %>


### PR DESCRIPTION
クラスのページで、表示しているクラスのインスタンスメソッドと継承しているメソッドに同じ名前のメソッドが、どちらでも表示されていることがあったのを修正しています。
すでに表示済みのメソッド名を表示しないようにする対応がありましたが、複数の名前を持つメソッドの考慮が漏れていたようでしたので追加しています。

以下はComplexクラスの例ですが、arg, conjugate, imaginaryなどのメソッドが重複して表示されていましたが、修正後には表示されないようになっています。

**修正前**
![image](https://user-images.githubusercontent.com/3143443/96659137-2d7fef00-1381-11eb-813f-cf2ad0375a2a.png)

---

**修正後**
![image](https://user-images.githubusercontent.com/3143443/96659178-48526380-1381-11eb-9980-34b1430367d8.png)
