### PR TITLE
継承の見出しの変更

### DIFF
--- a/data/bitclust/catalog/ja_JP.UTF-8
+++ b/data/bitclust/catalog/ja_JP.UTF-8
@@ -103,7 +103,7 @@ Text
 Thread
 スレッド
 ancestors
-クラスの継承リスト
+クラス・モジュールの継承リスト
 class %s
 %sクラス
 library %s


### PR DESCRIPTION
けっこう前ですが、ある勉強会を拝見した際に、
モジュールが含まれてることに疑問がでてた記憶があります。

通常Kernel等のモジュールも継承リストに入っているため、
モジュールを含めた方が誤解がないのでデメリットがなければ変更した方がいいかと思いました。

![image](https://user-images.githubusercontent.com/6189752/148849921-5caaada7-6496-4204-9b29-4d3867269f2d.png)


