### PR TITLE
Add statichtml --eol-warning to show an EOL banner

### DIFF
--- a/data/bitclust/catalog/ja_JP.UTF-8
+++ b/data/bitclust/catalog/ja_JP.UTF-8
@@ -62,6 +62,8 @@ Library
 ライブラリ
 Library Index
 ライブラリ一覧
+Latest version
+最新版のマニュアルへ
 Math
 数学
 Method
@@ -104,6 +106,8 @@ Text
 テキスト
 Thread
 スレッド
+This reference manual is for a version of Ruby that is no longer maintained.
+このマニュアルは既にメンテナンスが終了したバージョンの Ruby を対象としています。
 ancestors
 クラス・モジュールの継承リスト
 class %s

--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -23,6 +23,12 @@
 <script src="<%=h custom_js_url('js/search_init.js') %>"></script>
 </head>
 <body>
+<% if eol_warning?() %>
+<p class="eol-warning">
+<%= _('This reference manual is for a version of Ruby that is no longer maintained.') %>
+<a href="https://docs.ruby-lang.org/ja/latest/"><%= _('Latest version') %></a>
+</p>
+<% end %>
 <div id="rurema-topbar">
   <div id="rurema-brand"><%= manual_home_link %></div>
   <div id="search-section" role="search">

--- a/data/bitclust/template/layout
+++ b/data/bitclust/template/layout
@@ -13,6 +13,12 @@
   <link rel="search" type="application/opensearchdescription+xml" title="<%= _('Ruby %s Reference Manual', ruby_version()) %>" href="<%=h opensearchdescription_url() %>">
 </head>
 <body>
+<% if eol_warning?() %>
+<p class="eol-warning">
+<%= _('This reference manual is for a version of Ruby that is no longer maintained.') %>
+<a href="https://docs.ruby-lang.org/ja/latest/"><%= _('Latest version') %></a>
+</p>
+<% end %>
 <%= yield %>
 <div id="footer">
   <a rel="license" href="https://creativecommons.org/licenses/by/3.0/">

--- a/lib/bitclust/screen.rb
+++ b/lib/bitclust/screen.rb
@@ -314,6 +314,12 @@ module BitClust
       %Q(<meta name="description" content="">)
     end
 
+    # True when the build was told (via statichtml --eol-warning) that the
+    # documented Ruby version is no longer maintained.
+    def eol_warning?
+      !!@conf[:eol_warning]
+    end
+
     private
 
     def default_encoding

--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -121,6 +121,7 @@ module BitClust
         @gtm_tracking_id = nil
         @meta_robots_content = ["noindex"]
         @stop_on_syntax_error = true
+        @eol_warning = false
         @parser.banner = "Usage: #{File.basename($0, '.*')} statichtml [options]"
         @parser.on('-o', '--outputdir=PATH', 'Output directory') do |path|
           begin
@@ -156,6 +157,9 @@ module BitClust
         end
         @parser.on('--meta-robots-content=VALUE1,VALUE2,...', Array, 'HTML <meta> element: <meta name="robots" content="VALUE1,VALUE2..."') do |values|
           @meta_robots_content = values
+        end
+        @parser.on('--[no-]eol-warning', 'Show a warning banner that this Ruby version is no longer maintained') do |boolean|
+          @eol_warning = boolean
         end
         @parser.on('--no-stop-on-syntax-error', 'Do not stop on syntax error') do |boolean|
           @stop_on_syntax_error = boolean
@@ -242,6 +246,7 @@ module BitClust
           :gtm_tracking_id => @gtm_tracking_id,
           :meta_robots_content => @meta_robots_content,
           :stop_on_syntax_error => @stop_on_syntax_error,
+          :eol_warning => @eol_warning,
         }
         @manager_config[:urlmapper] = URLMapperEx.new(@manager_config)
         @urlmapper = @manager_config[:urlmapper]

--- a/sig/bitclust/screen.rbs
+++ b/sig/bitclust/screen.rbs
@@ -245,6 +245,8 @@ module BitClust
 
     def meta_description: () -> String
 
+    def eol_warning?: () -> bool
+
     private
 
     def default_encoding: () -> String

--- a/sig/bitclust/subcommands/statichtml_command.rbs
+++ b/sig/bitclust/subcommands/statichtml_command.rbs
@@ -23,6 +23,8 @@ module BitClust
 
       @stop_on_syntax_error: bool
 
