### PR TITLE
Requiring drb is required

### DIFF
--- a/lib/bitclust/database.rb
+++ b/lib/bitclust/database.rb
@@ -30,6 +30,7 @@ module BitClust
       when 'file'
         new(uri.path)
       when 'druby'
+        require 'drb'
         DRbObject.new_with_uri(uri.to_s)
       else
         raise InvalidScheme, "unknown database scheme: #{uri.scheme}"


### PR DESCRIPTION
```
❯ refe --server=druby://127.0.0.1:12345

❯ refe -d druby://127.0.0.1:12345 String#index
/Users/makicamel/.rbenv/versions/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bitclust-core-1.3.0/lib/bitclust/database.rb:34:in 'BitClust::Database.connect': uninitialized constant BitClust::Database::DRbObject (NameError)
```

となってしまうので require しました。
https://github.com/rurema/bitclust/commit/2da0beba08d4b94d0b67ff36de4d30073133735e#diff-0e1afb3d7fdac0c1f99dc5bea7bf5ef6ba3577ff19668b4924c52ac004fd0ffe からこうなっていますが、
refe サーバの使い方が想定と異なっているでしょうか...?