### PR TITLE
Fall back to raw signature for []= that cannot be shaped into self[...]=

### DIFF
--- a/lib/bitclust/methodsignature.rb
+++ b/lib/bitclust/methodsignature.rb
@@ -65,9 +65,14 @@ module BitClust
         "self[#{@params}]" + (@type ? " -> #{@type}" : "")
       when "[]="    # aset
         params = @params&.split(',')
-        raise ParseError, "invalid parameters for []= operator: #{@params.inspect}" if params.nil? || params.size < 2
-        val = params.pop or raise ParseError, "missing value parameter for []= operator: #{@params.inspect}"
-        "self[#{params.join(',').strip}] = #{val.strip}"
+        if params && params.size >= 2
+          val = params.pop
+          "self[#{params.join(',').strip}] = #{val.strip}"
+        else
+          # Signatures like []=(*idxary) in historic documents cannot be
+          # shaped into "self[...] = ..."; show the raw signature instead
+          to_s()
+        end
       when "`"  # `command`
         "`#{@params}`" + (@type ? " -> #{@type}" : "")
       when /\A\W/   # binary operator

--- a/test/test_methodsignature.rb
+++ b/test/test_methodsignature.rb
@@ -4,7 +4,9 @@ require 'bitclust/methodsignature'
 class TestMethodSignature < Test::Unit::TestCase
 
   data("special var" => ["$_ -> String | nil", "--- $_ -> String | nil"],
-       "backquote"   => ["`command` -> String", "--- `(command) -> String"])
+       "backquote"   => ["`command` -> String", "--- `(command) -> String"],
+       "aset"        => ["self[key] = value", "--- []=(key, value)"],
+       "aset splat"  => ["[]=(*idxary)", "--- []=(*idxary)"])
   def test_friendlyname(data)
     friendly_string, method_signature = data
     assert_equal(friendly_string, BitClust::MethodSignature.parse(method_signature).friendly_string)


### PR DESCRIPTION
## 問題

generated-documents の daily generate.sh が凍結版（1.8.7〜2.7.0）の静的 HTML 再生成
（`tool/bc-static-frozen.rb`）で失敗する問題の一部です（もう1つの原因への対処は
generated-documents 側の PR を参照）。

1.8.7〜2.3.0 の凍結 DB に対して `bitclust statichtml` を実行すると、途中で
クラッシュします:

```
bitclust: error: invalid parameters for []= operator: "*idxary"
```

## 原因

bd1667d で `MethodSignature#friendly_string` が、`[]=` のパラメータが2個未満の場合に
`ParseError` を raise するようになりました（不正な `self[] =` 出力の防止が目的）。

しかし、凍結版のソースにはこの形のシグネチャが実在します:

- `soap/baseData` の `SOAPArray#[]=(*idxary)`（frozen-1.8.7）
- `tk/entry` の `TkEntry#[]=(*args)`（frozen-1.9.3〜frozen-2.3.0）

これらは `self[添字] = 値` の糖衣形に整形できない正当な歴史的シグネチャで、
凍結ソースなので doctree 側で修正することもできません。現行の `manual/` には
この形は無いため、3.0〜4.1 のビルドでは顕在化しませんでした。

## 修正

整形できない `[]=` シグネチャは raise せず、**素のシグネチャ表示（`to_s`）に
フォールバック**します（例: `[]=(*idxary)`）。bd1667d が防ごうとした不正な
`self[] =` 出力は引き続き発生しません。

TDD: `test/test_methodsignature.rb` に通常の `[]=(key, value)`（回帰ガード）と
`[]=(*idxary)`（フォールバック）のケースを追加。

## 検証

- `test/test_methodsignature.rb`: 4 tests 全green（修正前は splat ケースが ParseError）
- フルスイート: 17,538 tests / 17,874 assertions、100% passed
- 凍結 DB での実地確認: db-1.8.7〜db-2.3.0 の6版すべてで statichtml が完走
  （16,967〜17,616 ファイル生成。本修正前は全て上記エラーで exit 1）。
  db-2.7.0 も完走（こちらは generated-documents 側 PR の修正のみで解消する版）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
