### PR TITLE
statichtml にクライアントサイド静的検索を追加（RDoc Aliki の検索UIを流用）

### DIFF
--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -7,6 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="<%=h css_url() %>">
 <link rel="stylesheet" href="<%=h custom_css_url("syntax-highlight.css") %>">
+<link rel="stylesheet" href="<%=h custom_css_url("search.css") %>">
 <link rel="icon" type="image/png" href="<%=h favicon_url() %>">
 <% if @conf[:canonical_base_url] %>
 <link rel="canonical" href="<%= canonical_url() %>">
@@ -14,8 +15,20 @@
 <title><%=h @title %> (Ruby <%=h ruby_version %> リファレンスマニュアル)</title>
 <meta name="description" content="<%=h @description %>">
 <script src="<%=h custom_js_url('script.js') %>"></script>
+<script>var index_rel_prefix = "<%=h html_base() %>/";</script>
+<script src="<%=h custom_js_url('js/search_data.js') %>"></script>
+<script src="<%=h custom_js_url('js/search_navigation.js') %>"></script>
+<script src="<%=h custom_js_url('js/search_ranker.js') %>"></script>
+<script src="<%=h custom_js_url('js/search_controller.js') %>"></script>
+<script src="<%=h custom_js_url('js/search_init.js') %>"></script>
 </head>
 <body>
+<div id="search-section" role="search">
+  <input id="search-field" type="text" autocomplete="off" spellcheck="false"
+         placeholder="クラス・メソッドを検索 (/ で移動)"
+         aria-label="検索" aria-autocomplete="list" aria-controls="search-results">
+  <ul id="search-results" class="search-results" aria-expanded="false"></ul>
+</div>
 <%= yield %>
 <footer id="footer">
   <a rel="license" href="https://creativecommons.org/licenses/by/3.0/">

--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -23,11 +23,14 @@
 <script src="<%=h custom_js_url('js/search_init.js') %>"></script>
 </head>
 <body>
-<div id="search-section" role="search">
-  <input id="search-field" type="text" autocomplete="off" spellcheck="false"
-         placeholder="クラス・メソッドを検索 (/ で移動)"
-         aria-label="検索" aria-autocomplete="list" aria-controls="search-results">
-  <ul id="search-results" class="search-results" aria-expanded="false"></ul>
+<div id="rurema-topbar">
+  <div id="rurema-brand"><%= manual_home_link %></div>
+  <div id="search-section" role="search">
+    <input id="search-field" type="text" autocomplete="off" spellcheck="false"
+           placeholder="クラス・メソッドを検索 (/)"
+           aria-label="検索" aria-autocomplete="list" aria-controls="search-results">
+    <ul id="search-results" class="search-results" aria-expanded="false"></ul>
+  </div>
 </div>
 <%= yield %>
 <footer id="footer">

--- a/lib/bitclust/screen.rb
+++ b/lib/bitclust/screen.rb
@@ -358,6 +358,12 @@ module BitClust
       @urlmapper.custom_js_url(js)
     end
 
+    # Relative path from the current page to the site root, used as the
+    # prefix for client-side search result links in statichtml output.
+    def html_base
+      @urlmapper.respond_to?(:bitclust_html_base) ? @urlmapper.bitclust_html_base : '.'
+    end
+
     def favicon_url
       @urlmapper.favicon_url
     end

--- a/lib/bitclust/search_index_generator.rb
+++ b/lib/bitclust/search_index_generator.rb
@@ -109,11 +109,16 @@ module BitClust
 
     def document_entries(db)
       db.docs.map do |doc|
+        slug  = doc.name
+        title = doc.title
+        # Prose pages are identified by a Japanese title, so index the title
+        # (for human queries) together with the slug (for identifier queries).
+        label = (title && !title.empty? && title != slug) ? "#{title} (#{slug})" : slug
         {
-          name:      doc.name,
-          full_name: doc.name,
+          name:      label,
+          full_name: label,
           type:      'document',
-          path:      "doc/#{encode(doc.name)}#{@suffix}",
+          path:      "doc/#{encode(slug)}#{@suffix}",
         }
       end
     end

