### PR TITLE
Do not require WEBrick on top level

### DIFF
--- a/lib/bitclust/server.rb
+++ b/lib/bitclust/server.rb
@@ -15,7 +15,6 @@ require 'bitclust/classentry'
 require 'bitclust/methodentry'
 require 'bitclust/docentry'
 require 'drb'
-require 'webrick/server'
 
 module BitClust
 
@@ -27,6 +26,11 @@ module BitClust
     end
 
     def listen(url, foreground = false)
+      begin
+        require 'webrick/server'
+      rescue LoadError
+        abort "webrick is not found. You may need to `gem install webrick` to install webrick."
+      end
       WEBrick::Daemon.start unless foreground
       DRb.start_service url, @db
       DRb.thread.join

--- a/lib/bitclust/subcommands/server_command.rb
+++ b/lib/bitclust/subcommands/server_command.rb
@@ -5,7 +5,6 @@ require 'find'
 require 'pp'
 require 'optparse'
 require 'yaml'
-require 'webrick'
 require 'uri'
 
 require 'bitclust'
@@ -16,7 +15,6 @@ module BitClust
     class ServerCommand < Subcommand
       def initialize
         super
-        require 'webrick'
         require 'uri'
 
         @params = {
@@ -118,6 +116,11 @@ module BitClust
       end
 
       def exec(argv, options)
+        begin
+          require 'webrick'
+        rescue LoadError
+          abort "webrick is not found. You may need to `gem install webrick` to install webrick."
+        end
         require 'bitclust/app'
         if @debugp
           @params[:Logger] = WEBrick::Log.new($stderr, WEBrick::Log::DEBUG)


### PR DESCRIPTION
On docs.ruby-lang.org, gems depended by bitclust are not installed.