### PR TITLE
Display ancestor's singleton methods in class page

### DIFF
--- a/data/bitclust/catalog/ja_JP.UTF-8
+++ b/data/bitclust/catalog/ja_JP.UTF-8
@@ -14,6 +14,8 @@ Ancestor Methods
 継承しているメソッド
 Ancestor Methods %s
 %sから継承しているメソッド
+Ancestor Singleton Methods %s
+%sから継承している特異メソッド
 Builtin
 組み込み
 Builtin Library

--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -146,7 +146,8 @@
 
 <%
 _myself, *ancestors = @entry.ancestors.reject { |c| %w[Object Kernel BasicObject].include?(c.name) }
-displayed_methods = Set.new(ents.instance_methods.flat_map(&:names))
+displayed_instance_methods = Set.new(ents.instance_methods.flat_map(&:names))
+displayed_singleton_methods = Set.new(ents.singleton_methods.flat_map(&:names))
 %>
 
 <% unless ancestors.empty? %>
@@ -154,9 +155,28 @@ displayed_methods = Set.new(ents.instance_methods.flat_map(&:names))
 <dl>
   <% ancestors.each do |c|
        undefined_methods = @entry.partitioned_entries.undefined
+       methods = c.partitioned_entries(@alevel).singleton_methods
+         .flat_map { |m| m.names.map { |n| [n, m] } }
+         .reject { |name,| displayed_singleton_methods.include?(name) }
+         .reject { |name,| undefined_methods.any? { |m| m.names.include?(name) } }
+         .sort
+       next if methods.empty? %>
+<dt><%= _('Ancestor Singleton Methods %s', c.name) %></dt>
+<dd>
+  <ul class="class-toc">
+    <% methods.each do |name, m| %>
+      <li><%= method_link(m.spec_string, name) %></li>
+      <% displayed_singleton_methods << name %>
+    <% end %>
+  </ul>
+</dd>
+  <% end %>
+
+  <% ancestors.each do |c|
+       undefined_methods = @entry.partitioned_entries.undefined
        methods = c.partitioned_entries(@alevel).instance_methods
          .flat_map { |m| m.names.map { |n| [n, m] } }
-         .reject { |name,| displayed_methods.include?(name) }
+         .reject { |name,| displayed_instance_methods.include?(name) }
          .reject { |name,| undefined_methods.any? { |m| m.names.include?(name) } }
          .sort
        next if methods.empty? %>
@@ -165,14 +185,13 @@ displayed_methods = Set.new(ents.instance_methods.flat_map(&:names))
   <ul class="class-toc">
     <% methods.each do |name, m| %>
       <li><%= method_link(m.spec_string, name) %></li>
-      <% displayed_methods << name %>
+      <% displayed_instance_methods << name %>
     <% end %>
   </ul>
 </dd>
-<%
-  end
-end %>
+  <% end %>
 </dl>
+<% end %>
 
 <%
     items.each do |label, entries|


### PR DESCRIPTION
Close https://github.com/rurema/doctree/issues/2365

親クラスから継承している特異メソッドを、クラスのページに表示します。

# Screenshot

File classの例

before
![201024194601](https://user-images.githubusercontent.com/4361134/97079784-97262480-1631-11eb-8fb9-b1cf4740439b.png)

after
![201024194608](https://user-images.githubusercontent.com/4361134/97079786-98575180-1631-11eb-944a-5b2c2cbb6223.png)
