### PR TITLE
doc: adopt BitClust usage/database pages from the doctree wiki

### DIFF
--- a/doc/database.md
+++ b/doc/database.md
@@ -1,0 +1,119 @@
+# BitClust データベースについて
+
+> 旧 doctree wiki の「BitClustDatabase」ページを移設したものです（2026年7月）。
+> クラスリファレンスデータベースの構造の記述は現行実装とおおむね一致しますが、
+> 「C API データベース (予定)」の節は構想当時のもので、現在は
+> FunctionDatabase として実装済みです。
+
+## クラスリファレンスデータベース
+
+ファイルシステムべったりの実装。
+以下のようなディレクトリツリーを持つ。
+
+    PREFIX/
+        properties
+        library/
+            _builtin
+            English
+            Env
+            Win32API
+            abbrev
+            base64
+            benchmark
+            bigdecimal
+            bigdecimal.jacobian
+                :
+                :
+        class/
+            ARGF
+            Abbrev
+            ArgumentError
+            Array
+            Base64
+            Benchmark
+            BigDecimal
+            Bignum
+            Binding
+            CGI
+                :
+                :
+        method/
+            ARGF/
+                s.binmode._builtin
+                s.close._builtin
+                s.closed=3f._builtin
+                s.dup._builtin
+                s.each._builtin
+                s.each_byte._builtin
+                s.each_line._builtin
+                s.eof._builtin
+                s.file._builtin
+                s.filename._builtin
+                        :
+                        :
+            Abbrev/
+            Array/
+            Base64/
+            Benchmark/
+            BigDecimal/
+            Bignum/
+            Binding/
+            CGI/
+            CGI__Cookie/
+                :
+                :
+
+
+メソッドのファイル名のフォーマットは以下の通り。
+
+    TYPECHAR.METHODNAME.LIBID
+
+<dl>
+<dt>TYPECHAR</dt>
+<dd>
+メソッドの名前空間を表す一文字。
+s: 特異メソッド、i: インスタンスメソッド、m: モジュール関数、
+c: 定数、v: 特殊変数
+</dd>
+<dt>METHODNAME</dt>
+<dd>
+メソッド名をエンコードしたもの。
+/?w/ 以外の文字は「=」+「文字コード」にエンコードされる。
+</dd>
+<dt>LIBID</dt>
+<dd>
+ライブラリ ID。require に書く名前を tr('/', '.') したもの。
+既存のライブラリに「.」を使ってるようなバカがいないことを願う。
+</dd>
+</dl>
+
+メソッドの追加や上書きに対応するため、
+メソッドのファイルにライブラリ ID を入れたところが特徴である。
+
+各ライブラリやクラス、メソッドのファイルの内容は
+以下のようなフォーマットで記録される。
+
+    requires=
+    classes=ERB,ERB__Util,ERB__DefMethod
+    methods=
+    
+    eRuby スクリプトを処理するクラス。
+    従来 ERbLight と呼ばれていたもので、標準出力への印字が文字列の挿入とならない点が
+    eruby と異なります。
+    
+    (以下略)
+
+最初に key=value の行が並び、
+空行を 1 行入れてドキュメントが来る。これだけ。
+ドキュメントのフォーマットについては
+[MARKUP_SPEC.md](markdown-samples/MARKUP_SPEC.md) を参照。
+
+## C API データベース (予定)
+
+こちらもファイルシステムべったり構造。
+シンボル名でディレクトリを掘っただけの超シンプルなディレクトリツリーを持つ。
+
+    PREFIX/
+        rb_define_method/
+            document
+            source

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -1,0 +1,251 @@
+# BitClust の使い方
+
+> 旧 doctree wiki の「BitClust」ページを移設したものです（2026年7月）。
+> 記述の多くは refm（RRD 記法）時代のもので、コマンド例には旧来のパスが
+> 残っています。2026年7月の Markdown 移行後のビルドは doctree の
+> `manual/` ツリー（`--markdowntree`）が正です。順次更新してください。
+
+BitClust は新リファレンスマニュアルの核となるプログラムです。
+ドキュメントデータベースからウェブインターフェイス、
+執筆支援ツールまで、いろいろ入ってます。
+計画に参加するメンバーは必ず入手しておいてください。
+
+## 入手方法
+
+BitClust は Git レポジトリと Gem パッケージで公開されています。
+
+- [rurema/bitclust](https://github.com/rurema/bitclust)
+
+tar.gz や zip で提供していたパッケージ版の提供は不定期に行うので、最新のドキュメントが読みたい人は web 版を見るか Gem パッケージ版を使用して自分でドキュメントを生成してください。
+
+## インストール
+
+Gem パッケージがリリースされています。
+
+ReFe2 だけ使用したい人は以下のコマンドでインストールすることができます。
+
+```
+$ gem install refe2
+```
+
+るりまのリリース作業など読んだり使ったりするだけでは物足りない人は
+以下のコマンドで関連するパッケージを全てインストールすることができます。
+
+```
+$ gem install bitclust-core bitclust-dev refe2
+```
+
+## 使用方法
+
+各コマンドに --help を付けて起動するとオプションの簡単な説明が表示されます。
+
+## 主要コマンド
+
+<dl>
+<dt>bitclust</dt>
+<dd>
+リファレンスデータベースの更新、表示、検索などを行う。
+以下の「bitclust サブコマンド」の項も参照。
+</dd>
+<dt>refe</dt>
+<dd>BitClust データベースに対応した ReFe (ReFe2)。</dd>
+</dl>
+
+## bitclust サブコマンド
+
+```--capi``` オプションを付けた場合，C API（doctree の manual/capi 以下）を対象とします。付けない場合，ライブラリ（manual/api 以下）と言語仕様など（manual/doc 以下）を対象とします。
+
+$HOME/.bitclust/config がある場合は、```-d```オプションは省略可能です。
+
+### ユーザー向け
+
+<dl>
+<dt>bitclust setup</dt>
+<dd>
+設定ファイルの初期化と BitClust データベースの初期化・生成を実行します。
+今のところ git コマンドに PATH が通っている必要があります。
+</dd>
+</dl>
+
+例
+
+```
+bitclust setup
+```
+
+<dl>
+</dd>
+<dt>bitclust init</dt>
+<dd>
+BitClust データベースを初期化する。
+setup があるので内部を理解している人以外は使わない。
+</dd>
+</dl>
+
+例
+
+```
+bitclust -d ./db-3_4 init version=3.4 encoding=utf-8
+```
+
+<dl>
+<dt>bitclust update</dt>
+<dd>BitClust データベースを更新する。</dl>
+</dl>
+
+例（Markdown 移行後の manual/ ツリーから）
+
+```
+bitclust -d ./db-3_4 update --markdowntree=../doctree/manual/api
+bitclust -d ./db-3_4 --capi update --markdowntree=../doctree/manual/capi
+```
+
+旧 refm ツリー（凍結）から構築する場合:
+
+```
+bitclust -d ./db-3_4 update --stdlibtree=../doctree/refm/api/src
+bitclust -d ./db-3_4 --capi update ../doctree/refm/capi/src/*
+```
+
+<dl>
+<dt>bitclust list</dt>
+<dd>特定の種類のエントリをリストする。</dd>
+</dl>
+
+例
+
+```
+bitclust -d ./db list --library
+bitclust -d ./db list --class
+bitclust -d ./db list --method
+bitclust -d ./db --capi list --function
+```
+
+<dl>
+<dt>bitclust lookup</dt>
+<dd>指定されたエントリの内容を出力する。</dd>
+</dl>
+
+例
+
+```
+bitclust -d ./db lookup --library=_builtin
+bitclust -d ./db lookup --class=Object
+bitclust -d ./db lookup --method=Object#inspect
+bitclust -d ./db lookup --method=Object#inspect --html
+bitclust -d ./db --capi lookup --function=rb_ary_new3
+```
+
+<dl>
+<dt>bitclust search</dt>
+<dd>refe と同じ(refeの本体)。</dd>
+</dl>
+
+例
+
+```
+bitclust -d ./db search Object#inspect
+bitclust -d ./db --capi search rb_ary_new3
+```
+
+### 開発者向け
+
+<dl>
+<dt>bitclust ancestors</dt>
+<dd>クラスの継承階層をRubyとBitClustのDB間で比較する。</dd>
+<dt>bitclust htmlfile</dt>
+<dd>リファレンスの1ファイルを HTML に変換する。データベースの更新なしにhtmlへの変換結果が見られて便利。</dd>
+</dl>
+
+例
+
+```
+bitclust htmlfile --target=Range Range > t.html
+bitclust htmlfile ../doctree/refm/api/src/_builtin/Array --target Array > t.html
+bitclust htmlfile ../doctree/refm/api/src/net/https.rd > a.html
+bitclust htmlfile src/zlib/GzipReader                              #ライブラリGzipReader
+bitclust htmlfile src/zlib/GzipReader --target=Zlib::GZipReader    #クラスGzipReader
+bitclust htmlfile --force mkmf.rd                                  #ファイルの全体を強制的に出力する
+bitclust htmlfile --ruby=1.8.6 --target=Array Array > t.html       #rubyのバージョンを指定
+bitclust htmlfile --capi ../doctree/refm/capi/src/array.c.rd --target=rb_ary_new3 # C API では現状 --target 必須
+```
+
+<dl>
+<dt>bitclust query</dt>
+<dt>bitclust property</dt>
+<dd>データベースプロパティを操作する。</dd>
+</dl>
+
+例
+
+```
+bitclust -d ./db property --list
+bitclust -d ./db property --get encoding
+bitclust -d ./db property --set encoding euc-jp
+```
+
+<dt>bitclust preproc</dt>
+<dd>プリプロセスだけを行う</dd>
+<dt>bitclust extract</dt>
+<dd>リファレンスファイルに含まれるメソッドエントリをリストする</dd>
+<dt>bitclust classes</dt>
+<dd>システムに存在する全 ruby について、定義されているクラスを表示する</dd>
+<dt>bitclust methods</dt>
+<dd>
+システムに存在する全 ruby について、定義されているメソッドを表示する。
+るりまのリファレンスファイルに書かれてあるメソッドに不足がないかもチェックできる。
+ -c をつけると不足しているメソッドの ri の内容が表示される。
+ライブラリに対して使うときは -r オプションが必須。
+[<a href="http://www.fdiary.net/ml/ruby-reference-manual/msg/468">ruby-reference-manual:468</a>], [<a href="http://www.fdiary.net/ml/ruby-reference-manual/msg/558">ruby-reference-manual:558</a>]
+</dd>
+
+例
+
+```
+bitclust methods Object
+bitclust methods -rLIBRARY --ruby=RUBY_VERSION --diff=RDFILE CLASS_NAME
+bitclust methods -rstringio --ruby=1.9.3 --diff=StringIO StringIO
+ruby-1.9 -S bitclust methods --ruby=1.9.3 --diff=Object Object  -c
+```
+
+### パッケージ作成者向け
+
+<dl>
+<dt>bitclust chm</dt>
+<dd>Microsoft HTML Workshop用のchm素材を出力する。</dd>
+</dl>
+
+例
+
+```
+bitclust chm -d ./db -o ~/tmp/chm    #-o省略時は ./chm に出力される
+このあと、hhc.exe ~/tmp/chm/refm.hhp とするとrefm.chmができる
+```
+
+<dl>
+<dt>bitclust statichtml</dt>
+<dd>静的 HTML を出力する。</dd>
+<dt>bitclust searchpage</dt>
+<dd>全バージョン横断の静的検索ページを出力する。</dd>
+<dt>bitclust info</dt>
+<dd>未実装。info を出力する。</dd>
+</dl>
+
+## ツール (tools/*.rb)
+
+るりまを書く人用のツールです。gem install bitclust-devでインストールできます。
+
+<dl>
+<dt>bc-rdoc</dt>
+<dd>RDoc データベースと BitClust データベースを比較処理。 [<a href="http://www.fdiary.net/ml/ruby-reference-manual/msg/468">ruby-reference-manual:468</a>]</dd>
+<dt>forall-ruby</dt>
+<dd>システムに存在する全 ruby について、同じコマンドラインオプションを付けて実行する</dd>
+<dt>bc-convert</dt>
+<dd>旧リファレンスマニュアルのファイルを BitClustフォーマットに変換します。今はもう使われていません。</dd>
+</dl>
+
+## 実装の詳細
+
+- [database.md](database.md) — データベースの内部構造
+- [MARKUP_SPEC.md](markdown-samples/MARKUP_SPEC.md) — リファレンスの記法仕様（Markdown）
+- [markdown-operations.md](markdown-operations.md) — Markdown ツリーの運用コマンド集


### PR DESCRIPTION
## 概要

doctree の wiki を docs/ ツリーへ取り込む作業（rurema/doctree#3037 の棚卸し）に伴い、ツール自体を説明する2ページを bitclust リポジトリで引き取ります。

- **doc/usage.md** ← wiki「BitClust」ページ（入手方法・サブコマンド一覧・tools）
- **doc/database.md** ← wiki「BitClustDatabase」ページ（DB の内部構造）

## 変更方針

内容は基本的に取り込み時点のまま（冒頭に由来と鮮度の注記を追加）。ただし以下だけ更新しています:

- wiki リンク（`[[Page]]`）をリポジトリ内/リポジトリ間リンクに変換
- usage.md の `bitclust update` の例を Markdown 移行後の `--markdowntree` 形を主に（旧 `--stdlibtree` は凍結 refm 用として残記)
- `--capi` の対象パス説明を manual/ に更新、サブコマンド一覧に `searchpage` を追記
- database.md の「C API データベース (予定)」は FunctionDatabase として実装済みである旨を注記

残りのコマンド例（htmlfile の refm パス等）の鮮度確認は追って行います（ページ冒頭に注記済み）。

doctree 側で2ページを削除する companion PR があります。こちらを先にマージする想定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
