### PR TITLE
クラス・メソッド検索の候補表示をホバー時に見やすくする (#193)

### DIFF
--- a/theme/default/search.css
+++ b/theme/default/search.css
@@ -96,6 +96,20 @@
   border-radius: 2px;
 }
 
+/* On hover the global `a:hover` rule paints the whole anchor with the #33a
+   accent and white text. Round the anchor (and pad it slightly) so its
+   background follows the rounded highlight instead of poking square corners
+   out behind it, and recolor the highlighted match so the yellow background
+   stays legible against the white-on-blue hover text. */
+.search-results .search-match > a {
+  padding: 1px;
+  border-radius: 3px;
+}
+
+.search-results .search-match > a:hover > em {
+  color: #33a;
+}
+
 .search-type {
   display: inline-block;
   margin-left: 0.5em;


### PR DESCRIPTION
## 概要

クラス・メソッド検索の候補一覧で、項目をホバーしたときの表示を改善します。
Issue #193 で報告された 2 点を修正します。

## 背景・問題

候補をホバーすると、グローバルな `a:hover`（`color: #fff; background-color: #33a;`）
によって候補のリンク全体が青く反転します。このとき次の不具合がありました。

1. ハイライトされたマッチ部分（`<em>`）は黄色背景のままで文字が白くなるため、
   白字 on 黄色で読みづらい。
2. `<em>` は角丸なのにリンクの背景は角丸でないため、左上・左下にリンクの
   四角い角（青）がはみ出して見栄えがよくない。

## 修正内容

`theme/default/search.css` に以下を追加しました。

```css
.search-results .search-match > a {
  padding: 1px;
  border-radius: 3px;
}

.search-results .search-match > a:hover > em {
  color: #33a;
}
```

- リンクを角丸＋わずかにパディングし、ホバー時の青背景がハイライトの角丸に沿うようにする
- ホバー時にマッチ部分の文字色を `#33a` にし、黄色背景でも読めるようにする

Issue で提案されたスタイルを、ファイル内の既存ルール（`.search-results .search-match`、
`.search-results em`）の書き方に合わせて `.search-results` スコープに揃えています。

## 確認

- 候補の DOM 構造（`search_init.js` が生成する `<p class="search-match"><a><em>…</em></a>`）に
  セレクタが一致することを確認。
- before / after は Issue #193 のスクリーンショットのとおり。

Closes #193
