### PR TITLE
Fix error on ruby 3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,13 +3,24 @@ name: test
 on: [push, pull_request]
 
 jobs:
+  ruby-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.versions.outputs.value }}
+    steps:
+      - id: versions
+        run: |
+          versions=$(curl -s 'https://cache.ruby-lang.org/pub/misc/ci_versions/cruby.json' | jq -c '. + []')
+          echo "value=${versions}" >> $GITHUB_OUTPUT
+
   build:
+    needs: ruby-versions
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 3.1, '3.0', 2.7, 2.6, 2.5, 2.4, 2.3, ruby-head ]
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
@@ -19,16 +30,17 @@ jobs:
       run: bundle exec rake
 
   rurema:
+    needs: ruby-versions
     runs-on: ubuntu-latest
     strategy:
       matrix:
         # NOTE: rurema/doctreeは2.5+しかサポートしていない
-        ruby: [ 3.1, '3.0', 2.7, 2.6, 2.5, ruby-head ]
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         path: 'bitclust'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         repository: 'rurema/doctree'
         path: 'doctree'
@@ -52,7 +64,7 @@ jobs:
         for d in *.*; do
           tar acf ../artifact/$d.tar.xz $d
         done
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: statichtml-ubuntu-latest-${{ matrix.ruby }}
         path: /tmp/artifact/*.tar.xz
@@ -61,7 +73,7 @@ jobs:
       run: |
         cd /tmp
         mv -v html html.pr
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         path: 'bitclust'
         ref: ${{ github.event.pull_request.base.sha }}
@@ -77,7 +89,7 @@ jobs:
         mv -v html html.base
         git diff --no-index html.base html.pr --stat || true
         git diff --no-index html.base html.pr --output artifact/html.diff || true
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: diff-ubuntu-latest-${{ matrix.ruby }}
         path: /tmp/artifact/html.diff

--- a/bitclust-core.gemspec
+++ b/bitclust-core.gemspec
@@ -34,4 +34,6 @@ EOD
   s.add_runtime_dependency "rack"
   s.add_runtime_dependency "progressbar", ">= 1.9.0", "< 2.0"
   s.add_runtime_dependency "webrick"
+  s.add_runtime_dependency "drb"
+  s.add_runtime_dependency "nkf"
 end

--- a/lib/bitclust/version.rb
+++ b/lib/bitclust/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module BitClust
-  VERSION = "1.3.1"
+  VERSION = "1.4.0"
 end


### PR DESCRIPTION
doctree の pull request の CI で head のときにエラーになって、ちゃんと確認できない状態になっているので、 `gemspec` に依存を足して、とりあえず ruby 3.4 でも動くようにしておく。

`drb` を不要なときに読み込まないようにする、 NKF から `String#encode` への移行などの根本的な対応は今度の予定にしておく。