### PR TITLE
特殊変数を「$;」形式のクエリで検索できるようにする (#194)

### DIFF
--- a/lib/bitclust/search_index_generator.rb
+++ b/lib/bitclust/search_index_generator.rb
@@ -89,8 +89,16 @@ module BitClust
           next if seen[path]
 
           seen[path] = true
-          full_name = (tmark == '$' ? '' : cname) + tmark + mname
-          result << { name: mname, full_name: full_name, type: type, path: path }
+          if tmark == '$'
+            # A special variable has no owning class to qualify it; its "$"
+            # sigil is the only thing distinguishing it, so keep it in +name+
+            # too (not just +full_name+) or a "$;"-style query can't match it.
+            name = full_name = tmark + mname
+          else
+            name = mname
+            full_name = cname + tmark + mname
+          end
+          result << { name: name, full_name: full_name, type: type, path: path }
         end
       end
       result

--- a/test/test_search_index_generator.rb
+++ b/test/test_search_index_generator.rb
@@ -77,6 +77,36 @@ class TestSearchIndexGenerator < Test::Unit::TestCase
     assert_equal 'method/-foo/c/-a-a-a.html', e[:path]
   end
 
+  def test_special_variable_keeps_its_sigil_in_name
+    # A special variable's "$" is part of how it is written and is the only
+    # thing distinguishing it (there is no owning class to qualify it), so it
+    # must stay in +name+ for a "$;"-style query to match. See issue #194.
+    #
+    # The +name+/+type+ assertions below are what issue #194 is about. The
+    # +path+ assertion is secondary and filesystem-dependent: @gen defaults to
+    # fs_casesensitive: false, so the path is built by encodename_fs ("Kernel"
+    # -> "-kernel", ";" -> "=3b"). It is fine to ignore ONLY the path failure if
+    # it broke because the fs encoding scheme changed or a case-sensitive build
+    # (fs_casesensitive: true, giving "method/Kernel/v/...") is in use -- as long
+    # as name/type still hold. A name/type failure is a real regression.
+    index = @gen.build_index(@db)
+    e = find_entry(index, '$;')
+    assert_not_nil e
+    assert_equal '$;', e[:name]
+    assert_equal 'variable', e[:type]
+    assert_equal 'method/-kernel/v/=3b.html', e[:path],
+                 'filesystem-encoded path (fs_casesensitive: false); ' \
+                 'ignore only this failure if just the fs encoding/casing changed'
+  end
+
+  def test_special_variable_word_name_keeps_its_sigil
+    index = @gen.build_index(@db)
+    e = find_entry(index, '$stdout')
+    assert_not_nil e
+    assert_equal '$stdout', e[:name]
+    assert_equal 'variable', e[:type]
+  end
+
   def test_same_method_name_in_two_classes
     index = @gen.build_index(@db)
     assert_not_nil find_entry(index, 'Foo#foo')
@@ -135,6 +165,11 @@ description
 == Module Functions
 --- at_exit{ ... } -> Proc
 aaa
+== Special Variables
+--- $; -> String | nil
+区切り文字。
+--- $stdout -> IO
+標準出力。
 
 HERE
     end

--- a/theme/default/js/search_init.js
+++ b/theme/default/js/search_init.js
@@ -13,6 +13,27 @@
  *                       set inline in the page <head> by the layout template.
  */
 (function() {
+  // BitClust extension (the vendored Aliki files above are kept verbatim).
+  //
+  // RDoc's parseQuery() rewrites "." to "::" (its class-method separator) and
+  // matches "::"/"."/"#" queries against full_name instead of name. Ruby's
+  // special variables are indexed with their "$" sigil in full_name, and one of
+  // them ($.) contains a literal "." — so a "$." query would become "$::" and
+  // never match. Wrap parseQuery so that any "$"-prefixed (special variable)
+  // query keeps its literal text and is matched against full_name.
+  // See https://github.com/rurema/bitclust/issues/194
+  if (typeof parseQuery === 'function') {
+    var alikiParseQuery = parseQuery;
+    parseQuery = function(query) {
+      var q = alikiParseQuery(query);
+      if (query.charAt(0) === '$') {
+        q.normalized = query.toLowerCase();  // undo the "." -> "::" rewrite
+        q.matchesFullName = true;            // the "$" sigil lives in full_name
+      }
+      return q;
+    };
+  }
+
   function createSearchInstance(input, result) {
     if (!input || !result) return null;
 


### PR DESCRIPTION
## 概要

クラス・メソッド検索窓で特殊変数を検索できるようにします。
Issue #194 で報告された 2 点を修正します。

- 「$;」と入力しても候補に何も表示されない
- 「$.」は「.」だけ入力しても出てこない

## 背景・問題

クライアントサイド検索インデックス（`search_data.js`）では、特殊変数が

```json
{"name":";","full_name":"$;","type":"variable","path":"method/Kernel/v/=3b.html"}
```

のように、`name` から `$` 記号が削られた形（`;`）で格納されていました。
ベンダリングされた Aliki の検索処理は通常のクエリを `name` に対して照合する
ため、「$;」と入力しても一致しませんでした（「;」だけなら一致する）。

また「$.」は、検索処理がクエリ中の `.` を `::`（クラスメソッドの区切り）に
変換してから照合するため、「$.」でも「.」でも決して一致しませんでした。

## 修正内容

### 1. データ側 — `lib/bitclust/search_index_generator.rb`

特殊変数は所属クラスによる修飾を持たず、`$` 記号そのものが名前の一部です。
そこで `full_name` だけでなく `name` にも記号を残すようにしました。

```json
{"name":"$;","full_name":"$;","type":"variable", ...}
```

これにより、`$;` や `$stdout` などが**ベンダリングされた検索処理を変更せずに**
検索可能になります。おまけとして、「$」だけ入力すると全特殊変数が一覧表示
されるようにもなります。

### 2. クエリ解析側 — `theme/default/js/search_init.js`

「$.」は `.`→`::` 変換がクエリ側で起きるため、データ側では直せません。
Aliki のベンダーファイルは無改変（verbatim）に保つ方針なので、BitClust 独自
ファイルである `search_init.js` から `parseQuery` をラップし、「$」始まりの
クエリは文字列をそのまま保持して `full_name` に照合するようにしました。
これで「$.」を含むすべての特殊変数が検索できます。

## 確認

- `name`/`type` を確認するテストを `test/test_search_index_generator.rb` に追加
  （`$;`、`$stdout`）。bitclust 全テストはパス（17038 件、失敗 0）。
- `steep check`：変更行に新規の指摘なし。
- この環境には JS ランタイムが無いため、検索アルゴリズム（`parseQuery` +
  上書き + `computeScore`）を Ruby に忠実に移植して検証し、`$;` / `;` / `$.` /
  `$` / `$stdout` / `stdout` および回帰（クラス検索・誤ヒット防止）が
  すべて正しく解決することを確認しました。

## 備考

- 追加した path のアサーションは `fs_casesensitive: false`（デフォルト）の
  ファイルシステムエンコードに依存します。いつ失敗を無視してよいかを
  テスト内のコメントと失敗時メッセージに明記しています。
- `search_init.js` の変更はこのプロジェクトの Ruby テストでは実行できません。
  検索 JS の回帰テストが必要であれば、別途 Node ベースのテストを追加できます。

Closes #194
