### PR TITLE
protectedメソッドが独立して表示されるように変更

### DIFF
--- a/data/bitclust/catalog/ja_JP.UTF-8
+++ b/data/bitclust/catalog/ja_JP.UTF-8
@@ -78,6 +78,8 @@ Objects
 オブジェクト
 Private Instance Methods
 privateメソッド
+Protected Instance Methods
+protectedメソッド
 Private Singleton Methods
 private特異メソッド
 Required Libraries

--- a/data/bitclust/template.epub/class
+++ b/data/bitclust/template.epub/class
@@ -57,6 +57,7 @@
      [_('Instance Methods'),          ents.instance_methods           ],
      [_('Private Singleton Methods'), ents.private_singleton_methods  ],
      [_('Private Instance Methods'),  ents.private_instance_methods   ],
+     [_('Protected Instance Methods'),ents.protected_instance_methods ],
      [_('Module Functions'),          ents.module_functions           ],
      [_('Constants'),                 ents.constants                  ],
      [_('Special Variables'),         ents.special_variables          ,'$']] %>
@@ -98,4 +99,3 @@
     end
     headline_pop
 %>
-

--- a/data/bitclust/template.lillia/class
+++ b/data/bitclust/template.lillia/class
@@ -59,6 +59,7 @@
      [_('Instance Methods'),          ents.instance_methods           ],
      [_('Private Singleton Methods'), ents.private_singleton_methods  ],
      [_('Private Instance Methods'),  ents.private_instance_methods   ],
+     [_('Protected Instance Methods'),ents.protected_instance_methods ],
      [_('Module Functions'),          ents.module_functions           ],
      [_('Constants'),                 ents.constants                  ],
      [_('Special Variables'),         ents.special_variables          ],

--- a/data/bitclust/template.lillia/class
+++ b/data/bitclust/template.lillia/class
@@ -70,7 +70,7 @@
 <%
         headline_push
         entries.each do |m|
-%> 
+%>
 <span id="<%= BitClust::NameUtils.encodename_url(m.name) %>"></span>
 <%=     compile_method(m) %>
 <%
@@ -107,11 +107,11 @@
 </form>
 <ul id="index-classes-list">
 <%
-    lib = @entry.library 
-    ((lib.all_classes - lib.all_error_classes).sort + lib.all_error_classes).each do |c| 
-%> 
+    lib = @entry.library
+    ((lib.all_classes - lib.all_error_classes).sort + lib.all_error_classes).each do |c|
+%>
 <li><%= class_link(c.name, "#{c.name}") %></li>
-<%  end  %>    
+<%  end  %>
 </ul>
 </div>
 

--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -120,6 +120,7 @@
      [_('Instance Methods'),          ents.instance_methods           ],
      [_('Private Singleton Methods'), ents.private_singleton_methods  ],
      [_('Private Instance Methods'),  ents.private_instance_methods   ],
+     [_('Protected Instance Methods'),ents.protected_instance_methods ],
      [_('Module Functions'),          ents.module_functions           ],
      [_('Constants'),                 ents.constants                  ],
      [_('Special Variables'),         ents.special_variables          ,'$']] %>

--- a/data/bitclust/template/class
+++ b/data/bitclust/template/class
@@ -147,4 +147,3 @@
     end
     headline_pop
 %>
-

--- a/data/bitclust/template/class
+++ b/data/bitclust/template/class
@@ -60,6 +60,7 @@
      [_('Instance Methods'),          ents.instance_methods           ],
      [_('Private Singleton Methods'), ents.private_singleton_methods  ],
      [_('Private Instance Methods'),  ents.private_instance_methods   ],
+     [_('Protected Instance Methods'),ents.protected_instance_methods ],
      [_('Module Functions'),          ents.module_functions           ],
      [_('Constants'),                 ents.constants                  ],
      [_('Special Variables'),         ents.special_variables          ]]\

--- a/lib/bitclust/classentry.rb
+++ b/lib/bitclust/classentry.rb
@@ -252,14 +252,14 @@ module BitClust
     end
 
     Parts = Struct.new(:singleton_methods, :private_singleton_methods,
-                       :instance_methods,  :private_instance_methods,
+                       :instance_methods,  :private_instance_methods, :protected_instance_methods,
                        :module_functions,
                        :constants, :special_variables,
                        :added, :undefined)
 
     def partitioned_entries(level = 0)
       s = []; spv = []
-      i = []; ipv = []
+      i = []; ipv = []; ipt = []
       mf = []
       c = []; v = []
       added = []
