### PR TITLE
Add webrick dependency

### DIFF
--- a/bitclust-core.gemspec
+++ b/bitclust-core.gemspec
@@ -33,4 +33,5 @@ EOD
   s.add_development_dependency "test-unit-rr"
   s.add_runtime_dependency "rack"
   s.add_runtime_dependency "progressbar", ">= 1.9.0", "< 2.0"
+  s.add_runtime_dependency "webrick"
 end


### PR DESCRIPTION
Ruby 3.0からWEBrickが標準ライブラリから削除されるようなので依存関係を追加しました。