### PR TITLE
リストのインデントがずれていたのを修正

### DIFF
--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -196,8 +196,8 @@ module BitClust
             nl
             string compile_text(cont.strip)
           end
-          line @item_stack.pop # current level li
-        elsif /\A(\s+)(?:\*\s|\(\d+\))/ =~ @f.peek and level < $1.size
+        end
+        if /\A(\s+)(?:\*\s|\(\d+\))/ =~ @f.peek and level < $1.size
           item_list($1.size)
           line @item_stack.pop # current level ul or ol
         elsif /\A(\s+)(?:\*\s|\(\d+\))/ =~ @f.peek and level > $1.size

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -525,13 +525,15 @@ HERE
     src = <<HERE
   * hoge1
     * fuga1
+      bar
   * hoge2
     * fuga2
 HERE
     expected = <<HERE
 <ul>
 <li>hoge1<ul>
-<li>fuga1</li>
+<li>fuga1
+bar</li>
 </ul>
 </li>
 <li>hoge2<ul>

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -541,7 +541,6 @@ bar</li>
 </ul>
 </li>
 </ul>
-
 HERE
     assert_compiled_source(expected, src)
   end
@@ -580,7 +579,6 @@ HERE
 </ol>
 </li>
 </ol>
-
 HERE
     assert_compiled_source(expected, src)
   end
@@ -607,7 +605,6 @@ HERE
 </ol>
 </li>
 </ul>
-
 HERE
     assert_compiled_source(expected, src)
   end
@@ -628,6 +625,8 @@ HERE
 <li>boo1</li>
 </ol>
 </li>
+</ol>
+</li>
 <li>hoge2<ol>
 <li>fuga2<ol>
 <li>boo2</li>
@@ -636,9 +635,6 @@ HERE
 </ol>
 </li>
 </ol>
-</li>
-</ol>
-
 HERE
     assert_compiled_source(expected, src)
   end


### PR DESCRIPTION
リストのインデントがずれることがある問題を修正しました。

Fix: https://github.com/rurema/doctree/issues/2621

インデントがずれる原因は2つありました。

1つはリストの項目中に改行含まれる場合に、その次の項目でインデントレベルが変わると条件判定が行われないためインデントが変わらないという問題でした。
もう1つは2レベル以上インデントが変わる場合の処理が不足していたためでした。この対応で `item_list` メソッドの `indent` パラメーターは不要になったので削除しています。

修正後(GC.html)
![image](https://user-images.githubusercontent.com/3143443/147382616-108640ac-14d2-42e1-b3f0-8545c1cd7148.png)

修正後(news=2f3_0_0.html)
![image](https://user-images.githubusercontent.com/3143443/147382652-45c701a9-a947-4d95-8637-80bafeec54a4.png)