--- a/lib/bitclust/search_index_generator.rb
+++ b/lib/bitclust/search_index_generator.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+#
+# bitclust/search_index_generator.rb
+#
+# Builds a client-side search index compatible with RDoc's Aliki theme.
+#
+# The index is a flat array of entries:
+#
+#   { name:, full_name:, type:, path: }
+#
+# serialized as a JavaScript assignment so it can be loaded over file://
+# without tripping the browser's CORS check on JSON files:
+#
+#   var search_data = { "index": [ ... ] };
+#
+# This mirrors the static layout produced by StatichtmlCommand so that the
+# +path+ of each entry points at the file actually generated there.
+#
+
+require 'json'
+require 'bitclust/nameutils'
+
+module BitClust
+  class SearchIndexGenerator
+    include NameUtils
+
+    # Maps BitClust method typenames onto the type vocabulary understood by
+    # Aliki's searcher (class/module/constant/class_method/instance_method).
+    # Module functions are callable as singleton methods, so they are indexed
+    # as class methods; special variables have no Aliki equivalent and keep
+    # their own label (the searcher only uses the type for ranking).
+    TYPENAME_TO_SEARCH_TYPE = {
+      singleton_method: 'class_method',
+      module_function:  'class_method',
+      instance_method:  'instance_method',
+      constant:         'constant',
+      special_variable: 'variable',
+    }.freeze
+
+    def initialize(suffix: '.html', fs_casesensitive: false)
+      @suffix = suffix
+      @fs_casesensitive = fs_casesensitive
+    end
+
+    # Builds the search index as an array of entry hashes.
+    # +db+ is a MethodDatabase; +fdb+ is an optional FunctionDatabase (C API).
+    def build_index(db, fdb = nil)
+      index = []
+      index.concat(class_entries(db))
+      index.concat(method_entries(db))
+      index.concat(library_entries(db))
+      index.concat(document_entries(db))
+      index.concat(function_entries(fdb)) if fdb
+      index
+    end
+
+    # Serializes the index as an Aliki-compatible +search_data.js+ body.
+    def to_js(db, fdb = nil)
+      "var search_data = #{JSON.generate(index: build_index(db, fdb))};"
+    end
+
+    private
+
+    def class_entries(db)
+      db.classes.sort.reject(&:dummy?).map do |c|
+        {
+          name:      c.name,
+          full_name: c.name,
+          type:      c.type.to_s,
+          path:      "class/#{encode(c.name)}#{@suffix}",
+        }
+      end
+    end
+
+    def method_entries(db)
+      seen = {}
+      result = []
+      db.methods.each do |entry|
+        next if entry.undefined?
+
+        type = TYPENAME_TO_SEARCH_TYPE[entry.typename]
+        next unless type
+
+        cname = entry.klass.name
+        tmark = entry.typemark
+        tchar = entry.typechar
+        entry.names.each do |mname|
+          path = "method/#{encode(cname)}/#{tchar}/#{encode(mname)}#{@suffix}"
+          next if seen[path]
+
+          seen[path] = true
+          full_name = (tmark == '$' ? '' : cname) + tmark + mname
+          result << { name: mname, full_name: full_name, type: type, path: path }
+        end
+      end
+      result
+    end
+
+    def library_entries(db)
+      db.libraries.sort.map do |lib|
+        {
+          name:      lib.name,
+          full_name: lib.name,
+          type:      'library',
+          path:      "library/#{encode(lib.name)}#{@suffix}",
+        }
+      end
+    end
+
+    def document_entries(db)
+      db.docs.map do |doc|
+        {
+          name:      doc.name,
+          full_name: doc.name,
+          type:      'document',
+          path:      "doc/#{encode(doc.name)}#{@suffix}",
+        }
+      end
+    end
+
+    def function_entries(fdb)
+      fdb.functions.sort.map do |func|
+        {
+          name:      func.name,
+          full_name: func.name,
+          type:      'function',
+          path:      "function/#{func.name}#{@suffix}",
+        }
+      end
+    end
+
+    def encode(str)
+      @fs_casesensitive ? encodename_url(str) : encodename_fs(str)
+    end
+  end
+end

--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -12,6 +12,7 @@ require 'bitclust/nameutils'
 require 'bitclust/subcommand'
 require 'bitclust/progress_bar'
 require 'bitclust/silent_progress_bar'
+require 'bitclust/search_index_generator'
 
 module BitClust
   module Subcommands
@@ -203,6 +204,7 @@ module BitClust
                     manager.function_index_screen(fdb.functions.sort, { :database => fdb }).body,
                     :verbose => @verbose)
         create_index_html(@outputdir)
+        create_search_index(@outputdir, db, fdb)
         FileUtils.cp(@manager_config[:themedir] + @manager_config[:css_url],
                      @outputdir.to_s, :verbose => @verbose, :preserve => true)
         FileUtils.cp(@manager_config[:themedir] + "syntax-highlight.css",
@@ -288,6 +290,16 @@ module BitClust
 <a href="doc/#{index_filename}">Go</a>
 HERE
         }
+      end
+
+      def create_search_index(outputdir, db, fdb)
+        generator = SearchIndexGenerator.new(suffix: @suffix,
+                                             fs_casesensitive: @fs_casesensitive)
+        jsdir = outputdir + "js"
+        FileUtils.mkdir_p(jsdir) unless jsdir.directory?
+        create_file(jsdir + "search_data.js",
+                    generator.to_js(db, fdb),
+                    :verbose => @verbose)
       end
 
       def create_html_file(entry, manager, outputdir, db)

--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -309,6 +309,9 @@ HERE
           FileUtils.cp(themedir + "js" + js, jsdir.to_s,
                        :verbose => @verbose, :preserve => true)
         end
+        # Ship the MIT notice for the vendored Aliki files alongside them.
+        FileUtils.cp(themedir + "js" + "NOTICE", jsdir.to_s,
+                     :verbose => @verbose, :preserve => true)
         FileUtils.cp(themedir + "search.css", outputdir.to_s,
                      :verbose => @verbose, :preserve => true)
       end

--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -292,6 +292,10 @@ HERE
         }
       end
 
+      SEARCH_JS_FILES = %w[
+        search_navigation.js search_ranker.js search_controller.js search_init.js
+      ].freeze
+
       def create_search_index(outputdir, db, fdb)
         generator = SearchIndexGenerator.new(suffix: @suffix,
                                              fs_casesensitive: @fs_casesensitive)
@@ -300,6 +304,13 @@ HERE
         create_file(jsdir + "search_data.js",
                     generator.to_js(db, fdb),
                     :verbose => @verbose)
+        themedir = @manager_config[:themedir]
+        SEARCH_JS_FILES.each do |js|
+          FileUtils.cp(themedir + "js" + js, jsdir.to_s,
+                       :verbose => @verbose, :preserve => true)
+        end
+        FileUtils.cp(themedir + "search.css", outputdir.to_s,
+                     :verbose => @verbose, :preserve => true)
       end
 
       def create_html_file(entry, manager, outputdir, db)

--- a/sig/bitclust/search_index_generator.rbs
+++ b/sig/bitclust/search_index_generator.rbs
@@ -1,0 +1,34 @@
+module BitClust
+  # Builds a client-side search index compatible with RDoc's Aliki theme.
+  class SearchIndexGenerator
+    @suffix: String
+
+    @fs_casesensitive: bool
+
+    include NameUtils
+
+    TYPENAME_TO_SEARCH_TYPE: Hash[Symbol, String]
+
+    type entry = Hash[Symbol, String]
+
+    def initialize: (?suffix: String, ?fs_casesensitive: bool) -> void
+
+    def build_index: (MethodDatabase db, ?FunctionDatabase? fdb) -> Array[entry]
+
+    def to_js: (MethodDatabase db, ?FunctionDatabase? fdb) -> String
+
+    private
+
+    def class_entries: (MethodDatabase db) -> Array[entry]
+
+    def method_entries: (MethodDatabase db) -> Array[entry]
+
+    def library_entries: (MethodDatabase db) -> Array[entry]
+
+    def document_entries: (MethodDatabase db) -> Array[entry]
+
+    def function_entries: (FunctionDatabase fdb) -> Array[entry]
+
+    def encode: (String str) -> String
+  end
+end