+      @eol_warning: bool
+
       @outputdir: Pathname
 
       type manager_config = {

--- a/test/test_eol_warning.rb
+++ b/test/test_eol_warning.rb
@@ -1,0 +1,43 @@
+require 'test/unit'
+require 'bitclust'
+require 'bitclust/screen'
+
+class TestEOLWarning < Test::Unit::TestCase
+  SRC = <<'HERE'
+= class Hoge
+hoge class
+== Instance Methods
+--- foo
+foo method
+HERE
+
+  BANNER_TEXT = 'このマニュアルは既にメンテナンスが終了したバージョンの Ruby を対象としています。'
+  LATEST_URL = 'https://docs.ruby-lang.org/ja/latest/'
+
+  def render(manager_options)
+    lib, = BitClust::RRDParser.parse(SRC, 'testlib')
+    datadir = File.expand_path('../data/bitclust', __dir__)
+    manager = BitClust::ScreenManager.new({
+      :templatedir => "#{datadir}/template.offline",
+      :catalogdir => "#{datadir}/catalog",
+      :encoding => 'utf-8',
+      :default_encoding => 'utf-8',
+      :base_url => '',
+      :target_version => '3.0'
+    }.merge(manager_options))
+    db = BitClust::MethodDatabase.dummy('version' => '3.0')
+    manager.class_screen(lib.fetch_class('Hoge'), :database => db).body
+  end
+
+  def test_eol_warning_banner_is_shown_when_enabled
+    html = render(:eol_warning => true)
+    assert_include(html, BANNER_TEXT)
+    assert_include(html, LATEST_URL)
+  end
+
+  def test_eol_warning_banner_is_hidden_by_default
+    html = render({})
+    assert_not_include(html, BANNER_TEXT)
+    assert_not_include(html, LATEST_URL)
+  end
+end

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -406,6 +406,18 @@ hr {
  right: 10px;
 }
 
+.eol-warning {
+    background-color: #aa3333;
+    color: white;
+    padding: 0.4em;
+    margin: 0;
+}
+
+.eol-warning a {
+    color: white;
+    text-decoration: underline;
+}
+
 @media only screen and (max-width:425px) {
     table.entries tr {
         display: block;


### PR DESCRIPTION
## 問題

EOL になった Ruby バージョンのリファレンスを見ていることに読者が気づけません。
#184 (@kyanagi さん) が警告バナーで対応していましたが、レビューで 3 点の問題が
見つかったため、本 PR で置き換えます（supersedes #184）。

1. #184 がバナーを入れたのは `template/layout`（`bitclust server` 用）のみで、
   本番静的サイトが使う `template.offline/layout` には入っておらず、
   docs.ruby-lang.org には警告が表示されない
2. `MINIMUM_SUPPORTED_RUBY_VERSION = '3.1'` のハードコードが既に陳腐化
   （3.2 も 2026-04 に EOL 済み）。EOL のたびに bitclust の修正とリリースが必要
3. `/\A\d(\.\d)+\z/` は "3.10" にマッチせず、文字列比較も `'3.9' < '3.10'` が
   false になるため、将来サイレントに機能停止する

## 方針

「どの版が EOL か」は bitclust ではなくビルドオーケストレータ
（doctree Rakefile / generated-documents）が知るべき情報なので、
statichtml に `--[no-]eol-warning` オプションを追加し、
**EOL 判定はビルド側の責務**としました。statichtml は 1 回の起動で
1 バージョンを生成するため boolean で足り、bitclust 側には
バージョン比較ロジックもしきい値も持ちません（上記 2・3 が構造的に解消）。

バナーの文言・CSS は #184 のものを踏襲しています。変更点:

- 両方のレイアウト（`template.offline/layout` と `template/layout`）に表示
- リンク先を https://docs.ruby-lang.org/ja/latest/ に変更
  （同じリファレンスの最新版へ誘導。`--canonical-base-url` とも一貫）
- リンクラベルの訳語は「最新版のマニュアルへ」（#184 の「最新版URL」から変更）

ビルド側の対応 PR: rurema/doctree（Rakefile）と rurema/generated-documents
（tool/vars.rb, tool/static_html.rb）に `MINIMUM_SUPPORTED_RUBY_VERSION` 定数と
条件付き `--eol-warning` 付与を追加します。**マージ順は本 PR が先**
（旧 bitclust に `--eol-warning` を渡すと optparse エラーになるため）。

## テスト・検証（TDD）

- 新規 `test/test_eol_warning.rb`: `template.offline` レイアウトを実際に描画し、
  `:eol_warning` 指定時のみバナーが出ることを検証（実装前は red）
- フルスイート: 17,541 tests / 17,880 assertions、100% passed
- `rake sig` / `steep check`: 追加分の RBS（`eol_warning?`・`@eol_warning`）を
  sig/ に追記。master 時点で両タスクとも既存の失敗があり（Markdown 移行分の
  シグネチャ負債、本 PR とは無関係）、本 PR による新規の型エラーはなし
- 実 DB（3.4 検証用 DB）で `statichtml --eol-warning` を実行し、生成された
  class 1,437 / method 10,847 / doc 66 ページ＋ライブラリ索引の全てに
  バナーが入ることを確認。フラグなしでは出ないことも確認

Supersedes #184（マージ後 #184 はクローズしてよいと思います）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
