### PR TITLE
htmlfileで指定のバージョンが表示されるように変更

### DIFF
--- a/lib/bitclust/screen.rb
+++ b/lib/bitclust/screen.rb
@@ -37,6 +37,7 @@ module BitClust
     private :default_message_catalog
 
     def entry_screen(entry, opt)
+      @conf[:target_version] = opt[:target_version]
       new_screen(Screen.for_entry(entry), entry, opt)
     end
 

--- a/lib/bitclust/subcommands/htmlfile_command.rb
+++ b/lib/bitclust/subcommands/htmlfile_command.rb
@@ -62,7 +62,7 @@ module BitClust
               lib = RRDParser.parse_stdlib_file(target_file, options)
             end
             entry = @target ? lookup(lib, @target) : lib
-            puts manager.entry_screen(entry, { :database => db }).body
+            puts manager.entry_screen(entry, { :database => db, :target_version => @version }).body
             return
           rescue ParseError => ex
             $stderr.puts ex.message


### PR DESCRIPTION
# 内容

現状、`bitclust htmlfile`コマンドで作成したHTMLファイルの左上に表示されるバージョンが、指定したバージョンとなりません。
`bitclust htmlfile`コマンドで対象となるバージョンが、HTMLファイルの表示に反映されるように変更するPRです。

[![Image from Gyazo](https://i.gyazo.com/738cc127e089cf9eb03423c4fbe9a7d9.png)](https://gyazo.com/738cc127e089cf9eb03423c4fbe9a7d9)

## 具体的に

```ruby
@target_version = h[:target_version] || h[:database].propget('version')
```
`screen.rb`のここの`h[:target_version]`が`nil`になってしまっているので、`htmlfile.rb`での`@version`を渡すようにしました。

## 備考

[Machida\.rb \#10](https://machidarb.doorkeeper.jp/events/120193) に参加した際に、ちょっとした質問としてあがっていた内容です。
また、別件ですが、同様に生成されるHTMLが翻訳前の英語な点もちょっとした質問としてでてました(備忘)。