### PR TITLE
Display ancestor singleton methods in class page

### DIFF
--- a/data/bitclust/catalog/ja_JP.UTF-8
+++ b/data/bitclust/catalog/ja_JP.UTF-8
@@ -14,6 +14,8 @@ Ancestor Methods
 継承しているメソッド
 Ancestor Methods %s
 %sから継承しているメソッド
+Ancestor Singleton Methods %s
+%sから継承している特異メソッド
 Builtin
 組み込み
 Builtin Library

--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -147,17 +147,38 @@
 
 <%
 _myself, *ancestors = @entry.ancestors.reject { |c| %w[Object Kernel BasicObject].include?(c.name) }
-displayed_methods = Set.new(ents.instance_methods.flat_map(&:names))
+displayed_instance_methods = Set.new(ents.instance_methods.flat_map(&:names))
+displayed_singleton_methods = Set.new(ents.singleton_methods.flat_map(&:names))
+undefined_methods = @entry.partitioned_entries.undefined
+undefined_instance_methods = undefined_methods.select(&:instance_method?)
+undefined_singleton_methods = undefined_methods.select(&:singleton_method?)
 %>
 
 <% unless ancestors.empty? %>
   <%= headline(_("Ancestor Methods")) %>
 <dl>
+  <%# Singleton methods are inherited only through the superclass chain, not from included modules. %>
+  <% ancestors.select(&:class?).each do |c|
+       methods = c.partitioned_entries(@alevel).singleton_methods
+         .flat_map { |m| m.names.map { |n| [n, m] } }
+         .reject { |name,| displayed_singleton_methods.include?(name) }
+         .reject { |name,| undefined_singleton_methods.any? { |m| m.names.include?(name) } }
+         .sort
+       next if methods.empty? %>
+<dt><%= _('Ancestor Singleton Methods %s', c.name) %></dt>
+<dd>
+  <ul class="class-toc">
+    <% methods.each do |name, m| %>
+      <li><%= method_link(m.spec_string, name) %></li>
+      <% displayed_singleton_methods << name %>
+    <% end %>
+  </ul>
+</dd>
+  <% end %>
   <% ancestors.each do |c|
-       undefined_instance_methods = @entry.partitioned_entries.undefined.select(&:instance_method?)
        methods = c.partitioned_entries(@alevel).instance_methods
          .flat_map { |m| m.names.map { |n| [n, m] } }
-         .reject { |name,| displayed_methods.include?(name) }
+         .reject { |name,| displayed_instance_methods.include?(name) }
          .reject { |name,| undefined_instance_methods.any? { |m| m.names.include?(name) } }
          .sort
        next if methods.empty? %>
@@ -166,7 +187,7 @@ displayed_methods = Set.new(ents.instance_methods.flat_map(&:names))
   <ul class="class-toc">
     <% methods.each do |name, m| %>
       <li><%= method_link(m.spec_string, name) %></li>
-      <% displayed_methods << name %>
+      <% displayed_instance_methods << name %>
     <% end %>
   </ul>
 </dd>

