### PR TITLE
サンプルコード内の `class Foo; end` が `class ;Foo end` と表示されるのを修正

### DIFF
--- a/lib/bitclust/syntax_highlighter.rb
+++ b/lib/bitclust/syntax_highlighter.rb
@@ -275,6 +275,28 @@ module BitClust
       on_default(:on_nl, token, data)
     end
 
+    def on_semicolon(token, data)
+      case
+      when @name_buffer.empty?
+        return on_default(:on_semicolon, token, data)
+      when @stack.last == :module
+        name = @name_buffer.join
+        data << "<span class=\"nn\">#{name}</span>"
+        @stack.pop
+        @name_buffer.clear
+      when @stack.last == :class
+        namespace = @name_buffer.values_at(0..-3).join
+        operator = @name_buffer[-2]
+        name = @name_buffer.last
+        data << "<span class=\"nn\">#{namespace}</span>"
+        data << "<span class=\"o\">#{operator}</span>"
+        data << "<span class=\"nc\">#{name}</span>"
+        @stack.pop
+        @name_buffer.clear
+      end
+      on_default(:on_semicolon, token, data)
+    end
+
     def on_regexp_beg(token, data)
       style = COLORS[:regexp_beg]
       data << "<span class=\"#{style}\">#{token}"

--- a/test/test_syntax_highlighter.rb
+++ b/test/test_syntax_highlighter.rb
@@ -104,4 +104,24 @@ class TestSyntaxHighlighter < Test::Unit::TestCase
     END
     assert_equal(expected, highlight(source))
   end
+
+  test 'one liner module' do
+    source = <<~END
+      module Foo; end
+    END
+    expected = <<~END
+      <span class="k">module</span> <span class="nn">Foo</span>; <span class="k">end</span>
+    END
+    assert_equal(expected, highlight(source))
+  end
+
+  test 'one liner class' do
+    source = <<~END
+      class Foo; end
+    END
+    expected = <<~END
+      <span class="k">class</span> <span class="nn"></span><span class="o"></span><span class="nc">Foo</span>; <span class="k">end</span>
+    END
+    assert_equal(expected, highlight(source))
+  end
 end


### PR DESCRIPTION
## 概要
サンプルコード内の `class Foo; end` が `class ;Foo end` と表示されるのを修正しました。

以下の変更で `class Foo; end` がその通りに出力されました。

トークン `;` について、改行時と同様に `@name_buffer` を `data` に吐き出す。

## 懸念

`on_sp` および `on_nl` とほぼ同じコードになっており、 `event` を引数に受け取る共通メソッドを設けるべきか悩みました。

なんとなくですが `on_sp` と `on_nl` は異なる処理が追加されることもありそうなので現状通り分けておいて良さそうです。
ですが、 `on_nl` と `on_semicolon` は常に同じ処理であるべきの様に思えます。
`;` は改行代わりの区切り文字であると理解しているためです。

## issue
#178