### PR TITLE
全バージョン対応の静的検索ページを生成する searchpage サブコマンドを追加

### DIFF
--- a/data/bitclust/searchpage/index.html
+++ b/data/bitclust/searchpage/index.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ruby リファレンスマニュアル検索</title>
+<link rel="stylesheet" href="search.css">
+<style>
+/* 検索ボックス用の search.css を全画面ページ向けに上書きする */
+body {
+  margin: 0;
+  font-family: sans-serif;
+  color: #222;
+  background: #fff;
+}
+a { color: #33a; }
+#searchpage-main {
+  max-width: 46em;
+  margin: 0 auto;
+  padding: 1.5em 1em 3em;
+}
+#searchpage-main h1 {
+  font-size: 1.3em;
+  border-bottom: 2px solid #33a;
+  padding-bottom: 0.3em;
+}
+#searchpage-main h1 a {
+  color: inherit;
+  text-decoration: none;
+}
+#search-section {
+  position: static;
+  width: auto;
+  max-width: none;
+  margin: 1em 0 0.5em;
+}
+#search-field {
+  font-size: 1.1em;
+}
+.search-results {
+  position: static;
+  border: none;
+  box-shadow: none;
+  max-height: none;
+  overflow: visible;
+}
+.search-versions {
+  margin: 0.15em 0 0;
+  font-size: 0.8em;
+  color: #555;
+}
+.search-versions a {
+  display: inline-block;
+  margin-right: 0.35em;
+  padding: 0 0.4em;
+  border: 1px solid #99a;
+  border-radius: 3px;
+  text-decoration: none;
+}
+.searchpage-note {
+  font-size: 0.85em;
+  color: #555;
+}
+</style>
+<script>
+var search_versions = %%SEARCH_VERSIONS%%;
+var search_version_base = "../";
+</script>
+<script src="js/search_data.js"></script>
+<script src="js/search_navigation.js"></script>
+<script src="js/search_ranker.js"></script>
+<script src="js/search_controller.js"></script>
+<script src="js/search_page.js"></script>
+</head>
+<body>
+<main id="searchpage-main">
+<h1><a href="../">Ruby リファレンスマニュアル</a> 検索</h1>
+<div id="search-section" role="search">
+  <input id="search-field" type="text" autocomplete="off" spellcheck="false"
+         placeholder="クラス / メソッド / ライブラリ名で検索 (例: Array#each, String, socket)"
+         aria-label="リファレンス検索">
+  <ul id="search-results" class="search-results" aria-expanded="false"></ul>
+</div>
+<div class="searchpage-note">
+  <p>クラス・モジュール・メソッド・ライブラリ・特殊変数・ドキュメントの<strong>名前</strong>を全バージョン横断で検索します。検索結果のバージョンリンクから各バージョンのページを開けます。</p>
+  <p>本文の全文検索が必要な場合は、検索エンジンで <code>site:docs.ruby-lang.org/ja/ キーワード</code> を利用してください。</p>
+</div>
+</main>
+</body>
+</html>

--- a/lib/bitclust/runner.rb
+++ b/lib/bitclust/runner.rb
@@ -63,6 +63,7 @@ Subcommands(for developers):
 
 Subcommands(for packagers):
     statichtml  Generate static HTML files.
+    searchpage  Generate a static cross-version search page.
     epub        Generate EPUB file.
     chm         Generate static HTML files for CHM.
 
@@ -96,6 +97,7 @@ Global Options:
         'setup'       => BitClust::Subcommands::SetupCommand.new,
         'server'      => BitClust::Subcommands::ServerCommand.new,
         'statichtml'  => BitClust::Subcommands::StatichtmlCommand.new,
+        'searchpage'  => BitClust::Subcommands::SearchpageCommand.new,
         'htmlfile'    => BitClust::Subcommands::HtmlfileCommand.new,
         'chm'         => BitClust::Subcommands::ChmCommand.new,
         'epub'        => BitClust::Subcommands::EPUBCommand.new,
