### PR TITLE
サンプルコードの特異メソッド内でObject.newが.newObjectと表示されるのを修正

### DIFF
--- a/lib/bitclust/syntax_highlighter.rb
+++ b/lib/bitclust/syntax_highlighter.rb
@@ -221,6 +221,9 @@ module BitClust
       case
       when token == "::" && [:class, :module].include?(@stack.last)
         @name_buffer << token
+      when token == "<<" && @stack.last == :class
+        @stack.pop
+        on_default(:on_op, token, data)
       else
         @stack.pop if @stack.last == :method_call
         on_default(:on_op, token, data)

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -427,7 +427,14 @@ HERE
 //emlist[][ruby]{
 class <<obj
   def foo
+    Object.new
   end
+end
+class << Object.new
+end
+class << self
+end
+class << FOO::BAR::BAZ
 end
 p Foo.singleton_method(:foo)
 //}
@@ -438,9 +445,16 @@ HERE
 <dd class="method-description">
 <pre class="highlight ruby">
 <code>
-<span class="k">class</span> <span class="o">&lt;&lt;</span><span class="nn"></span><span class="o"></span><span class="nc">obj</span>
+<span class="k">class</span> <span class="o">&lt;&lt;</span>obj
   <span class="k">def</span> <span class="nf">foo</span>
+    <span class="no">Object</span><span class="p">.</span><span class="nf">new</span>
   <span class="k">end</span>
+<span class="k">end</span>
+<span class="k">class</span> <span class="o">&lt;&lt;</span> <span class="no">Object</span><span class="p">.</span><span class="nf">new</span>
+<span class="k">end</span>
+<span class="k">class</span> <span class="o">&lt;&lt;</span> <span class="nc">self</span>
+<span class="k">end</span>
+<span class="k">class</span> <span class="o">&lt;&lt;</span> <span class="no">FOO</span><span class="o">::</span><span class="no">BAR</span><span class="o">::</span><span class="no">BAZ</span>
 <span class="k">end</span>
 <span class="nb">p</span> <span class="no">Foo</span><span class="p">.</span><span class="nf">singleton_method</span><span class="p">(</span><span class="ss">:foo</span><span class="p">)</span>
 </code></pre>


### PR DESCRIPTION
## 概要

RubyリファレンスマニュアルのNEWS for Ruby 2.7.0"のサンプルコードで、特異メソッド内に書かれた `Object.new` が `.newObject` と表示されるのを修正しました。

https://docs.ruby-lang.org/ja/latest/doc/news=2f2_7_0.html

以下の変更で `Object.new` でシンタックスハイライトされました。

`BitClust::SyntaxHighlighter#on_kw` メソッドでトークンが `class` の場合、クラス定義が始まるとして `@stack` に `:class` を代入されます。
`BitClust::SyntaxHighlighter#on_op` メソッドで `class <<` を処理する時に、特異メソッドの定義が始まると考えて `@stack` にあるクラス定義を表す `:class` を外しました。

## issue

https://github.com/rurema/bitclust/issues/169