--- a/test/test_search_index_generator.rb
+++ b/test/test_search_index_generator.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'json'
+require 'fileutils'
+require 'bitclust'
+require 'bitclust/methoddatabase'
+require 'bitclust/search_index_generator'
+
+class TestSearchIndexGenerator < Test::Unit::TestCase
+  def setup
+    @prefix = 'db_si'
+    @root = 'src_si'
+    setup_files
+    @db = BitClust::MethodDatabase.new(@prefix)
+    @db.init
+    @db.transaction do
+      [%w[version 3.4], %w[encoding utf-8]].each do |k, v|
+        @db.propset(k, v)
+      end
+    end
+    @db.transaction do
+      @db.update_by_stdlibtree(@root)
+    end
+    @gen = BitClust::SearchIndexGenerator.new
+  end
+
+  def teardown
+    FileUtils.rm_r([@prefix, @root], :force => true)
+  end
+
+  def find_entry(index, full_name)
+    index.find { |e| e[:full_name] == full_name }
+  end
+
+  def test_class_entry
+    index = @gen.build_index(@db)
+    e = find_entry(index, 'Foo')
+    assert_not_nil e
+    assert_equal 'Foo', e[:name]
+    assert_equal 'class', e[:type]
+    assert_equal 'class/-foo.html', e[:path]
+  end
+
+  def test_module_entry_type
+    index = @gen.build_index(@db)
+    e = find_entry(index, 'Kernel')
+    assert_not_nil e
+    assert_equal 'module', e[:type]
+    assert_equal 'class/-kernel.html', e[:path]
+  end
+
+  def test_instance_method_entry
+    index = @gen.build_index(@db)
+    e = find_entry(index, 'Foo#foo')
+    assert_not_nil e
+    assert_equal 'foo', e[:name]
+    assert_equal 'instance_method', e[:type]
+    assert_equal 'method/-foo/i/foo.html', e[:path]
+  end
+
+  def test_module_function_is_class_method
+    index = @gen.build_index(@db)
+    e = find_entry(index, 'Kernel.#at_exit')
+    assert_not_nil e
+    assert_equal 'at_exit', e[:name]
+    assert_equal 'class_method', e[:type]
+    assert_equal 'method/-kernel/m/at_exit.html', e[:path]
+  end
+
+  def test_constant_entry
+    index = @gen.build_index(@db)
+    e = find_entry(index, 'Foo::AAA')
+    assert_not_nil e
+    assert_equal 'AAA', e[:name]
+    assert_equal 'constant', e[:type]
+    assert_equal 'method/-foo/c/-a-a-a.html', e[:path]
+  end
+
+  def test_same_method_name_in_two_classes
+    index = @gen.build_index(@db)
+    assert_not_nil find_entry(index, 'Foo#foo')
+    assert_not_nil find_entry(index, 'Bar#foo')
+  end
+
+  def test_no_duplicate_paths
+    index = @gen.build_index(@db)
+    paths = index.map { |e| e[:path] }
+    assert_equal paths.uniq.size, paths.size, 'index must not contain duplicate paths'
+  end
+
+  def test_to_js_format
+    js = @gen.to_js(@db)
+    assert_match(/\Avar search_data = \{/, js)
+    assert(js.end_with?(';'), 'to_js output must end with a semicolon')
+
+    json = js.sub(/\Avar search_data = /, '').sub(/;\z/, '')
+    data = JSON.parse(json)
+    assert_kind_of Array, data['index']
+    assert(data['index'].any? { |e| e['full_name'] == 'Foo#foo' })
+  end
+
+  private
+
+  def setup_files
+    FileUtils.mkdir_p("#{@root}/_builtin")
+
+    File.open("#{@root}/LIBRARIES", 'w+') do |file|
+      file.puts '_builtin'
+    end
+
+    File.open("#{@root}/_builtin.rd", 'w+') do |file|
+      file.puts <<'HERE'
+description
+
+= class Foo < Object
+description
+== Instance Methods
+--- foo
+== Constants
+--- AAA
+= class Bar < Object
+== Instance Methods
+--- foo
+= module Kernel
+description
+== Module Functions
+--- at_exit{ ... } -> Proc
+aaa
+
+HERE
+    end
+  end
+end

--- a/test/test_search_index_generator.rb
+++ b/test/test_search_index_generator.rb
@@ -9,7 +9,8 @@ require 'bitclust/search_index_generator'
 class TestSearchIndexGenerator < Test::Unit::TestCase
   def setup
     @prefix = 'db_si'
-    @root = 'src_si'
+    @base = 'tree_si'
+    @root = "#{@base}/refm/api/src"
     setup_files
     @db = BitClust::MethodDatabase.new(@prefix)
     @db.init
@@ -25,7 +26,7 @@ class TestSearchIndexGenerator < Test::Unit::TestCase
   end
 
   def teardown
-    FileUtils.rm_r([@prefix, @root], :force => true)
+    FileUtils.rm_r([@prefix, @base], :force => true)
   end
 
   def find_entry(index, full_name)
@@ -88,6 +89,14 @@ class TestSearchIndexGenerator < Test::Unit::TestCase
     assert_equal paths.uniq.size, paths.size, 'index must not contain duplicate paths'
   end
 
+  def test_document_entry_uses_title_and_slug
+    index = @gen.build_index(@db)
+    e = index.find { |x| x[:type] == 'document' && x[:path] == 'doc/glossary.html' }
+    assert_not_nil e
+    assert_equal 'Ruby用語集 (glossary)', e[:full_name]
+    assert_equal 'Ruby用語集 (glossary)', e[:name]
+  end
+
   def test_to_js_format
     js = @gen.to_js(@db)
     assert_match(/\Avar search_data = \{/, js)
@@ -128,6 +137,15 @@ description
 aaa
 
 HERE
+    end
+
+    # Prose doc pages are loaded from <stdlibtree>/../../doc/**/*.rd
+    docdir = "#{@base}/refm/doc"
+    FileUtils.mkdir_p(docdir)
+    File.open("#{docdir}/glossary.rd", 'w+') do |file|
+      file.puts '= Ruby用語集'
+      file.puts
+      file.puts '用語の説明。'
     end
   end
 end

--- a/theme/default/js/NOTICE
+++ b/theme/default/js/NOTICE
@@ -1,0 +1,42 @@
+Third-party notices for theme/default/js/
+=========================================
+
+The following files are vendored verbatim from RDoc's Aliki theme
+(lib/rdoc/generator/template/aliki/js/), RDoc v7.2.0:
+
+  * search_navigation.js
+  * search_ranker.js
+  * search_controller.js
+
+Per RDoc's LEGAL.rdoc, the Aliki theme is written by Stan Lo and is included
+under the MIT License:
+
+  https://github.com/ruby/rdoc/blob/v7.2.0/LEGAL.rdoc
+
+----------------------------------------------------------------------
+MIT License
+
+Copyright (c) 2025 Stan Lo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+----------------------------------------------------------------------
+
+Note: search_init.js is original to BitClust and is not part of the vendored
+Aliki files. It is dual-licensed under the Ruby License or the MIT License so
+it can be used together with the MIT-licensed Aliki files above.

--- a/theme/default/js/search_controller.js
+++ b/theme/default/js/search_controller.js
@@ -1,0 +1,129 @@
+SearchController = function(data, input, result) {
+  this.data = data;
+  this.input = input;
+  this.result = result;
+
+  this.current = null;
+  this.view = this.result.parentNode;
+  this.ranker = new SearchRanker(data.index);
+  this.init();
+}
+
+SearchController.prototype = Object.assign({}, SearchNavigation, new function() {
+  var suid = 1;
+
+  this.init = function() {
+    var _this = this;
+    var observer = function(e) {
+      switch(e.key) {
+        case 'ArrowUp':
+        case 'ArrowDown':
+          return;
+      }
+      _this.search(_this.input.value);
+    };
+    this.input.addEventListener('keyup', observer);
+    this.input.addEventListener('click', observer); // mac's clear field
+
+    this.ranker.ready(function(results, isLast) {
+      _this.addResults(results, isLast);
+    })
+
+    this.initNavigation();
+    this.setNavigationActive(false);
+  }
+
+  this.search = function(value, selectFirstMatch) {
+    this.selectFirstMatch = selectFirstMatch;
+
+    value = value.trim();
+    if (value) {
+      this.setNavigationActive(true);
+    } else {
+      this.setNavigationActive(false);
+    }
+
+    if (value == '') {
+      this.lastQuery = value;
+      this.result.innerHTML = '';
+      this.result.setAttribute('aria-expanded', 'false');
+      this.setNavigationActive(false);
+    } else if (value != this.lastQuery) {
+      this.lastQuery = value;
+      this.result.setAttribute('aria-busy',     'true');
+      this.result.setAttribute('aria-expanded', 'true');
+      this.firstRun = true;
+      this.ranker.find(value);
+    }
+  }
+
+  this.addResults = function(results, isLast) {
+    var target = this.result;
+    if (this.firstRun && (results.length > 0 || isLast)) {
+      this.current = null;
+      this.result.innerHTML = '';
+    }
+
+    for (var i=0, l = results.length; i < l; i++) {
+      var item = this.renderItem.call(this, results[i]);
+      item.setAttribute('id', 'search-result-' + target.childElementCount);
+      target.appendChild(item);
+    };
+
+    if (this.firstRun && results.length > 0) {
+      this.firstRun = false;
+      this.current = target.firstChild;
+      this.current.classList.add('search-selected');
+    }
+    //TODO: ECMAScript
+    //if (jQuery.browser.msie) this.$element[0].className += '';
+
+    if (this.selectFirstMatch && this.current) {
+      this.selectFirstMatch = false;
+      this.select(this.current);
+    }
+
+    if (isLast) {
+      this.selectFirstMatch = false;
+      this.result.setAttribute('aria-busy', 'false');
+    }
+  }
+
+  this.move = function(isDown) {
+    if (!this.current) return;
+    var next = isDown ? this.current.nextElementSibling : this.current.previousElementSibling;
+    if (next) {
+      this.current.classList.remove('search-selected');
+      next.classList.add('search-selected');
+      this.input.setAttribute('aria-activedescendant', next.getAttribute('id'));
+      this.scrollInElement(next, this.result);
+      this.current = next;
+      this.input.value = next.firstChild.firstChild.text;
+      this.input.select();
+    }
+    return true;
+  }
+
+  this.hlt = function(html) {
+    return this.escapeHTML(html).
+      replace(/\u0001/g, '<em>').
+      replace(/\u0002/g, '</em>');
+  }
+
+  this.escapeHTML = function(html) {
+    return html.replace(/[&<>"`']/g, function(c) {
+      return '&#' + c.charCodeAt(0) + ';';
+    });
+  }
+
+  this.hide = function() {
+    this.result.setAttribute('aria-expanded', 'false');
+    this.setNavigationActive(false);
+  }
+
+  this.show = function() {
+    this.result.setAttribute('aria-expanded', 'true');
+    this.setNavigationActive(true);
+  }
+});
+

--- a/theme/default/js/search_controller.js
+++ b/theme/default/js/search_controller.js
@@ -1,3 +1,8 @@
+/*
+ * Vendored from RDoc's Aliki theme (lib/rdoc/generator/template/aliki/js/), RDoc v7.2.0.
+ * Copyright (c) 2025 Stan Lo. Released under the MIT License.
+ * See https://github.com/ruby/rdoc/blob/v7.2.0/LEGAL.rdoc
+ */
 SearchController = function(data, input, result) {
   this.data = data;
   this.input = input;

--- a/theme/default/js/search_init.js
+++ b/theme/default/js/search_init.js
@@ -1,0 +1,90 @@
+'use strict';
+/*
+ * Wires up the client-side search box for statichtml output.
+ *
+ * The sibling files search_navigation.js, search_ranker.js and
+ * search_controller.js are vendored verbatim from RDoc's Aliki theme.
+ * They expect two globals to be defined before this script runs:
+ *
+ *   search_data       - defined by js/search_data.js (the index)
+ *   index_rel_prefix  - relative path from the current page to the site root,
+ *                       set inline in the page <head> by the layout template.
+ */
+(function() {
+  function createSearchInstance(input, result) {
+    if (!input || !result) return null;
+
+    var search = new SearchController(search_data, input, result);
+
+    search.renderItem = function(r) {
+      var li = document.createElement('li');
+      var html = '<p class="search-match"><a href="' +
+        index_rel_prefix + this.escapeHTML(r.path) + '">' +
+        this.hlt(r.title) + '</a>';
+      if (r.type) {
+        var typeClass = r.type.replace(/_/g, '-');
+        html += '<span class="search-type search-type-' +
+          this.escapeHTML(typeClass) + '">' + this.formatType(r.type) + '</span>';
+      }
+      html += '</p>';
+      if (r.snippet) html += '<div class="search-snippet">' + r.snippet + '</div>';
+      li.innerHTML = html;
+      return li;
+    };
+
+    search.formatType = function(type) {
+      var labels = {
+        'class': 'class', 'module': 'module', 'object': 'object',
+        'constant': 'const', 'instance_method': 'method', 'class_method': 'method',
+        'variable': 'var', 'library': 'lib', 'document': 'doc', 'function': 'func'
+      };
+      return labels[type] || type;
+    };
+
+    search.select = function(selected) {
+      if (selected) window.location.href = selected.firstChild.firstChild.href;
+    };
+
+    return search;
+  }
+
+  function hookSearch() {
+    var input = document.querySelector('#search-field');
+    var result = document.querySelector('#search-results');
+    if (!input || !result) return;
+
+    var search = createSearchInstance(input, result);
+    if (!search) return;
+
+    document.addEventListener('click', function(e) {
+      if (!e.target.closest('#search-section')) search.hide();
+    });
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape' && input.matches(':focus')) { search.hide(); input.blur(); }
+    });
+    input.addEventListener('focus', function() {
+      if (input.value.trim()) search.show();
+    });
+
+    if (typeof URLSearchParams !== 'undefined') {
+      var q = new URLSearchParams(window.location.search).get('q');
+      if (q) { input.value = q; search.search(q, false); }
+    }
+  }
+
+  // Press "/" anywhere to focus the search box.
+  function hookFocus() {
+    document.addEventListener('keydown', function(e) {
+      if (document.activeElement && document.activeElement.tagName === 'INPUT') return;
+      if (e.key === '/') {
+        var f = document.querySelector('#search-field');
+        if (f) { e.preventDefault(); f.focus(); }
+      }
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    hookSearch();
+    hookFocus();
+  });
+})();

--- a/theme/default/js/search_init.js
+++ b/theme/default/js/search_init.js
@@ -1,5 +1,7 @@
 'use strict';
 /*
+ * Part of BitClust. Distributed under the Ruby License or the MIT License.
+ *
  * Wires up the client-side search box for statichtml output.
  *
  * The sibling files search_navigation.js, search_ranker.js and

--- a/theme/default/js/search_navigation.js
+++ b/theme/default/js/search_navigation.js
@@ -1,0 +1,105 @@
+/*
+ * SearchNavigation allows movement using the arrow keys through the search results.
+ *
+ * When using this library you will need to set scrollIntoView to the
+ * appropriate function for your layout.  Use scrollInWindow if the container
+ * is not scrollable and scrollInElement if the container is a separate
+ * scrolling region.
+ */
+SearchNavigation = new function() {
+  this.initNavigation = function() {
+    var _this = this;
+
+    document.addEventListener('keydown', function(e) {
+      _this.onkeydown(e);
+    });
+
+    this.navigationActive = true;
+  }
+
+  this.setNavigationActive = function(state) {
+    this.navigationActive = state;
+  }
+
+  this.onkeydown = function(e) {
+    if (!this.navigationActive) return;
+    switch(e.key) {
+      case 'ArrowLeft':
+        if (this.moveLeft()) e.preventDefault();
+        break;
+      case 'ArrowUp':
+        if (e.key == 'ArrowUp' || e.ctrlKey) {
+          if (this.moveUp()) e.preventDefault();
+        }
+        break;
+      case 'ArrowRight':
+        if (this.moveRight()) e.preventDefault();
+        break;
+      case 'ArrowDown':
+        if (e.key == 'ArrowDown' || e.ctrlKey) {
+          if (this.moveDown()) e.preventDefault();
+        }
+        break;
+      case 'Enter':
+        if (this.current) e.preventDefault();
+        this.select(this.current);
+        break;
+    }
+    if (e.ctrlKey && e.shiftKey) this.select(this.current);
+  }
+
+  this.moveRight = function() {
+  }
+
+  this.moveLeft = function() {
+  }
+
+  this.move = function(isDown) {
+  }
+
+  this.moveUp = function() {
+    return this.move(false);
+  }
+
+  this.moveDown = function() {
+    return this.move(true);
+  }
+
+  /*
+   * Scrolls to the given element in the scrollable element view.
+   */
+  this.scrollInElement = function(element, view) {
+    var offset, viewHeight, viewScroll, height;
+    offset = element.offsetTop;
+    height = element.offsetHeight;
+    viewHeight = view.offsetHeight;
+    viewScroll = view.scrollTop;
+
+    if (offset - viewScroll + height > viewHeight) {
+      view.scrollTop = offset - viewHeight + height;
+    }
+    if (offset < viewScroll) {
+      view.scrollTop = offset;
+    }
+  }
+
+  /*
+   * Scrolls to the given element in the window.  The second argument is
+   * ignored
+   */
+  this.scrollInWindow = function(element, ignored) {
+    var offset, viewHeight, viewScroll, height;
+    offset = element.offsetTop;
+    height = element.offsetHeight;
+    viewHeight = window.innerHeight;
+    viewScroll = window.scrollY;
+
+    if (offset - viewScroll + height > viewHeight) {
+      window.scrollTo(window.scrollX, offset - viewHeight + height);
+    }
+    if (offset < viewScroll) {
+      window.scrollTo(window.scrollX, offset);
+    }
+  }
+}
+

--- a/theme/default/js/search_navigation.js
+++ b/theme/default/js/search_navigation.js
@@ -1,4 +1,9 @@
 /*
+ * Vendored from RDoc's Aliki theme (lib/rdoc/generator/template/aliki/js/), RDoc v7.2.0.
+ * Copyright (c) 2025 Stan Lo. Released under the MIT License.
+ * See https://github.com/ruby/rdoc/blob/v7.2.0/LEGAL.rdoc
+ */
+/*
  * SearchNavigation allows movement using the arrow keys through the search results.
  *
  * When using this library you will need to set scrollIntoView to the

--- a/theme/default/js/search_ranker.js
+++ b/theme/default/js/search_ranker.js
@@ -1,0 +1,239 @@
+/**
+ * Aliki Search Implementation
+ *
+ * Search algorithm with the following priorities:
+ * 1. Exact full_name match always wins (for namespace/method queries)
+ * 2. Exact name match gets high priority
+ * 3. Match types:
+ *    - Namespace queries (::) and method queries (# or .) match against full_name
+ *    - Regular queries match against unqualified name
+ *    - Prefix (10000) > substring (5000) > fuzzy (1000)
+ * 4. First character determines type priority:
+ *    - Starts with lowercase: methods first
+ *    - Starts with uppercase: classes/modules/constants first
+ * 5. Within same type priority:
+ *    - Unqualified match > qualified match
+ *    - Shorter name > longer name
+ * 6. Class methods > instance methods
+ * 7. Result limit: 30
+ * 8. Minimum query length: 1 character
+ */
+
+var MAX_RESULTS = 30;
+var MIN_QUERY_LENGTH = 1;
+
+/*
+ * Scoring constants - organized in tiers where each tier dominates lower tiers.
+ * This ensures match type always beats type priority, etc.
+ *
+ * Tier 0: Exact matches (immediate return)
+ * Tier 1: Match type (prefix > substring > fuzzy)
+ * Tier 2: Exact name bonus
+ * Tier 3: Type priority (method vs class based on query case)
+ * Tier 4: Minor bonuses (top-level, class method, name length)
+ */
+var SCORE_EXACT_FULL_NAME = 1000000;  // Tier 0: Query exactly matches full_name
+var SCORE_MATCH_PREFIX    = 10000;    // Tier 1: Query is prefix of name
+var SCORE_MATCH_SUBSTRING = 5000;     // Tier 1: Query is substring of name
+var SCORE_MATCH_FUZZY     = 1000;     // Tier 1: Query chars appear in order
+var SCORE_EXACT_NAME      = 500;      // Tier 2: Name exactly equals query
+var SCORE_TYPE_PRIORITY   = 100;      // Tier 3: Preferred type (method/class)
+var SCORE_TOP_LEVEL       = 50;       // Tier 4: Top-level over namespaced
+var SCORE_CLASS_METHOD    = 10;       // Tier 4: Class method over instance method
+
+/**
+ * Check if all characters in query appear in order in target
+ * e.g., "addalias" fuzzy matches "add_foo_alias"
+ */
+function fuzzyMatch(target, query) {
+  var ti = 0;
+  for (var qi = 0; qi < query.length; qi++) {
+    ti = target.indexOf(query[qi], ti);
+    if (ti === -1) return false;
+    ti++;
+  }
+  return true;
+}
+
+/**
+ * Parse and normalize a search query
+ * @param {string} query - The raw search query
+ * @returns {Object} Parsed query with normalized form and flags
+ */
+function parseQuery(query) {
+  // Lowercase for case-insensitive matching (so "hash" finds both Hash class and #hash methods)
+  var normalized = query.toLowerCase();
+  var isNamespaceQuery = query.includes('::');
+  var isMethodQuery = query.includes('#') || query.includes('.');
+
+  // Normalize . to :: (RDoc uses :: for class methods in full_name)
+  if (query.includes('.')) {
+    normalized = normalized.replace(/\./g, '::');
+  }
+
+  return {
+    original: query,
+    normalized: normalized,
+    isNamespaceQuery: isNamespaceQuery,
+    isMethodQuery: isMethodQuery,
+    // Namespace and method queries match against full_name instead of name
+    matchesFullName: isNamespaceQuery || isMethodQuery,
+    // If query starts with lowercase, prioritize methods; otherwise prioritize classes/modules/constants
+    prioritizeMethod: !/^[A-Z]/.test(query)
+  };
+}
+
+/**
+ * Main search function
+ * @param {string} query - The search query
+ * @param {Array} index - The search index to search in
+ * @returns {Array} Array of matching entries, sorted by relevance
+ */
+function search(query, index) {
+  if (!query || query.length < MIN_QUERY_LENGTH) {
+    return [];
+  }
+
+  var q = parseQuery(query);
+  var results = [];
+
+  for (var i = 0; i < index.length; i++) {
+    var entry = index[i];
+    var score = computeScore(entry, q);
+
+    if (score !== null) {
+      results.push({ entry: entry, score: score });
+    }
+  }
+
+  results.sort(function(a, b) {
+    return b.score - a.score;
+  });
+
+  return results.slice(0, MAX_RESULTS).map(function(r) {
+    return r.entry;
+  });
+}
+
+/**
+ * Compute the relevance score for an entry
+ * @param {Object} entry - The search index entry
+ * @param {Object} q - Parsed query from parseQuery()
+ * @returns {number|null} Score or null if no match
+ */
+function computeScore(entry, q) {
+  var name = entry.name;
+  var fullName = entry.full_name;
+  var type = entry.type;
+
+  var nameLower = name.toLowerCase();
+  var fullNameLower = fullName.toLowerCase();
+
+  // Exact full_name match (e.g., "Array#filter" matches Array#filter)
+  if (q.matchesFullName && fullNameLower === q.normalized) {
+    return SCORE_EXACT_FULL_NAME;
+  }
+
+  var matchScore = 0;
+  var target = q.matchesFullName ? fullNameLower : nameLower;
+
+  if (target.startsWith(q.normalized)) {
+    matchScore = SCORE_MATCH_PREFIX;     // Prefix (e.g., "Arr" matches "Array")
+  } else if (target.includes(q.normalized)) {
+    matchScore = SCORE_MATCH_SUBSTRING;  // Substring (e.g., "ray" matches "Array")
+  } else if (fuzzyMatch(target, q.normalized)) {
+    matchScore = SCORE_MATCH_FUZZY;      // Fuzzy (e.g., "addalias" matches "add_foo_alias")
+  } else {
+    return null;
+  }
+
+  var score = matchScore;
+  var isMethod = (type === 'instance_method' || type === 'class_method');
+
+  if (q.prioritizeMethod ? isMethod : !isMethod) {
+    score += SCORE_TYPE_PRIORITY;
+  }
+
+  if (type === 'class_method') score += SCORE_CLASS_METHOD;
+  if (name === fullName) score += SCORE_TOP_LEVEL;  // Top-level (Hash) > namespaced (Foo::Hash)
+  if (nameLower === q.normalized) score += SCORE_EXACT_NAME;  // Exact name match
+  score -= name.length;
+
+  return score;
+}
+
+/**
+ * SearchRanker class for compatibility with the Search UI
+ * Provides ready() and find() interface
+ */
+function SearchRanker(index) {
+  this.index = index;
+  this.handlers = [];
+}
+
+SearchRanker.prototype.ready = function(fn) {
+  this.handlers.push(fn);
+};
+
+SearchRanker.prototype.find = function(query) {
+  var q = parseQuery(query);
+  var rawResults = search(query, this.index);
+  var results = rawResults.map(function(entry) {
+    return formatResult(entry, q);
+  });
+
+  var _this = this;
+  this.handlers.forEach(function(fn) {
+    fn.call(_this, results, true);
+  });
+};
+
+/**
+ * Format a search result entry for display
+ */
+function formatResult(entry, q) {
+  var result = {
+    title: highlightMatch(entry.full_name, q),
+    path: entry.path,
+    type: entry.type
+  };
+
+  if (entry.snippet) {
+    result.snippet = entry.snippet;
+  }
+
+  return result;
+}
+
+/**
+ * Add highlight markers (\u0001 and \u0002) to matching portions of text
+ * @param {string} text - The text to highlight
+ * @param {Object} q - Parsed query from parseQuery()
+ */
+function highlightMatch(text, q) {
+  if (!text || !q) return text;
+
+  var textLower = text.toLowerCase();
+  var query = q.normalized;
+
+  // Try contiguous match first (prefix or substring)
+  var matchIndex = textLower.indexOf(query);
+  if (matchIndex !== -1) {
+    return text.substring(0, matchIndex) +
+      '\u0001' + text.substring(matchIndex, matchIndex + query.length) + '\u0002' +
+      text.substring(matchIndex + query.length);
+  }
+
+  // Fall back to fuzzy highlight (highlight each matched character)
+  var result = '';
+  var ti = 0;
+  for (var qi = 0; qi < query.length; qi++) {
+    var charIndex = textLower.indexOf(query[qi], ti);
+    if (charIndex === -1) return text;
+    result += text.substring(ti, charIndex);
+    result += '\u0001' + text[charIndex] + '\u0002';
+    ti = charIndex + 1;
+  }
+  result += text.substring(ti);
+  return result;
+}

--- a/theme/default/js/search_ranker.js
+++ b/theme/default/js/search_ranker.js
@@ -1,3 +1,8 @@
+/*
+ * Vendored from RDoc's Aliki theme (lib/rdoc/generator/template/aliki/js/), RDoc v7.2.0.
+ * Copyright (c) 2025 Stan Lo. Released under the MIT License.
+ * See https://github.com/ruby/rdoc/blob/v7.2.0/LEGAL.rdoc
+ */
 /**
  * Aliki Search Implementation
  *

--- a/theme/default/search.css
+++ b/theme/default/search.css
@@ -1,34 +1,69 @@
-/* Client-side search box (statichtml output). */
+/* Client-side search box (statichtml output).
+   Styled to match rurema's theme (accent color #33a). */
+
+/* Full-width sticky top bar: manual-home link on the left, search on the right.
+   Negative margins break out of the body's 20px top / 2% side margins so the
+   bar spans the viewport; the matching padding keeps its content aligned with
+   the page body. */
+#rurema-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1em;
+  margin: -20px -2% 1em;
+  padding: 6px 2%;
+  background: #f7f7fb;
+  border-bottom: 2px solid #33a;
+}
+
+#rurema-brand {
+  font-size: 0.95em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
 #search-section {
   position: relative;
-  margin: 0.5em 0 1em;
-  max-width: 42em;
+  flex: 0 0 auto;
+  width: 26em;
+  max-width: 50%;
 }
 
 #search-field {
   width: 100%;
   box-sizing: border-box;