@@ -271,7 +271,9 @@ module BitClust
           when :singleton_method
             (m.public? ? s : spv).push m
           when :instance_method
-            (m.public? ? i : ipv).push m
+            tmp = m.public? ? i : ipv
+            tmp = ipt if m.protected?
+            tmp.push m
           when :module_function
             mf.push m
           when :constant
@@ -287,7 +289,7 @@ module BitClust
           undefined.push m
         end
       end
-      Parts.new(s,spv, i,ipv, mf, c, v, added, undefined)
+      Parts.new(s,spv, i,ipv,ipt, mf, c, v, added, undefined)
     end
 
     def singleton_methods(level = 0)
@@ -321,6 +323,10 @@ module BitClust
     end
 
     alias private_methods   private_instance_methods
+
+    def protected_instance_methods(level = 0)
+      entries(level).select(&:protected_instance_method?).sort_by(&:sort_key)
+    end
 
     def constants(level = 0)
       entries(level).select(&:constant?).sort_by(&:sort_key)

--- a/lib/bitclust/methodentry.rb
+++ b/lib/bitclust/methodentry.rb
@@ -148,7 +148,7 @@ module BitClust
     end
 
     def public?
-      visibility() != :private
+      visibility() != :private && visibility() != :protected
     end
 
     def protected?
@@ -172,7 +172,11 @@ module BitClust
     end
 
     def private_instance_method?
-      instance_method? and public?
+      instance_method? and private?
+    end
+
+    def protected_instance_method?
+      instance_method? and protected?
     end
 
     def singleton_method?

--- a/lib/bitclust/rrdparser.rb
+++ b/lib/bitclust/rrdparser.rb
@@ -219,7 +219,7 @@ module BitClust
       f.while_match(/\A==[^=]/) do |line|
         case line.sub(/\A==/, '').strip
         when /\A((?:public|private|protected)\s+)?(?:(class|singleton|instance)\s+)?methods?\z/i
-          @context.visibility = ($1 || 'public').downcase.intern
+          @context.visibility = ($1 || 'public').downcase.strip.intern
           t = ($2 || 'instance').downcase.sub(/class/, 'singleton')
           @context.type = "#{t}_method".intern
         when /\AModule\s+Functions?\z/i

--- a/test/test_rrdparser.rb
+++ b/test/test_rrdparser.rb
@@ -39,4 +39,32 @@ HERE
     test_undef_spec = BitClust::MethodSpec.parse('Dummy#test_undef')
     assert_equal(:undefined, methoddatabase.get_method(test_undef_spec).kind)
   end
+
+  def test_instance_methods
+    result = BitClust::RRDParser.parse(<<HERE, 'dummy')
+= module Dummy
+
+== Instance Methods
+--- im
+
+== Private Methods
+
+--- pvi
+
+== Protected Instance Methods
+
+--- pti
+
+HERE
+    _library, methoddatabase = result
+
+    test_undef_spec = BitClust::MethodSpec.parse('Dummy#im')
+    assert_equal(true, methoddatabase.get_method(test_undef_spec).public?)
+
+    test_undef_spec = BitClust::MethodSpec.parse('Dummy#pvi')
+    assert_equal(true, methoddatabase.get_method(test_undef_spec).private?)
+
+    test_undef_spec = BitClust::MethodSpec.parse('Dummy#pti')
+    assert_equal(true, methoddatabase.get_method(test_undef_spec).protected?)
+  end
 end


### PR DESCRIPTION
## 内容

Issue #162

publicメソッドの中にprotectedメソッドが混ざってしまっていたので、
protectedメソッドが独立して表示されるように対応しました。

[![Image from Gyazo](https://i.gyazo.com/4b9fe3f964a06b2808d53b5521637b69.png)](https://gyazo.com/4b9fe3f964a06b2808d53b5521637b69)

[![Image from Gyazo](https://i.gyazo.com/5e157a99d7b6bdbcde4a5528439a1498.png)](https://gyazo.com/5e157a99d7b6bdbcde4a5528439a1498)

## 備考

###  lib/bitclust/rrdparser.rb での変更点

正規表現のところで、protectedメソッド等は末尾に余計な空白がついてしまっていたので、`strip`を追加しました。

```ruby
line = "Instance Methods"
line = "Private Instance Methods"
line = "Protected Instance Methods"

case line.sub(/\A==/, '').strip
when /\A((?:public|private|protected)\s+)?(?:(class|singleton|instance)\s+)?methods?\z/i
  p $1  # => "Private "
  p $2  # => "Instance"
end
``` 