@@ -134,9 +136,12 @@ Global Options:
         @version ||= config[:default_version]
         @prefix ||= "#{config[:database_prefix]}-#{@version}"
       end
+      # searchpage のように DB パスを引数で受けるサブコマンドは
+      # グローバル --database を要求しない
+      needs_database = !cmd.respond_to?(:needs_database?) || cmd.needs_database?
       # @type var options: Subcommand::options
       options = {
-        :prefix => (@prefix || raise),
+        :prefix => (needs_database ? (@prefix || raise) : @prefix),
         :capi   => @capi
       }
       cmd.exec(argv, options)

--- a/lib/bitclust/search_index_generator.rb
+++ b/lib/bitclust/search_index_generator.rb
@@ -59,6 +59,31 @@ module BitClust
       "var search_data = #{JSON.generate(index: build_index(db, fdb))};"
     end
 
+    # Merges per-version indexes (an array of [version, index] pairs) into a
+    # single index whose entries carry a +versions+ array, for the standalone
+    # cross-version search page. Entries are considered the same when all of
+    # name/full_name/type/path match. Versions are sorted numerically ("3.10"
+    # sorts after "3.4"), and entry order is the first appearance while
+    # scanning versions in ascending order — independent of the caller's
+    # argument order, so the generated file diffs stay stable.
+    def self.merge(version_indexes)
+      merged = {}
+      sorted = version_indexes.sort_by { |version, _| Gem::Version.new(version) }
+      sorted.each do |version, index|
+        index.each do |e|
+          key = e.values_at(:name, :full_name, :type, :path)
+          entry = (merged[key] ||= e.merge(versions: []))
+          entry[:versions] << version
+        end
+      end
+      merged.values
+    end
+
+    # Serializes a merged multi-version index as a +search_data.js+ body.
+    def self.merged_js(version_indexes)
+      "var search_data = #{JSON.generate(index: merge(version_indexes))};"
+    end
+
     private
 
     def class_entries(db)

--- a/lib/bitclust/subcommand.rb
+++ b/lib/bitclust/subcommand.rb
@@ -24,6 +24,12 @@ module BitClust
       @parser.parse! argv
     end
 
+    # グローバル --database（options[:prefix]）を必要とするか。
+    # DB パスを自前の引数で受けるサブコマンド（searchpage）は false を返す
+    def needs_database?
+      true
+    end
+
     def help
       @parser.help
     end

