### PR TITLE
Fix search page result links missing the version segment

### DIFF
--- a/theme/default/js/search_page.js
+++ b/theme/default/js/search_page.js
@@ -40,6 +40,33 @@
     return search_version_base + version + '/' + path;
   }
 
+  function compareVersions(a, b) {
+    var as = a.split('.');
+    var bs = b.split('.');
+    for (var i = 0; i < Math.max(as.length, bs.length); i++) {
+      var d = parseInt(as[i] || '0', 10) - parseInt(bs[i] || '0', 10);
+      if (d) return d;
+    }
+    return 0;
+  }
+
+  // ranker の formatResult は {title, path, type} だけを結果に残し、統合 index の
+  // versions を落とす（vendored ファイルは verbatim 維持）。path から versions を
+  // 引けるよう対応表を作る。同じ path が複数エントリに現れる稀なケース
+  // （版によって type 等が違う）は、ページとしては存在する版の和集合が正しい
+  function buildVersionsByPath() {
+    var map = {};
+    for (var i = 0; i < search_data.index.length; i++) {
+      var e = search_data.index[i];
+      var list = map[e.path] || (map[e.path] = []);
+      var vs = e.versions || [];
+      for (var j = 0; j < vs.length; j++) {
+        if (list.indexOf(vs[j]) < 0) list.push(vs[j]);
+      }
+    }
+    return map;
+  }
+
   // rurema-search compatibility: accept ?q=, its ?query= parameter, and its
   // /query:<word>/ path form (the latter only reaches this page when the
   // server rewrites unknown /ja/search/* paths here).
@@ -68,10 +95,12 @@
     if (!input || !result) return;
 
     var search = new SearchController(search_data, input, result);
+    var versionsByPath = buildVersionsByPath();
 
     search.renderItem = function(r) {
       var li = document.createElement('li');
-      var versions = (r.versions || []).slice().reverse();  // newest first
+      var versions = (versionsByPath[r.path] || [])
+        .slice().sort(compareVersions).reverse();  // newest first
       var newest = versions[0] || '';
       var html = '<p class="search-match"><a href="' +
         this.escapeHTML(versionHref(newest, r.path)) + '">' +


### PR DESCRIPTION
検索結果のリンクが /ja//method/... になりリンク切れしていた。
vendored ranker の formatResult が {title, path, type} だけを結果に 残すため、統合 index に付けた versions が renderItem に届かず、
バージョン部分が空文字になっていた。

vendored ファイルは verbatim 維持の方針のまま、search_page.js 側で index から path -> versions の対応表を作って引くようにする。
同じ path が複数エントリに現れる稀なケース（版により type 等が違う）は
和集合を取り、表示順は数値比較（3.4 < 3.10）の降順。

検証: quickjs で実データ（3.0+3.4 統合 index）+ 実 ranker + 本ファイルの 抽出関数を実行し、Array#each -> ../3.4/method/Array/i/each.html、 Bignum -> ../3.0/...、旧ロジックが報告どおり ..//... になることを確認。