### PR TITLE
Support syntax highlighting `%i`, `%I`

### DIFF
--- a/lib/bitclust/syntax_highlighter.rb
+++ b/lib/bitclust/syntax_highlighter.rb
@@ -56,6 +56,7 @@ module BitClust
       nl: nil,                         # \n
       op: "o",                         # operator
       period: "p",                     # .
+      qsymbols_beg: "ss",              # %i(
       qwords_beg: "sx",                # %w(
       rbrace: "p",                     # }
       rbracket: "p",                   # ]
@@ -65,6 +66,7 @@ module BitClust
       semicolon: nil,                  # ;
       sp: nil,                         # space
       symbeg: "ss",                    # :
+      symbols_beg: "ss",               # %I(
       tlambda: "o",                    # ->
       tlambeg: "p",                    # (->) {
       tstring_beg: nil,                # " (string")
@@ -319,7 +321,7 @@ module BitClust
       case
       when token == "'"
         data << "#{token}</span>"
-      when [:qwords, :words].include?(@stack.last)
+      when %i[qwords words qsymbols symbols].include?(@stack.last)
         @stack.pop
         data << "#{token}</span>"
       else
@@ -339,6 +341,20 @@ module BitClust
     def on_words_beg(token, data)
       @stack.push(:words)
       style = COLORS[:words_beg]
+      data << "<span class=\"#{style}\">#{token}"
+      data
+    end
+
+    def on_qsymbols_beg(token, data)
+      @stack.push(:qsymbols)
+      style = COLORS[:qsymbols_beg]
+      data << "<span class=\"#{style}\">#{token}"
+      data
+    end
+
+    def on_symbols_beg(token, data)
+      @stack.push(:symbols)
+      style = COLORS[:symbols_beg]
       data << "<span class=\"#{style}\">#{token}"
       data
     end

--- a/test/test_syntax_highlighter.rb
+++ b/test/test_syntax_highlighter.rb
@@ -104,4 +104,22 @@ class TestSyntaxHighlighter < Test::Unit::TestCase
     END
     assert_equal(expected, highlight(source))
   end
+
+  test 'symbol list' do
+    source = <<~END
+      %i[hellow world].each {|s| p s }
+    END
+    expected = <<~END
+      <span class="ss">%i[hellow world]</span><span class="p">.</span><span class="nf">each</span> <span class="p">{</span><span class="o">|</span>s<span class="o">|</span> <span class="nb">p</span> s <span class="p">}</span>
+    END
+    assert_equal(expected, highlight(source))
+
+    source = <<~END
+      %I[hellow world].each {|s| p s }
+    END
+    expected = <<~END
+      <span class="ss">%I[hellow world]</span><span class="p">.</span><span class="nf">each</span> <span class="p">{</span><span class="o">|</span>s<span class="o">|</span> <span class="nb">p</span> s <span class="p">}</span>
+    END
+    assert_equal(expected, highlight(source))
+  end
 end


### PR DESCRIPTION
fix https://github.com/rurema/bitclust/issues/159

以下のように `%i[]` がシンタックスハイライトされるように対応しました。色はシンボルに合わせています。
![image](https://user-images.githubusercontent.com/3143443/115642946-d28e7b00-a356-11eb-9b14-6f39f99a9ab4.png)

`%i` の場合は `qsymbols_beg`, `%I` の場合は `symbols_beg` イベントが実行されていたため、対応するメソッドを追加しました。