--- a/lib/bitclust/subcommands/searchpage_command.rb
+++ b/lib/bitclust/subcommands/searchpage_command.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+#
+# bitclust/subcommands/searchpage_command.rb
+#
+# Generates a standalone, cross-version, client-side search page from
+# multiple version databases:
+#
+#   bitclust searchpage --outputdir=DIR db-3.0 db-3.1 ... db-4.1
+#
+# The output (index.html + js/search_data.js + assets) is fully static and
+# replaces the server-backed rurema-search app at docs.ruby-lang.org/ja/search/.
+# Each database's version is read from its own properties, and the merged
+# index tags every entry with the versions it appears in.
+#
+
+require 'pathname'
+require 'fileutils'
+require 'json'
+require 'optparse'
+
+require 'bitclust'
+require 'bitclust/subcommand'
+require 'bitclust/search_index_generator'
+
+module BitClust
+  module Subcommands
+    class SearchpageCommand < Subcommand
+      # search_init.js is the in-page dropdown wiring used by statichtml
+      # layouts; this page ships its own wiring (search_page.js) instead.
+      VENDORED_JS_FILES = %w[
+        search_navigation.js search_ranker.js search_controller.js
+      ].freeze
+
+      def initialize
+        super
+        @outputdir = nil
+        @themedir = srcdir_root + "theme/default"
+        @templatedir = srcdir_root + "data/bitclust/searchpage"
+        @suffix = ".html"
+        @fs_casesensitive = false
+        @verbose = false
+        @parser.banner = "Usage: #{File.basename($0, '.*')} searchpage [options] <dbpath>..."
+        @parser.on('-o', '--outputdir=PATH', 'Output directory.') {|path|
+          @outputdir = Pathname.new(path)
+        }
+        @parser.on('--themedir=PATH', 'Theme directory.') {|path|
+          @themedir = Pathname.new(path)
+        }
+        @parser.on('--fs-casesensitive', 'Filesystem is case-sensitive.') {
+          @fs_casesensitive = true
+        }
+        @parser.on('--verbose', 'Show progress.') {
+          @verbose = true
+        }
+      end
+
+      # DB paths are taken as positional arguments (one per version), so the
+      # global --database option is not required.
+      def needs_database?
+        false
+      end
+
+      def exec(argv, options)
+        error("no --outputdir given") unless @outputdir
+        error("no database given (pass one path per version)") if argv.empty?
+
+        generator = SearchIndexGenerator.new(suffix: @suffix,
+                                             fs_casesensitive: @fs_casesensitive)
+        version_indexes = argv.map {|path|
+          db = MethodDatabase.new(path)
+          fdb = FunctionDatabase.new(path) if File.directory?(File.join(path, 'function'))
+          version = db.properties['version'] or
+            error("#{path}: no version property (not a bitclust database?)")
+          $stderr.puts "indexing #{path} (#{version})" if @verbose
+          [version, generator.build_index(db, fdb)]
+        }
+        versions = version_indexes.map {|version, _| version }
+                                  .sort_by {|v| Gem::Version.new(v) }
+
+        jsdir = @outputdir + "js"
+        FileUtils.mkdir_p(jsdir)
+        File.write(jsdir + "search_data.js",
+                   SearchIndexGenerator.merged_js(version_indexes))
+        VENDORED_JS_FILES.each do |js|
+          FileUtils.cp(@themedir + "js" + js, jsdir.to_s, :preserve => true)
+        end
+        # Ship the MIT notice for the vendored Aliki files alongside them.
+        FileUtils.cp(@themedir + "js" + "NOTICE", jsdir.to_s, :preserve => true)
+        FileUtils.cp(@themedir + "js" + "search_page.js", jsdir.to_s, :preserve => true)
+        FileUtils.cp(@themedir + "search.css", @outputdir.to_s, :preserve => true)
+        File.write(@outputdir + "index.html", render_page(versions))
+        $stderr.puts "generated search page for #{versions.join(', ')}" if @verbose
+      end
+
+      private
+
+      def render_page(versions)
+        template = File.read(@templatedir + "index.html")
+        template.sub('%%SEARCH_VERSIONS%%', JSON.generate(versions))
+      end
+    end
+  end
+end

--- a/sig/bitclust/search_index_generator.rbs
+++ b/sig/bitclust/search_index_generator.rbs
@@ -17,6 +17,12 @@ module BitClust
 
     def to_js: (MethodDatabase db, ?FunctionDatabase? fdb) -> String
 
+    type merged_entry = Hash[Symbol, String | Array[String]]
+
+    def self.merge: (Array[[String, Array[entry]]] version_indexes) -> Array[merged_entry]
+
+    def self.merged_js: (Array[[String, Array[entry]]] version_indexes) -> String
+
     private
 
     def class_entries: (MethodDatabase db) -> Array[entry]

--- a/sig/bitclust/subcommand.rbs
+++ b/sig/bitclust/subcommand.rbs
@@ -9,11 +9,13 @@ module BitClust
 
     type argv = Array[String]
     type options = {
-      :prefix => String,
+      :prefix => String?,
       :capi => bool,
     }
 
     def parse: (argv argv) -> void
+
+    def needs_database?: () -> bool
 
     def help: () -> String
 

--- a/sig/bitclust/subcommands/searchpage_command.rbs
+++ b/sig/bitclust/subcommands/searchpage_command.rbs
@@ -1,0 +1,30 @@
+module BitClust
+  module Subcommands
+    # 複数バージョンの DB から /ja/search/ 置換用の静的検索ページを生成する
+    class SearchpageCommand < Subcommand
+      VENDORED_JS_FILES: Array[String]
+
+      @outputdir: Pathname?
+
+      @themedir: Pathname
+
+      @templatedir: Pathname
+
+      @suffix: String
+
+      @fs_casesensitive: bool
+
+      @verbose: bool
+
+      def initialize: () -> void
+
+      def needs_database?: () -> bool
+
+      def exec: (argv argv, options options) -> void
+
+      private
+
+      def render_page: (Array[String] versions) -> String
+    end
+  end
+end

