### PR TITLE
Add Ruby 3.0, 3.1 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Set up Bundler
-      run: gem install bundler --no-document
     - name: Install dependencies
       run: bundle install
     - name: Run test
@@ -39,9 +37,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Set up Bundler
-      run: gem install bundler --no-document
-      if: ${{ matrix.ruby == '2.5' }}
     - name: Install dependencies
       run: bundle install
       working-directory: ./doctree

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,6 @@ jobs:
       working-directory: ./doctree
 
     - name: Create tarballs
-      if: ${{ runner.os != 'Windows' }}
       run: |
         set -ex
         mkdir /tmp/artifact
@@ -58,14 +57,6 @@ jobs:
         for d in *.*; do
           tar acf ../artifact/$d.tar.xz $d
         done
-    - name: Create tarballs
-      if: ${{ runner.os == 'Windows' }}
-      run: |
-        mkdir /tmp/artifact
-        cd /tmp/html
-        ls -Name "*.*" | foreach {
-          tar acf "../artifact/${_}.tar.xz" $_
-        }
     - uses: actions/upload-artifact@v2
       with:
         name: statichtml-ubuntu-latest-${{ matrix.ruby }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 2.7, 2.6, 2.5, 2.4, 2.3, ruby-head ]
+        ruby: [ 3.1, '3.0', 2.7, 2.6, 2.5, 2.4, 2.3, ruby-head ]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: rurema/doctreeは2.5+しかサポートしていない
-        ruby: [ 2.7, 2.6, 2.5, ruby-head ]
+        ruby: [ 3.1, '3.0', 2.7, 2.6, 2.5, ruby-head ]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -69,7 +69,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: statichtml-ubuntu-latest-${{ matrix.ruby }}
-        path: /tmp/artifact/2.?.0.tar.xz
+        path: /tmp/artifact/*.tar.xz
 
     - name: Rename generated html
       run: |


### PR DESCRIPTION
GitHub Actions の matrix に Ruby 3.0, 3.1 を追加しました。
また、合わせて以下の不要な処理があったので削除しています。

* Windows 環境で実行していないため、 Windows 用の分岐処理を削除
* setup-ruby で bundler がインストールされるため、独自の処理を削除
