### PR TITLE
htmlfileコマンドでのデフォルトのRubyバージョンを変更

### DIFF
--- a/lib/bitclust/subcommands/htmlfile_command.rb
+++ b/lib/bitclust/subcommands/htmlfile_command.rb
@@ -16,7 +16,7 @@ module BitClust
         @target = nil
         @templatedir = srcdir_root + "data/bitclust/template.offline"
         @baseurl = "file://" + srcdir_root.to_s
-        @version = "2.0.0"
+        @version = RUBY_VERSION
         @parser.banner = "Usage: #{File.basename($0, '.*')} htmlfile [options] rdfile"
         @parser.on('--target=NAME', 'Compile NAME to HTML.') {|name|
           @target = name


### PR DESCRIPTION
`bitclust htmlfile`コマンドでデフォルトのRubyバージョンの変更です。

現状、指定しない場合は、Ruby 2.0.0の説明として、HTMLファイルが生成されています。
換言すると、`--ruby=2.0.0`と指定されたのと同じ状態で、HTMLファイルが作成されています。
しかし、これは古いバージョンであり、るりまのサポート対象外でもあり、変更した方がいいだろうという考えのPRです。

`@version = RUBY_VERSION`

上記に書き換えることで、バージョン指定をしなかったときに、実行してるRubyのバージョンに合わせてHTMLファイルが生成されます。

以下のコードと揃えました。
[lib/bitclust/subcommands/ancestors_command.rb#L18](https://github.com/rurema/bitclust/blob/131817367901b686296f788dff9b6a345277cf8f/lib/bitclust/subcommands/ancestors_command.rb#L18)
[lib/bitclust/subcommands/methods_command.rb#L18](https://github.com/rurema/bitclust/blob/131817367901b686296f788dff9b6a345277cf8f/lib/bitclust/subcommands/methods_command.rb#L18)

## 余談
[Machida\.rb \#10](https://machidarb.doorkeeper.jp/events/120193) に参加させてもらったときに、
`bitclust htmlfile`コマンドのデフォルトのRubyバージョンが話題として少しあがり、
デフォルトのバージョンが2.0.0などであることを教えてもらいました。

## 追記 同日4/27 22:44

`@version = ENV["BITCLUST_HTMLFILE_RUBY_VERSION"] || "3.0.0"`

もともと上記のように具体的な安定最新版の3.0.0を指定したり、環境変数で個別に設定できるようにしてPRしましたが、
他の箇所に`RUBY_VESION`を使っているのがあり、こちらの方がいちいち変更せずに済んでよさそうだったので変更しました。