--- a/test/test_search_index_generator.rb
+++ b/test/test_search_index_generator.rb
@@ -138,6 +138,55 @@ class TestSearchIndexGenerator < Test::Unit::TestCase
     assert(data['index'].any? { |e| e['full_name'] == 'Foo#foo' })
   end
 
+  # 全バージョン対応の検索ページ用: 版ごとの index を versions タグ付きで統合する
+
+  def entry(over = {})
+    { name: 'Foo', full_name: 'Foo', type: 'class', path: 'class/-foo.html' }.merge(over)
+  end
+
+  def test_merge_dedupes_identical_entries_across_versions
+    merged = BitClust::SearchIndexGenerator.merge(
+      [['3.4', [entry]], ['3.0', [entry]]])
+    assert_equal 1, merged.size
+    assert_equal %w[3.0 3.4], merged[0][:versions]
+    assert_equal 'Foo', merged[0][:full_name]
+  end
+
+  def test_merge_sorts_versions_numerically
+    # "3.10" は文字列比較だと "3.4" より前に来てしまう
+    merged = BitClust::SearchIndexGenerator.merge(
+      [['4.1', [entry]], ['3.10', [entry]], ['3.4', [entry]]])
+    assert_equal %w[3.4 3.10 4.1], merged[0][:versions]
+  end
+
+  def test_merge_keeps_entries_with_different_paths_separate
+    a = entry(full_name: 'X#x', name: 'x', type: 'instance_method',
+              path: 'method/-x/i/x.html')
+    b = a.merge(path: 'method/=x/i/x.html')
+    merged = BitClust::SearchIndexGenerator.merge([['3.4', [a]], ['4.1', [b]]])
+    assert_equal 2, merged.size
+    assert_equal [['3.4'], ['4.1']], merged.map { |e| e[:versions] }
+  end
+
+  def test_merge_orders_entries_by_first_appearance_in_version_order
+    # 入力順に依らず「昇順の版を走査して最初に現れた順」で安定させる
+    # （generated-documents にコミットされる出力の diff を安定させるため）
+    a = entry(full_name: 'A', name: 'A', path: 'class/-a.html')
+    b = entry(full_name: 'B', name: 'B', path: 'class/-b.html')
+    merged = BitClust::SearchIndexGenerator.merge(
+      [['3.4', [a, b]], ['3.0', [b]]])
+    assert_equal %w[B A], merged.map { |e| e[:full_name] }
+  end
+
+  def test_merged_js_format
+    js = BitClust::SearchIndexGenerator.merged_js([['3.4', [entry]]])
+    assert_match(/\Avar search_data = \{/, js)
+    assert(js.end_with?(';'))
+    data = JSON.parse(js.sub(/\Avar search_data = /, '').sub(/;\z/, ''))
+    assert_equal ['3.4'], data['index'][0]['versions']
+    assert_equal 'Foo', data['index'][0]['full_name']
+  end
+
   private
 
   def setup_files

--- a/test/test_searchpage_command.rb
+++ b/test/test_searchpage_command.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'json'
+require 'fileutils'
+require 'bitclust'
+require 'bitclust/methoddatabase'
+require 'bitclust/subcommands/searchpage_command'
+
+# searchpage サブコマンド: 複数バージョンの DB から /ja/search/ 置換用の
+# 静的検索ページ一式（index.html + 統合 search_data.js + JS/CSS アセット）を
+# 生成する。rurema-search（サーバ常駐の全文検索）のリタイア先。
+#
+# テストリスト:
+# [x] 統合 index: 全版共通エントリは versions に全版、片方だけのものはその版のみ
+# [x] index.html に search_versions（昇順）と検索 UI の要素が埋まる
+# [x] vendored JS + NOTICE + search_page.js + search.css がコピーされる
+# [x] ページ専用 UI なので search_init.js（ページ内ボックス用）は含めない
+# [x] DB を持たない引数なし呼び出しはエラー
+# [x] グローバル --database 不要（needs_database? が false）
+class TestSearchpageCommand < Test::Unit::TestCase
+  def setup
+    @tmpdir = "searchpage_test_tmp"
+    FileUtils.rm_rf(@tmpdir)
+    @db34 = build_db('3.4', <<~'RD')
+      description
+
+      = class Foo < Object
+      == Instance Methods
+      --- foo
+    RD
+    @db41 = build_db('4.1', <<~'RD')
+      description
+
+      = class Foo < Object
+      == Instance Methods
+      --- foo
+      --- bar
+    RD
+    @out = "#{@tmpdir}/out"
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def build_db(version, builtin_rd)
+    root = "#{@tmpdir}/tree-#{version}/refm/api/src"
+    FileUtils.mkdir_p("#{root}/_builtin")
+    File.write("#{root}/LIBRARIES", "_builtin\n")
+    File.write("#{root}/_builtin.rd", builtin_rd)
+    prefix = "#{@tmpdir}/db-#{version}"
+    db = BitClust::MethodDatabase.new(prefix)
+    db.init
+    db.transaction do
+      db.propset('version', version)
+      db.propset('encoding', 'utf-8')
+    end
+    db.transaction do
+      db.update_by_stdlibtree(root)
+    end
+    prefix
+  end
+
+  def run_command(argv)
+    cmd = BitClust::Subcommands::SearchpageCommand.new
+    cmd.parse(argv)
+    cmd.exec(argv, { prefix: nil, capi: false })
+    cmd
+  end
+
+  def test_needs_no_global_database_option
+    cmd = BitClust::Subcommands::SearchpageCommand.new
+    assert_false cmd.needs_database?
+  end
+
+  def test_merged_index_versions
+    run_command(["--outputdir=#{@out}", @db41, @db34])
+    js = File.read("#{@out}/js/search_data.js")
+    assert_match(/\Avar search_data = \{/, js)
+    data = JSON.parse(js.sub(/\Avar search_data = /, '').sub(/;\z/, ''))
+    foo = data['index'].find { |e| e['full_name'] == 'Foo#foo' }
+    bar = data['index'].find { |e| e['full_name'] == 'Foo#bar' }
+    klass = data['index'].find { |e| e['full_name'] == 'Foo' }
+    assert_equal %w[3.4 4.1], foo['versions']
+    assert_equal %w[4.1], bar['versions']
+    assert_equal %w[3.4 4.1], klass['versions']
+  end
+
+  def test_index_html_embeds_versions_and_ui
+    run_command(["--outputdir=#{@out}", @db41, @db34])
+    html = File.read("#{@out}/index.html")
+    assert_match(/var search_versions = \["3\.4","4\.1"\];/, html)
+    assert_match(/var search_version_base = "\.\.\/";/, html)
+    assert_match(/id="search-field"/, html)
+    assert_match(/id="search-results"/, html)
+    assert_match(%r{js/search_data\.js}, html)
+    assert_match(%r{js/search_page\.js}, html)
+  end
+
+  def test_assets_are_copied
+    run_command(["--outputdir=#{@out}", @db41, @db34])
+    %w[search_navigation.js search_ranker.js search_controller.js
+       search_page.js NOTICE].each do |f|
+      assert File.exist?("#{@out}/js/#{f}"), "js/#{f} not copied"
+    end
+    assert File.exist?("#{@out}/search.css")
+    # ページ内ドロップダウン用の search_init.js はこのページでは使わない
+    assert_false File.exist?("#{@out}/js/search_init.js")
+  end
+
+  def test_no_database_arguments_is_an_error
+    cmd = BitClust::Subcommands::SearchpageCommand.new
+    argv = ["--outputdir=#{@out}"]
+    cmd.parse(argv)
+    assert_raise(SystemExit) do
+      capture_stderr { cmd.exec(argv, { prefix: nil, capi: false }) }
+    end
+  end
+
+  def test_missing_outputdir_is_an_error
+    cmd = BitClust::Subcommands::SearchpageCommand.new
+    argv = [@db34]
+    cmd.parse(argv)
+    assert_raise(SystemExit) do
+      capture_stderr { cmd.exec(argv, { prefix: nil, capi: false }) }
+    end
+  end
+
+  private
+
+  def capture_stderr
+    orig = $stderr
+    $stderr = StringIO.new
+    yield
+  ensure
+    $stderr = orig
+  end
+end

--- a/theme/default/js/search_page.js
+++ b/theme/default/js/search_page.js
@@ -1,0 +1,124 @@
+'use strict';
+/*
+ * Part of BitClust. Distributed under the Ruby License or the MIT License.
+ *
+ * Wires up the standalone cross-version search page (the static replacement
+ * for the server-backed rurema-search app at /ja/search/).
+ *
+ * The sibling files search_navigation.js, search_ranker.js and
+ * search_controller.js are vendored verbatim from RDoc's Aliki theme.
+ * They expect these globals to be defined before this script runs:
+ *
+ *   search_data         - defined by js/search_data.js. Each entry carries a
+ *                         `versions` array (ascending) added by
+ *                         SearchIndexGenerator.merge.
+ *   search_versions     - all indexed versions, ascending (inline in the page).
+ *   search_version_base - relative path from this page to the directory that
+ *                         holds the per-version document roots ("../" when the
+ *                         page lives at /ja/search/).
+ */
+(function() {
+  // BitClust extension (the vendored Aliki files above are kept verbatim).
+  //
+  // Same special-variable handling as search_init.js: keep "$"-prefixed
+  // queries literal (no "." -> "::" rewrite) and match them against
+  // full_name, where the "$" sigil lives.
+  // See https://github.com/rurema/bitclust/issues/194
+  if (typeof parseQuery === 'function') {
+    var alikiParseQuery = parseQuery;
+    parseQuery = function(query) {
+      var q = alikiParseQuery(query);
+      if (query.charAt(0) === '$') {
+        q.normalized = query.toLowerCase();
+        q.matchesFullName = true;
+      }
+      return q;
+    };
+  }
+
+  function versionHref(version, path) {
+    return search_version_base + version + '/' + path;
+  }
+
+  // rurema-search compatibility: accept ?q=, its ?query= parameter, and its
+  // /query:<word>/ path form (the latter only reaches this page when the
+  // server rewrites unknown /ja/search/* paths here).
+  function initialQuery() {
+    var q = null;
+    if (typeof URLSearchParams !== 'undefined') {
+      var params = new URLSearchParams(window.location.search);
+      q = params.get('q') || params.get('query');
+    }
+    if (!q) {
+      var m = window.location.pathname.match(/\/query:([^\/]+)/);
+      if (m) {
+        try {
+          q = decodeURIComponent(m[1]);
+        } catch (e) {
+          q = m[1];
+        }
+      }
+    }
+    return q;
+  }
+
+  function init() {
+    var input = document.querySelector('#search-field');
+    var result = document.querySelector('#search-results');
+    if (!input || !result) return;
+
+    var search = new SearchController(search_data, input, result);
+
+    search.renderItem = function(r) {
+      var li = document.createElement('li');
+      var versions = (r.versions || []).slice().reverse();  // newest first
+      var newest = versions[0] || '';
+      var html = '<p class="search-match"><a href="' +
+        this.escapeHTML(versionHref(newest, r.path)) + '">' +
+        this.hlt(r.title) + '</a>';
+      if (r.type) {
+        var typeClass = r.type.replace(/_/g, '-');
+        html += '<span class="search-type search-type-' +
+          this.escapeHTML(typeClass) + '">' + this.formatType(r.type) + '</span>';
+      }
+      html += '</p><p class="search-versions">';
+      for (var i = 0; i < versions.length; i++) {
+        html += '<a href="' + this.escapeHTML(versionHref(versions[i], r.path)) +
+          '">' + this.escapeHTML(versions[i]) + '</a>';
+      }
+      html += '</p>';
+      li.innerHTML = html;
+      return li;
+    };
+
+    search.formatType = function(type) {
+      var labels = {
+        'class': 'class', 'module': 'module', 'object': 'object',
+        'constant': 'const', 'instance_method': 'method', 'class_method': 'method',
+        'variable': 'var', 'library': 'lib', 'document': 'doc', 'function': 'func'
+      };
+      return labels[type] || type;
+    };
+
+    search.select = function(selected) {
+      if (selected) window.location.href = selected.firstChild.firstChild.href;
+    };
+
+    // Keep the query shareable: mirror the box into the ?q= parameter.
+    input.addEventListener('input', function() {
+      var q = input.value.trim();
+      var url = q ? '?q=' + encodeURIComponent(q) : window.location.pathname;
+      window.history.replaceState(null, '', url);
+    });
+
+    var q = initialQuery();
+    if (q) {
+      input.value = q;
+      window.history.replaceState(null, '', '?q=' + encodeURIComponent(q));
+      search.search(q, false);
+    }
+    input.focus();
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();


### PR DESCRIPTION
## 概要

docs.ruby-lang.org/ja/search/ のるりまサーチ（rurema-search、サーバ常駐の groonga 全文検索）を、サーバ不要の静的検索ページで置き換えるためのジェネレータです。#190 でページ内検索ボックスとして導入した Aliki 互換のクライアントサイド検索を、**全バージョン横断の単独ページ**に拡張します。

```console
$ bitclust searchpage --outputdir=DIR --fs-casesensitive db-3.0 db-3.1 ... db-4.1
```

出力: `index.html` + `js/search_data.js`（統合 index）+ vendored Aliki JS 3本（NOTICE 込み）+ `search_page.js` + `search.css`。各 DB のバージョンは DB 自身の properties から読みます。

## 実装

- **`SearchIndexGenerator.merge`**: 版ごとの index を `versions` タグ付きで統合。name/full_name/type/path が全一致するエントリを1つにまとめ、versions は数値順（"3.10" > "3.4"）。エントリ順は「昇順の版の初出順」で入力順に依存させず、生成物の diff を安定させています。
- **`search_page.js`**（BitClust 自作、Ruby/MIT デュアル）: vendored の SearchController をそのまま使い、renderItem だけ差し替えて検索結果に全バージョンのリンクを表示（主リンクは最新版）。`?q=` に加えて rurema-search 互換の `?query=` と `/query:<語>/` パス形式も受け付けます。ranker は versions フィールドを無視するので vendored 3本は verbatim のままです。
- **`Subcommand#needs_database?`**: DB パスを引数で受けるサブコマンド用に、グローバル `--database` の必須チェックを条件化（既存サブコマンドの挙動は不変）。

## 実測（refm 3.0 + 3.4 の実 DB）

- 統合 13,556 エントリ / **gzip 176KB**（1版 177KB とほぼ同じ。重複排除が効くため対象 7 版でも大きくは増えない見込み）
- 版タグの妥当性: `Array#each`=[3.0, 3.4]、`Data`=[3.4]（3.2 で導入）、`Bignum`/`Fixnum`/`TimeoutError`=[3.0]

## テスト

新規: `SearchIndexGenerator.merge` 単体 5 件 + searchpage コマンド e2e 6 件。フルスイート green、`rbs parse` OK（sig 追加済み）。

## 後続（別 PR）

1. rurema/generated-documents: 全版 DB から `html/ja/search/` を生成
2. ruby/docs.ruby-lang.org: `system/bc-static-all` の rsync 対象に search を追加 + `/ja/` トップのリンク文言
3. インフラ: `/ja/search/` をアプリへのプロキシから静的配信へ切り替え → rurema-search リタイア

制約の明示: 置き換え後は**名前検索のみ**になります（本文の全文検索・サジェストは提供しない。全文検索は外部検索エンジンの site: 検索を案内）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
