### PR TITLE
source_location の行番号を削除して生成ドキュメントの差分肥大化を防ぐ

### DIFF
--- a/lib/bitclust/entry.rb
+++ b/lib/bitclust/entry.rb
@@ -117,7 +117,7 @@ module BitClust
         when '[LibraryEntry]' then "restore_libraries(h['#{@name}'])"
         when '[ClassEntry]'   then "restore_classes(h['#{@name}'])"
         when '[MethodEntry]'  then "restore_methods(h['#{@name}'])"
-        when 'Location'       then "h['#{@name}']&.tap { |loc| break if loc.empty?; break Location.new(*loc.split(?:)) }"
+        when 'Location'       then "h['#{@name}']&.tap { |loc| break if loc.empty?; break Location.new(loc.split(?:).first, nil) }"
         else
           raise "must not happen: @type=#{@type.inspect}"
         end
@@ -135,7 +135,7 @@ module BitClust
         when '[LibraryEntry]' then "serialize_entries(@#{@name})"
         when '[ClassEntry]'   then "serialize_entries(@#{@name})"
         when '[MethodEntry]'  then "serialize_entries(@#{@name})"
-        when 'Location'       then "@#@name.to_s"
+        when 'Location'       then "(@#{@name} && @#{@name}.file).to_s"
         else
           raise "must not happen: @type=#{@type.inspect}"
         end

--- a/lib/bitclust/functionreferenceparser.rb
+++ b/lib/bitclust/functionreferenceparser.rb
@@ -61,7 +61,7 @@ module BitClust
         f.name = h.name
         f.params = h.params
         f.source = body.join('')
-        f.source_location = body[0]&.location&.tap {|loc| break Location.new(@path, loc.line - 1) }
+        f.source_location = body[0]&.location && Location.new(@path, nil)
       }
     end
 

--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -90,7 +90,7 @@ module BitClust
         end
 
         def edit_url(location)
-          "#{@edit_base_url}/#{location.file}#L#{location.line}".sub(/([^:])\/\/+/, "\\1/")
+          "#{@edit_base_url}/#{location.file}".sub(/([^:])\/\/+/, "\\1/")
         end
 
         def encodename_package(str)

--- a/test/test_functionreferenceparser.rb
+++ b/test/test_functionreferenceparser.rb
@@ -48,4 +48,15 @@ HERE
       assert_equal data[:expected], result.collect(&:source)
     }
   end
+
+  # source_location points at the file only; the line number is no longer
+  # recorded (it would only churn the generated diffs).
+  def test_source_location_has_no_line_number
+    @db.transaction {
+      result = @parser.parse_file(@path, "test.c", {"version" => "2.6.0"})
+      location = result.first.source_location
+      assert_equal @path, location.file
+      assert_nil location.line
+    }
+  end
 end

--- a/test/test_methoddatabase.rb
+++ b/test/test_methoddatabase.rb
@@ -57,6 +57,22 @@ class TestMethodDatabase < Test::Unit::TestCase
                  @db.get_class("B").dynamically_included.map{|m| m.name})
   end
 
+  # source_location must be stored without a line number so that regenerating
+  # the database does not churn the persisted entries (and the generated HTML).
+  def test_source_location_serialized_without_line_number
+    entry = @db.search_methods(BitClust::MethodNamePattern.new(nil, nil, 'at_exit')).records.first.entry
+    entry.source_location = BitClust::Location.new('refm/api/src/_builtin/Kernel', 42)
+    assert_equal('refm/api/src/_builtin/Kernel', entry._get_properties['source_location'])
+  end
+
+  def test_source_location_roundtrip_drops_line_number
+    entry = @db.search_methods(BitClust::MethodNamePattern.new(nil, nil, 'at_exit')).records.first.entry
+    entry.source_location = BitClust::Location.new('refm/api/src/_builtin/Kernel', 42)
+    entry._set_properties(entry._get_properties)
+    assert_equal('refm/api/src/_builtin/Kernel', entry.source_location.file)
+    assert_nil(entry.source_location.line)
+  end
+
   private
   def setup_files
     FileUtils.mkdir_p("#{@root}/_builtin")

--- a/test/test_statichtml_command.rb
+++ b/test/test_statichtml_command.rb
@@ -1,0 +1,28 @@
+require 'test/unit'
+require 'bitclust'
+require 'bitclust/subcommands/statichtml_command'
+
+class TestStatichtmlURLMapperEx < Test::Unit::TestCase
+  def setup
+    @urlmapper = BitClust::Subcommands::StatichtmlCommand::URLMapperEx.new(
+      :suffix => 'html',
+      :edit_base_url => 'https://github.com/rurema/doctree/edit/master',
+    )
+  end
+
+  # The edit URL must not contain a line number, so that shifting source lines
+  # does not churn the generated HTML diff.
+  def test_edit_url_has_no_line_number
+    location = BitClust::Location.new('refm/api/src/_builtin/Array', 42)
+    assert_equal('https://github.com/rurema/doctree/edit/master/refm/api/src/_builtin/Array',
+                 @urlmapper.edit_url(location))
+  end
+
+  # A location restored from the database has no line number (nil); the edit URL
+  # must still be a clean file link without a trailing "#L".
+  def test_edit_url_without_line_in_location
+    location = BitClust::Location.new('refm/api/src/_builtin/Array', nil)
+    assert_equal('https://github.com/rurema/doctree/edit/master/refm/api/src/_builtin/Array',
+                 @urlmapper.edit_url(location))
+  end
+end


### PR DESCRIPTION
## 背景・動機

各エントリの `source_location` には `file:line` 形式でソースの行番号が保存され、
生成HTMLの edit リンクにも `#L<line>` として出力されています。

この行番号はソースファイルを編集するたびにズレるため、ドキュメントの内容自体が
変わっていなくても、[生成されるデータベースや HTML](https://github.com/rurema/generated-documents) の差分が
大きく肥大化する原因になっていました。一方で行番号を使っている edit リンクは
あまり活用されていません。

行番号を使っているのは edit リンクだけなので、これを削除して差分を安定化させます。
（将来的には edit リンク自体の削除も検討しています）

## 変更内容

- **`entry.rb`**: `source_location` をファイルパスのみで直列化・復元するように変更
  （行番号は保存しない）。既存DBの `file:line` 形式も後方互換で読めます。
- **`statichtml_command.rb`**: edit URL から `#L<line>` アンカーを削除。
  edit リンクはファイルそのものを指す有効なリンクとして残ります。
- **`functionreferenceparser.rb`**: 不要になった行番号計算（`loc.line - 1`）を削除。
  「body が無ければ nil を代入」という従来の挙動は維持。

## 影響

- **DB**: `source_location=file:line` → `source_location=file`。
  初回の再生成時のみ全エントリで `:line` が消える一度きりの大きな差分が出ますが、
  以降は行ズレによる churn がなくなります。
- **生成HTML**: edit リンクが `…/<file>#L<line>` → `…/<file>` になり、
  行ズレで差分が膨らまなくなります。
- **edit リンク**: ファイルの先頭を指す形で引き続き機能します。
- エラー・警告メッセージの行番号表示には影響ありません
  （そちらはパース中の `line.location` を使っており、`source_location` とは別物）。

## テスト

t_wada流TDD（Red→Green）で以下を追加・確認:

- `test/test_statichtml_command.rb`（新規）— edit URL に行番号が付かないこと（line あり/nil 両方）
- `test/test_methoddatabase.rb` — `source_location` が行番号なしで直列化・往復すること
- `test/test_functionreferenceparser.rb` — 関数の `source_location` が行番号を持たないこと

全 17027 テストがパスしています。