-  padding: 0.45em 0.7em;
-  font-size: 1em;
-  border: 1px solid #bbb;
+  padding: 0.35em 0.6em;
+  font-size: 0.95em;
+  border: 1px solid #99a;
   border-radius: 4px;
+  background: #fff;
+}
+
+#search-field:focus {
+  outline: none;
+  border-color: #33a;
+  box-shadow: 0 0 0 2px rgba(51, 51, 170, 0.25);
 }
 
 .search-results {
   list-style: none;
-  margin: 0.2em 0 0;
+  margin: 0.25em 0 0;
   padding: 0;
   position: absolute;
+  top: 100%;
   left: 0;
   right: 0;
   background: #fff;
-  border: 1px solid #ccc;
+  border: 1px solid #33a;
   border-radius: 4px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-  max-height: 70vh;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+  max-height: 75vh;
   overflow-y: auto;
-  z-index: 1000;
+  z-index: 1001;
 }
 
 .search-results[aria-expanded="false"] {
@@ -36,9 +71,10 @@
 }
 
 .search-results li {
-  padding: 0.35em 0.7em;
+  padding: 0.35em 0.6em;
   border-bottom: 1px solid #eee;
   cursor: pointer;
+  line-height: 1.25;
 }
 
 .search-results li:last-child {
@@ -46,31 +82,44 @@
 }
 
 .search-results li.search-selected {
-  background: #e8f0fe;
+  background: #e8eaf6; /* light tint of #33a */
 }
 
 .search-results .search-match {
   margin: 0;
-}
-
-.search-results .search-match a {
-  text-decoration: none;
+  font-weight: normal;
 }
 
 .search-results em {
   font-style: normal;
-  font-weight: bold;
-  background: #fff2a8;
+  background: #ff9;
+  border-radius: 2px;
 }
 
 .search-type {
-  color: #888;
-  font-size: 0.8em;
+  display: inline-block;
   margin-left: 0.5em;
+  padding: 0 0.4em;
+  font-size: 0.75em;
+  color: #fff;
+  background: #33a;
+  border-radius: 3px;
+  vertical-align: middle;
 }
 
 .search-snippet {
   color: #555;
   font-size: 0.85em;
-  margin-top: 0.2em;
+  margin-top: 0.15em;
+}
+
+@media only screen and (max-width: 768px) {
+  #rurema-topbar {
+    flex-wrap: wrap;
+    gap: 0.4em;
+  }
+  #search-section {
+    width: 100%;
+    max-width: none;
+  }
 }

