### PR TITLE
クラスページ目次の一部ブラウザでの表示崩れを修正

### DIFF
--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -360,10 +360,13 @@ hr {
 }
 
 .class-toc > li {
+    display: inline-block;
     padding-left: 1em;
     text-indent: -1em;
     word-break: break-all;
     break-inside: avoid;
+    width: 100%;
+    box-sizing: border-box;
 }
 
 @media print {


### PR DESCRIPTION
クラスページの目次の段組みが、FirefoxとInternet Explorerで意図していないであろう表示になっていました。
具体的には、列幅に収まらないメソッド名が2列に渡ってしまう場合がありました。

Google Chrome 87, Firefox 84, Internet Explorer 11での [Hash](https://docs.ruby-lang.org/ja/latest/class/Hash.html) ページの表示（下2つでは`ruby2_keywords_hash?`が2列に分かれている）
<img src="https://user-images.githubusercontent.com/18339861/103479933-5eb27c00-4e14-11eb-8318-0781de11ab70.png" alt="修正前" width="80%">

これをFirefox, IEでもChromeと同様の表示になるように修正しました。

修正後
<img src="https://user-images.githubusercontent.com/18339861/103480850-2f9f0900-4e1a-11eb-9cc1-6563ae62c2e2.png" alt="修正後" width="80%">