--- a/test/test_class_screen.rb
+++ b/test/test_class_screen.rb
@@ -1,0 +1,82 @@
+require 'test/unit'
+require 'bitclust'
+require 'bitclust/screen'
+
+class TestClassScreen < Test::Unit::TestCase
+  SRC = <<'HERE'
+= class Base < Object
+base class
+== Class Methods
+--- base_class_method
+base class method
+--- shared_name
+shared name
+--- hidden_class_method
+hidden class method
+== Instance Methods
+--- base_instance_method
+base instance method
+= module Mixin
+mixin module
+== Class Methods
+--- mixin_class_method
+mixin class method
+== Instance Methods
+--- mixin_instance_method
+mixin instance method
+= class Sub < Base
+include Mixin
+sub class
+== Class Methods
+--- sub_class_method
+sub class method
+--- hidden_class_method
+@undef
+== Instance Methods
+--- shared_name
+@undef
+HERE
+
+  def setup
+    @lib, = BitClust::RRDParser.parse(SRC, 'testlib')
+    datadir = File.expand_path('../data/bitclust', __dir__)
+    manager = BitClust::ScreenManager.new(
+      :templatedir => "#{datadir}/template.offline",
+      :catalogdir => "#{datadir}/catalog",
+      :encoding => 'utf-8',
+      :default_encoding => 'utf-8',
+      :base_url => '',
+      :target_version => '3.4'
+    )
+    db = BitClust::MethodDatabase.dummy('version' => '3.4')
+    @html = manager.class_screen(@lib.fetch_class('Sub'), :database => db).body
+  end
+
+  def test_ancestor_singleton_methods_are_displayed
+    assert_include(@html, 'Baseから継承している特異メソッド')
+    assert_include(@html, 'base_class_method')
+  end
+
+  def test_module_singleton_methods_are_not_inherited
+    # A class does not inherit singleton methods from included modules.
+    assert_not_include(@html, 'Mixinから継承している特異メソッド')
+    assert_not_include(@html, 'mixin_class_method')
+  end
+
+  def test_undefined_singleton_method_is_hidden
+    assert_not_include(@html, 'hidden_class_method')
+  end
+
+  def test_undefined_instance_method_does_not_hide_singleton_method
+    # Sub undefs the *instance* method shared_name; the inherited singleton
+    # method of the same name must still be listed.
+    assert_include(@html, 'shared_name')
+  end
+
+  def test_ancestor_instance_methods_include_modules
+    assert_include(@html, 'Baseから継承しているメソッド')
+    assert_include(@html, 'base_instance_method')
+    assert_include(@html, 'Mixinから継承しているメソッド')
+    assert_include(@html, 'mixin_instance_method')
+  end
+end


### PR DESCRIPTION
## 問題

クラスページの「継承しているメソッド」にはインスタンスメソッドしか表示されず、
親クラスから継承している特異メソッド（例: File ページの IO.read / IO.foreach）が
どこにも載っていません（https://github.com/rurema/doctree/issues/2365 ）。

#148 (@pocke さん) が同じ問題に取り組んでいましたが、6 年経過して master と
コンフリクトしており、レビューで以下の 2 点の問題も見つかったため、
本 PR で置き換えます（supersedes #148）。

## #148 からの修正点

1. **include したモジュールを除外**: `@entry.ancestors` には include した
   モジュール（Enumerable 等）も含まれますが、Ruby ではクラスは include した
   モジュールの特異メソッドを継承しません。#148 のまま入れると String ページに
   「Comparableから継承している特異メソッド」のような誤った節が出るため、
   特異メソッドのループはスーパークラス系列（`select(&:class?)`、
   `extended_modules` と同じイディオム）に限定しました。
2. **undef 判定の型別フィルタ**: #148 は `partitioned_entries.undefined` を
   型で絞らず名前照合していたため、undef された「インスタンス」メソッドと
   同名の継承特異メソッドが誤って隠れます。master で既にインスタンス側が
   `.select(&:instance_method?)` に修正済みのパターンに合わせ、特異側は
   `.select(&:singleton_method?)` を使います。

併せて、ループ不変だった `@entry.partitioned_entries.undefined` の計算を
祖先ごとのループの外に括り出し、`displayed_methods` は
`displayed_instance_methods` / `displayed_singleton_methods` にリネームしました
（#148 と同じリネーム）。節の並びは Index と同じく特異→インスタンスの順です。

## テスト・検証（TDD）

- 新規 `test/test_class_screen.rb`: `template.offline/class` を実際に描画して
  検証する 5 テスト（継承特異メソッドの表示・モジュール非継承・undef 型別
  フィルタ・インスタンス側の回帰ガード）。実装前は表示系 2 件が red。
- フルスイート: 17,544 tests / 17,886 assertions、100% passed。
- 実 DB（3.4）での描画確認:
  - File ページに「IOから継承している特異メソッド」13 件
    （binread, binwrite, copy_stream, for_fd, foreach, pipe, popen, read,
    readlines, select, sysopen, try_convert, write）が表示。
  - Enumerable は「継承しているメソッド」（インスタンス側）のみに出て、
    特異メソッド側には出ない。
  - ArgumentError ページに「Exceptionから継承している特異メソッド」が表示。
  - Kernel / Comparable（モジュール）、Object / BasicObject / Class / String /
    Data も描画エラーなし。

Close https://github.com/rurema/doctree/issues/2365
Supersedes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
