### PR TITLE
CSS font-family の指定をシステムフォントを優先するように修正

### DIFF
--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -5,7 +5,11 @@
 body {
     background-color: white;
     color: black;
-    font-family: Meiryo, "Hiragino Kaku Gothic Pro", "MS Gothic", Osaka, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont,
+      "Helvetica Neue", Arial,
+      "Hiragino Kaku Gothic ProN", "Hiragino Sans",
+      "BIZ UDGothic", Meiryo,
+      sans-serif;
     text-align: left;
     margin-top: 20px;
     margin-left: 2%;


### PR DESCRIPTION
* macOS Safari 環境で `\` が `¥` 表示になる問題への対応
  参考: [Mac/iOS Safariでバックスラッシュを円記号として表示する方法 - teppeis blog](https://teppeis.hatenablog.com/entry/2014/09/safari-backslash-yen-sign)
* どうせなら `font-family` 見直すべきだと思い、最近のOSに合わせてシステムフォントを優先したスタイルに変更しました。

![image](https://user-images.githubusercontent.com/5656927/132345400-3880f8aa-5f34-4048-a054-e00af3188cde.jpg)

---

ローカルでサーバーを立てる方法がwikiなどを見たのですが分からず、出力したHTMLのCSSリンクを書き換えての確認になっています。
以前のPR #71 と同様のファイルを修正しているので、問題ないと思いますが念の為確認をしていただけると幸いです。
特にWindows環境での確認が一切できておりません。