--- a/theme/default/search.css
+++ b/theme/default/search.css
@@ -1,0 +1,76 @@
+/* Client-side search box (statichtml output). */
+
+#search-section {
+  position: relative;
+  margin: 0.5em 0 1em;
+  max-width: 42em;
+}
+
+#search-field {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.45em 0.7em;
+  font-size: 1em;
+  border: 1px solid #bbb;
+  border-radius: 4px;
+}
+
+.search-results {
+  list-style: none;
+  margin: 0.2em 0 0;
+  padding: 0;
+  position: absolute;
+  left: 0;
+  right: 0;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  max-height: 70vh;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+.search-results[aria-expanded="false"] {
+  display: none;
+}
+
+.search-results li {
+  padding: 0.35em 0.7em;
+  border-bottom: 1px solid #eee;
+  cursor: pointer;
+}
+
+.search-results li:last-child {
+  border-bottom: none;
+}
+
+.search-results li.search-selected {
+  background: #e8f0fe;
+}
+
+.search-results .search-match {
+  margin: 0;
+}
+
+.search-results .search-match a {
+  text-decoration: none;
+}
+
+.search-results em {
+  font-style: normal;
+  font-weight: bold;
+  background: #fff2a8;
+}
+
+.search-type {
+  color: #888;
+  font-size: 0.8em;
+  margin-left: 0.5em;
+}
+
+.search-snippet {
+  color: #555;
+  font-size: 0.85em;
+  margin-top: 0.2em;
+}


### PR DESCRIPTION
## 概要

サーバ常駐の `rurema-search`（全文検索）が高負荷でアクセス制限が厳しくなり実質使いづらく
なっているため、その代替に向けた一歩として、`statichtml` の生成物に **サーバ不要のクライ
アントサイド静的検索** を追加します。検索UIは RDoc 7 の Aliki テーマのものを流用しています。
マルチバージョン機構（bitclust 本体）には手を入れていません。

## 変更内容

- **検索インデックス生成** (`SearchIndexGenerator`): Aliki 互換の `js/search_data.js`
  (`var search_data = {index:[...]}`) を出力。class / module / method / constant /
  特殊変数 / library / document / C API function を索引。各エントリの `path` と
  encodename は statichtml の出力レイアウトに厳密一致させ、結果リンクが実ファイルと一致。
- **statichtml 連携**: 生成時に `js/search_data.js` を出力し、検索用 JS・CSS・NOTICE を
  出力ディレクトリへコピー。
- **クライアントUI**: Aliki の検索JS（navigation / ranker / controller）を vendor し、
  bitclust 独自の `search_init.js` と `search.css` を追加。検索ボックスは rurema の
  アクセント色 `#33a` に合わせた **全幅スティッキー上部バー**（左=マニュアルトップへの
  リンク、右=検索）。各ページに `index_rel_prefix` を埋め込み、どの階層からでも結果リンク
  が解決。既存のパンくず／タイトルには影響なし。
- **ライセンス**: vendor した3ファイルは RDoc の LEGAL.rdoc により MIT
  (Copyright (c) 2025 Stan Lo)。各ファイルに帰属ヘッダ、`theme/default/js/NOTICE` に
  MIT 全文を同梱し、生成物にもコピー。`search_init.js` は BitClust 自作で Ruby License /
  MIT のデュアル。

## 設計上の判断

- **サーバ不要**（rurema-search サーバなしで動作）＝負荷問題を回避。
- 検索対象は **名前／シグネチャベース**（Aliki ランカーに準拠、本文全文検索ではない）。
  本文の全文検索は引き続き外部検索エンジンの担当を想定。
- 表示専用の **snippet は省略**。実測で「snippetなし ≈ 177KB(gzip)」に対し付与すると
  ≈ 420KB(gzip) と倍増し、かつ検索対象外のため省略が最適と判断。
- `search_data.js` は core+stdlib 全体で **約13,500エントリ / 約177KB(gzip)・約1.69MB(raw)**、
  バージョン非依存。バージョンごとに1ファイルで、全ページでキャッシュ共有。

## テスト

- 追加: `test/test_search_index_generator.rb`（8ケース）。
- 既存全テスト **17,185 件 green**。
- フルの 3.4 静的サイト（13,509ページ）を生成し、実ページで検索ボックス・アセット・
  結果リンク解決を確認。

## このPRに含まれないもの / 今後

- `rurema-search` の撤去は含みません（本PRは静的検索の追加。切替・撤去は別途）。
- 本文全文検索（外部エンジン連携）は別途。
- doctree 側 `rake statichtml` / `check_format` の通し確認。
- 複数バージョン横断検索（必要になれば version タグ付き統合index＋ランカー調整）。
