### PR TITLE
Fixed syntax highlighting when a symbol name starts with uppercase

### DIFF
--- a/lib/bitclust/syntax_highlighter.rb
+++ b/lib/bitclust/syntax_highlighter.rb
@@ -181,6 +181,9 @@ module BitClust
         @name_buffer << token
       when @stack.last == :module
         @name_buffer << token
+      when @stack.last == :symbol
+        data << "#{token}</span>"
+        @stack.pop
       else
         on_default(:on_const, token, data)
       end

--- a/test/test_syntax_highlighter.rb
+++ b/test/test_syntax_highlighter.rb
@@ -82,4 +82,26 @@ class TestSyntaxHighlighter < Test::Unit::TestCase
     END
     assert_equal(expected, highlight(source))
   end
+
+  test 'symbol const' do
+    source = <<~END
+      class Foo
+        def to_hash
+          {:Bar => 'a',
+           :Baz => 'b'
+          }
+        end
+      end
+    END
+    expected = <<~END
+      <span class="k">class</span> <span class="nn"></span><span class="o"></span><span class="nc">Foo</span>
+        <span class="k">def</span> <span class="nf">to_hash</span>
+          <span class="p">{</span><span class="ss">:Bar</span> <span class="o">=&gt;</span> <span class="s1">'a'</span>,
+           <span class="ss">:Baz</span> <span class="o">=&gt;</span> <span class="s1">'b'</span>
+          <span class="p">}</span>
+        <span class="k">end</span>
+      <span class="k">end</span>
+    END
+    assert_equal(expected, highlight(source))
+  end
 end


### PR DESCRIPTION
シンボル名が大文字で始まっている場合にシンタックスハイライトが崩れていたのを修正しました。

ref: https://docs.ruby-lang.org/ja/2.7.0/method/Hash/i/merge.html

修正前

![image](https://user-images.githubusercontent.com/3143443/112786407-2af09680-9091-11eb-876c-b2b3cfb311ea.png)

修正後

![image](https://user-images.githubusercontent.com/3143443/112786479-4b205580-9091-11eb-8142-a7a1da7cb9b4.png)
