### PR TITLE
Add statichtml --run-ruby-wasm: RUN button on Ruby sample code

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,13 @@ task :test do
   sh 'ruby test/run_test.rb'
 end
 
+desc "run JS tests (requires qjs / QuickJS)"
+namespace :test do
+  task :js do
+    sh 'qjs', 'test/js/test_run.mjs'
+  end
+end
+
 desc "Re-generate sig/prototype"
 task :sig do
   out_dir = 'sig-prototype'

--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -21,6 +21,10 @@
 <script src="<%=h custom_js_url('js/search_ranker.js') %>"></script>
 <script src="<%=h custom_js_url('js/search_controller.js') %>"></script>
 <script src="<%=h custom_js_url('js/search_init.js') %>"></script>
+<% if run_ruby_wasm_url %>
+<meta name="rurema-run-ruby-wasm" content="<%=h run_ruby_wasm_url %>">
+<script type="module" src="<%=h custom_js_url('js/run.mjs') %>"></script>
+<% end %>
 </head>
 <body>
 <% if eol_warning?() %>

--- a/data/bitclust/template/layout
+++ b/data/bitclust/template/layout
@@ -11,6 +11,10 @@
   <title><%=h @title %> (Ruby <%=h ruby_version %>)</title>
   <meta name="description" content="<%=h @description %>">
   <link rel="search" type="application/opensearchdescription+xml" title="<%= _('Ruby %s Reference Manual', ruby_version()) %>" href="<%=h opensearchdescription_url() %>">
+<% if run_ruby_wasm_url %>
+  <meta name="rurema-run-ruby-wasm" content="<%=h run_ruby_wasm_url %>">
+  <script type="module" src="<%=h custom_js_url('js/run.mjs') %>"></script>
+<% end %>
 </head>
 <body>
 <% if eol_warning?() %>

--- a/lib/bitclust/screen.rb
+++ b/lib/bitclust/screen.rb
@@ -320,6 +320,12 @@ module BitClust
       !!@conf[:eol_warning]
     end
 
+    # URL of the ruby.wasm module used by the in-browser RUN button on Ruby
+    # sample code (statichtml --run-ruby-wasm). nil disables the feature.
+    def run_ruby_wasm_url
+      @conf[:run_ruby_wasm]
+    end
+
     private
 
     def default_encoding

--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -122,6 +122,7 @@ module BitClust
         @meta_robots_content = ["noindex"]
         @stop_on_syntax_error = true
         @eol_warning = false
+        @run_ruby_wasm = nil
         @parser.banner = "Usage: #{File.basename($0, '.*')} statichtml [options]"
         @parser.on('-o', '--outputdir=PATH', 'Output directory') do |path|
           begin
@@ -160,6 +161,9 @@ module BitClust
         end
         @parser.on('--[no-]eol-warning', 'Show a warning banner that this Ruby version is no longer maintained') do |boolean|
           @eol_warning = boolean
+        end
+        @parser.on('--run-ruby-wasm=WASM_URL', 'Add a RUN button to Ruby sample code, executing it in-browser with the given ruby.wasm') do |url|
+          @run_ruby_wasm = url
         end
         @parser.on('--no-stop-on-syntax-error', 'Do not stop on syntax error') do |boolean|
           @stop_on_syntax_error = boolean
@@ -215,6 +219,7 @@ module BitClust
                      @outputdir.to_s, :verbose => @verbose, :preserve => true)
         FileUtils.cp(@manager_config[:themedir] + "script.js",
                      @outputdir.to_s, :verbose => @verbose, :preserve => true)
+        copy_run_ruby_wasm_script if @run_ruby_wasm
         FileUtils.cp(@manager_config[:themedir] + @manager_config[:favicon_url],
                      @outputdir.to_s, :verbose => @verbose, :preserve => true)
         Dir.mktmpdir do |tmpdir|
@@ -247,6 +252,7 @@ module BitClust
           :meta_robots_content => @meta_robots_content,
           :stop_on_syntax_error => @stop_on_syntax_error,
           :eol_warning => @eol_warning,
+          :run_ruby_wasm => @run_ruby_wasm,
         }
         @manager_config[:urlmapper] = URLMapperEx.new(@manager_config)
         @urlmapper = @manager_config[:urlmapper]
@@ -319,6 +325,20 @@ HERE
                      :verbose => @verbose, :preserve => true)
         FileUtils.cp(themedir + "search.css", outputdir.to_s,
                      :verbose => @verbose, :preserve => true)
+      end
+
+      # Copy the RUN-button script (statichtml --run-ruby-wasm). A themedir
+      # without js/run.mjs is tolerated: warn and skip instead of aborting the
+      # whole build.
+      def copy_run_ruby_wasm_script
+        run_mjs = @manager_config[:themedir] + "js" + "run.mjs"
+        unless run_mjs.file?
+          $stderr.puts "warning: #{run_mjs} not found; RUN button script not copied"
+          return
+        end
+        jsdir = @outputdir + "js"
+        FileUtils.mkdir_p(jsdir) unless jsdir.directory?
+        FileUtils.cp(run_mjs.to_s, jsdir.to_s, :verbose => @verbose, :preserve => true)
       end
 
       def create_html_file(entry, manager, outputdir, db)

--- a/sig/bitclust/screen.rbs
+++ b/sig/bitclust/screen.rbs
@@ -247,6 +247,8 @@ module BitClust
 
     def eol_warning?: () -> bool
 
+    def run_ruby_wasm_url: () -> String?
+
     private
 
     def default_encoding: () -> String

--- a/sig/bitclust/subcommands/statichtml_command.rbs
+++ b/sig/bitclust/subcommands/statichtml_command.rbs
@@ -25,6 +25,8 @@ module BitClust
 
       @eol_warning: bool
 
+      @run_ruby_wasm: String?
+
       @outputdir: Pathname
 
       type manager_config = {
@@ -42,6 +44,8 @@ module BitClust
         :gtm_tracking_id => String?,
         :meta_robots_content => Array[String],
         :stop_on_syntax_error => bool,
+        :eol_warning => bool,
+        :run_ruby_wasm => String?,
         ?:urlmapper  => URLMapperEx,
       }
 
@@ -116,6 +120,8 @@ module BitClust
       def create_html_methods: (String title, Hash[String, Array[MethodEntry]] methods, ScreenManager manager, MethodDatabase db) -> void
 
       def create_index_html: (Pathname outputdir) -> void
+
+      def copy_run_ruby_wasm_script: () -> void
 
       def create_html_file: (any_entry entry, ScreenManager manager, Pathname outputdir, Database db) -> void
 

--- a/test/js/test_run.mjs
+++ b/test/js/test_run.mjs
@@ -1,0 +1,84 @@
+// QuickJS-based tests for the pure logic in theme/default/js/run.mjs.
+// Run with: qjs test/js/test_run.mjs   (see the "test:js" rake task)
+// Importing the module doubles as a syntax/eval smoke test: its DOM setup is
+// guarded by `typeof window !== 'undefined'`.
+import { createOnceLoader, PRELUDE, formatRunError, truncateOutput } from '../../theme/default/js/run.mjs'
+
+let failures = 0
+function assert(cond, message) {
+  if (cond) {
+    print('ok: ' + message)
+  } else {
+    failures++
+    print('FAIL: ' + message)
+  }
+}
+
+// createOnceLoader: repeated calls share one load
+{
+  let calls = 0
+  const loader = createOnceLoader(async () => { calls++; return 'value' })
+  const [a, b] = [await loader(), await loader()]
+  assert(a === 'value' && b === 'value' && calls === 1,
+         'createOnceLoader loads once for repeated calls')
+}
+
+// createOnceLoader: concurrent calls share one in-flight promise
+{
+  let calls = 0
+  const loader = createOnceLoader(async () => { calls++; return calls })
+  const [a, b] = await Promise.all([loader(), loader()])
+  assert(a === 1 && b === 1 && calls === 1,
+         'createOnceLoader shares an in-flight load')
+}
+
+// createOnceLoader: a rejected load is retried on the next call
+// (regression test for the old draft's dataset.loading permadeath bug)
+{
+  let calls = 0
+  const loader = createOnceLoader(async () => {
+    await 0 // reject asynchronously, like a real network failure (also keeps
+            // this qjs build's unhandled-rejection tracker quiet)
+    calls++
+    if (calls === 1) throw new Error('network down')
+    return 'recovered'
+  })
+  let firstError = null
+  try { await loader() } catch (e) { firstError = e }
+  const second = await loader()
+  assert(firstError !== null && firstError.message === 'network down',
+         'first failing load rejects')
+  assert(second === 'recovered' && calls === 2,
+         'next call after a rejection retries the load')
+}
+
+// PRELUDE captures both streams into one StringIO
+assert(PRELUDE.includes('require "stringio"') &&
+       PRELUDE.includes('$stdout = StringIO.new') &&
+       PRELUDE.includes('$stderr = $stdout'),
+       'PRELUDE redirects $stdout and $stderr into one StringIO')
+
+// formatRunError
+assert(formatRunError(new Error('boom')) === 'boom',
+       'formatRunError uses error.message')
+assert(formatRunError('plain') === 'plain',
+       'formatRunError accepts non-Error values')
+{
+  const long = Array.from({ length: 30 }, (_, i) => 'line' + i).join('\n')
+  const formatted = formatRunError(new Error(long))
+  assert(formatted.split('\n').length === 20,
+         'formatRunError caps long messages at 20 lines')
+}
+
+// truncateOutput
+assert(truncateOutput('short') === 'short', 'truncateOutput keeps short output')
+{
+  const truncated = truncateOutput('x'.repeat(100), 10)
+  assert(truncated.startsWith('x'.repeat(10)) && truncated.endsWith('... (truncated)'),
+         'truncateOutput cuts long output with a marker')
+}
+
+if (failures > 0) {
+  throw new Error(failures + ' JS test(s) failed')
+}
+print('all JS tests passed')

--- a/test/test_run_ruby_wasm.rb
+++ b/test/test_run_ruby_wasm.rb
@@ -1,0 +1,54 @@
+require 'test/unit'
+require 'bitclust'
+require 'bitclust/screen'
+
+class TestRunRubyWasm < Test::Unit::TestCase
+  SRC = <<'HERE'
+= class Hoge
+hoge class
+== Instance Methods
+--- foo
+foo method
+HERE
+
+  WASM_URL = 'https://cdn.jsdelivr.net/npm/@ruby/3.4-wasm-wasi@2.9.3-2.9.4/dist/ruby+stdlib.wasm'
+  META_TAG = %Q(<meta name="rurema-run-ruby-wasm" content="#{WASM_URL}">)
+
+  def render(manager_options)
+    lib, = BitClust::RRDParser.parse(SRC, 'testlib')
+    datadir = File.expand_path('../data/bitclust', __dir__)
+    manager = BitClust::ScreenManager.new({
+      :templatedir => "#{datadir}/template.offline",
+      :catalogdir => "#{datadir}/catalog",
+      :encoding => 'utf-8',
+      :default_encoding => 'utf-8',
+      :base_url => '',
+      :target_version => '3.4'
+    }.merge(manager_options))
+    db = BitClust::MethodDatabase.dummy('version' => '3.4')
+    manager.class_screen(lib.fetch_class('Hoge'), :database => db).body
+  end
+
+  def test_run_script_is_loaded_when_enabled
+    html = render(:run_ruby_wasm => WASM_URL)
+    assert_include(html, META_TAG)
+    assert_include(html, 'js/run.mjs')
+  end
+
+  def test_run_script_is_not_loaded_by_default
+    html = render({})
+    assert_not_include(html, 'rurema-run-ruby-wasm')
+    assert_not_include(html, 'run.mjs')
+  end
+
+  def test_wasm_url_is_html_escaped
+    html = render(:run_ruby_wasm => 'https://example.com/ruby.wasm?a=1&b="x"')
+    assert_include(html, 'content="https://example.com/ruby.wasm?a=1&amp;b=&quot;x&quot;"')
+  end
+
+  def test_coexists_with_eol_warning
+    html = render(:run_ruby_wasm => WASM_URL, :eol_warning => true)
+    assert_include(html, META_TAG)
+    assert_include(html, 'class="eol-warning"')
+  end
+end

--- a/test/test_statichtml_command.rb
+++ b/test/test_statichtml_command.rb
@@ -1,4 +1,6 @@
 require 'test/unit'
+require 'tmpdir'
+require 'stringio'
 require 'bitclust'
 require 'bitclust/subcommands/statichtml_command'
 
@@ -24,5 +26,58 @@ class TestStatichtmlURLMapperEx < Test::Unit::TestCase
     location = BitClust::Location.new('refm/api/src/_builtin/Array', nil)
     assert_equal('https://github.com/rurema/doctree/edit/master/refm/api/src/_builtin/Array',
                  @urlmapper.edit_url(location))
+  end
+end
+
+class TestStatichtmlRunRubyWasm < Test::Unit::TestCase
+  def build_command(themedir, outputdir)
+    cmd = BitClust::Subcommands::StatichtmlCommand.new
+    cmd.instance_variable_set(:@manager_config, { :themedir => Pathname.new(themedir) })
+    cmd.instance_variable_set(:@outputdir, Pathname.new(outputdir))
+    cmd.instance_variable_set(:@verbose, false)
+    cmd
+  end
+
+  def test_option_defaults_to_nil
+    cmd = BitClust::Subcommands::StatichtmlCommand.new
+    assert_nil(cmd.instance_variable_get(:@run_ruby_wasm))
+  end
+
+  def test_option_is_parsed
+    url = 'https://cdn.jsdelivr.net/npm/@ruby/3.4-wasm-wasi@2.9.3-2.9.4/dist/ruby+stdlib.wasm'
+    cmd = BitClust::Subcommands::StatichtmlCommand.new
+    cmd.parse(["--run-ruby-wasm=#{url}"])
+    assert_equal(url, cmd.instance_variable_get(:@run_ruby_wasm))
+  end
+
+  def test_run_mjs_is_copied
+    Dir.mktmpdir do |dir|
+      themedir = File.join(dir, 'theme')
+      outputdir = File.join(dir, 'out')
+      FileUtils.mkdir_p(File.join(themedir, 'js'))
+      FileUtils.mkdir_p(outputdir)
+      File.write(File.join(themedir, 'js', 'run.mjs'), "// run\n")
+      cmd = build_command(themedir, outputdir)
+      cmd.send(:copy_run_ruby_wasm_script)
+      assert_true(File.file?(File.join(outputdir, 'js', 'run.mjs')))
+    end
+  end
+
+  def test_theme_without_run_mjs_is_tolerated
+    Dir.mktmpdir do |dir|
+      themedir = File.join(dir, 'theme')
+      outputdir = File.join(dir, 'out')
+      FileUtils.mkdir_p(themedir)
+      FileUtils.mkdir_p(outputdir)
+      cmd = build_command(themedir, outputdir)
+      orig_stderr, $stderr = $stderr, StringIO.new
+      begin
+        assert_nothing_raised { cmd.send(:copy_run_ruby_wasm_script) }
+        assert_match(/run\.mjs not found/, $stderr.string)
+      ensure
+        $stderr = orig_stderr
+      end
+      assert_false(File.exist?(File.join(outputdir, 'js', 'run.mjs')))
+    end
   end
 end

--- a/theme/default/js/run.mjs
+++ b/theme/default/js/run.mjs
@@ -1,0 +1,165 @@
+// RUN button for Ruby sample code: executes the sample in-browser with
+// ruby.wasm. Enabled per page via
+//   <meta name="rurema-run-ruby-wasm" content="<ruby+stdlib.wasm URL>">
+// which the layout emits when statichtml was invoked with --run-ruby-wasm.
+// The wasm URL is chosen by the build side to match the documented Ruby
+// version; this file only pins the loader library.
+
+// Exact pin of the npm "latest" dist-tag at the time of writing. Note the
+// version scheme: stable @ruby/* packages are published as
+// "<pkg version>-<ruby.wasm version>" (e.g. 2.9.3-2.9.4); plain "2.9.4"
+// does not exist on npm.
+const VM_ESM_URL = 'https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.9.3-2.9.4/dist/browser/+esm'
+const OUTPUT_LIMIT = 64 * 1024
+
+// Wrap an async loader so concurrent and repeated calls share one in-flight
+// promise, while a rejected attempt clears the cache so the next call
+// retries instead of staying broken forever.
+export function createOnceLoader(loadFn) {
+  let cached
+  return function () {
+    if (!cached) {
+      cached = (async () => {
+        try {
+          return await loadFn()
+        } catch (error) {
+          cached = undefined
+          throw error
+        }
+      })()
+    }
+    return cached
+  }
+}
+
+// Collect $stdout/$stderr into one StringIO so the output can be read back
+// after eval; sharing one StringIO preserves stdout/stderr interleaving.
+export const PRELUDE = 'require "stringio"; $stdout = StringIO.new; $stderr = $stdout'
+
+export function formatRunError(error) {
+  const text = String((error && error.message) || error)
+  return text.split('\n').slice(0, 20).join('\n')
+}
+
+export function truncateOutput(text, limit = OUTPUT_LIMIT) {
+  if (text.length <= limit) return text
+  return text.slice(0, limit) + '\n... (truncated)'
+}
+
+// One runner per page: the wasm module is compiled once and cached, but each
+// run gets a fresh VM so samples never see each other's state. `running`
+// keeps a single VM alive at a time; a run attempted meanwhile returns null.
+function createRunner(wasmUrl) {
+  const loadModule = createOnceLoader(async () => {
+    const [{ DefaultRubyVM }, module] = await Promise.all([
+      import(VM_ESM_URL),
+      WebAssembly.compileStreaming(fetch(wasmUrl)).catch(async () => {
+        // Retry without streaming for servers that send a non-wasm MIME type
+        // (e.g. `ruby -run -e httpd` when testing locally).
+        const response = await fetch(wasmUrl)
+        return WebAssembly.compile(await response.arrayBuffer())
+      }),
+    ])
+    return { DefaultRubyVM, module }
+  })
+  let running = false
+  return async function run(code, onLoaded) {
+    if (running) return null
+    running = true
+    try {
+      const { DefaultRubyVM, module } = await loadModule()
+      if (onLoaded) onLoaded()
+      const { vm } = await DefaultRubyVM(module, { consolePrint: false })
+      vm.eval(PRELUDE)
+      let error = null
+      try {
+        vm.eval(code)
+      } catch (e) {
+        error = formatRunError(e)
+      }
+      const output = vm.eval('$stdout.string').toString()
+      return { output: truncateOutput(output), error }
+    } finally {
+      running = false
+    }
+  }
+}
+
+function setupBlock(pre, run) {
+  const code = pre.querySelector('code')
+  if (!code) return
+
+  const button = document.createElement('button')
+  button.type = 'button'
+  button.className = 'highlight__run-button'
+  button.textContent = 'RUN'
+  // script.js has already prepended the COPY button (its window.onload
+  // handler fires before our load listener); keep COPY rightmost.
+  const copyButton = pre.querySelector('.highlight__copy-button')
+  if (copyButton) {
+    copyButton.after(button)
+  } else {
+    pre.prepend(button)
+  }
+
+  let output
+  const ensureOutput = () => {
+    if (!output) {
+      output = document.createElement('pre')
+      output.className = 'highlight__run-output'
+      output.setAttribute('aria-live', 'polite')
+      pre.after(output)
+    }
+    return output
+  }
+
+  const execute = async () => {
+    if (button.disabled) return
+    button.disabled = true
+    button.setAttribute('aria-busy', 'true')
+    button.textContent = 'LOADING...'
+    const out = ensureOutput()
+    out.classList.remove('highlight__run-output--error')
+    out.textContent = ''
+    let label = 'RUN'
+    try {
+      const result = await run(code.textContent, () => {
+        button.textContent = 'RUNNING...'
+      })
+      if (result) {
+        out.textContent = result.error
+          ? (result.output === '' ? result.error : result.output + '\n' + result.error)
+          : result.output
+        if (result.error) out.classList.add('highlight__run-output--error')
+      }
+    } catch (e) {
+      out.classList.add('highlight__run-output--error')
+      out.textContent = formatRunError(e)
+      label = 'RETRY'
+    } finally {
+      button.textContent = label
+      button.disabled = false
+      button.removeAttribute('aria-busy')
+    }
+  }
+  button.addEventListener('click', execute)
+}
+
+function init() {
+  const meta = document.querySelector('meta[name="rurema-run-ruby-wasm"]')
+  if (!meta || !meta.content) return
+  const blocks = document.querySelectorAll('pre.highlight.ruby')
+  if (blocks.length === 0) return
+  const run = createRunner(meta.content)
+  blocks.forEach((pre) => setupBlock(pre, run))
+}
+
+// Guarded so the module stays side-effect-free outside a browser
+// (test/js/test_run.mjs imports it under QuickJS).
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  if (document.readyState === 'complete') {
+    init()
+  } else {
+    window.addEventListener('load', init)
+  }
+}

--- a/theme/default/js/run.mjs
+++ b/theme/default/js/run.mjs
@@ -113,6 +113,23 @@ function setupBlock(pre, run) {
     return output
   }
 
+  // After the first run the sample becomes editable (like a scratchpad);
+  // Ctrl+Enter (or Cmd+Enter) re-runs the edited code. Editing gradually
+  // loses the syntax-highlight spans; the COPY button keeps copying the
+  // original text.
+  const enableEditing = () => {
+    if (code.isContentEditable) return
+    code.contentEditable = 'true'
+    code.spellcheck = false
+    pre.dataset.editing = 'true'
+    pre.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+        event.preventDefault()
+        execute()
+      }
+    })
+  }
+
   const execute = async () => {
     if (button.disabled) return
     button.disabled = true
@@ -131,6 +148,7 @@ function setupBlock(pre, run) {
           ? (result.output === '' ? result.error : result.output + '\n' + result.error)
           : result.output
         if (result.error) out.classList.add('highlight__run-output--error')
+        enableEditing()
       }
     } catch (e) {
       out.classList.add('highlight__run-output--error')

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -173,6 +173,16 @@ pre.highlight {
 .highlight__run-output--error {
   color: #a00;
 }
+pre.highlight.ruby[data-editing="true"]:focus-within {
+  outline: auto;
+}
+pre.highlight.ruby[data-editing="true"] > code {
+  display: inline-block;
+  width: 100%;
+}
+pre.highlight.ruby[data-editing="true"] > code:focus {
+  outline: none;
+}
 
 /* for COPY */
 .highlight__copy-button {

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -142,6 +142,38 @@ pre.highlight {
     position: relative;
 }
 
+/* for RUN (js/run.mjs, statichtml --run-ruby-wasm) */
+.highlight__run-button {
+  float: right;
+  margin: 0 0 0.25em 0.5em;
+  padding: 0.25em 0.5em;
+  background-color: #DDD;
+  opacity: 0.75;
+  cursor: pointer;
+  border: 0;
+  font: inherit;
+}
+.highlight__run-button:hover {
+  background-color: #EE8;
+  opacity: 1;
+}
+.highlight__run-button[disabled] {
+  background-color: #070;
+  color: white;
+  opacity: 1;
+  cursor: wait;
+}
+.highlight__run-output {
+  width: 100%;
+  box-sizing: border-box;
+  background-color: #f2f2f2;
+  margin-top: 0;
+  white-space: pre-wrap;
+}
+.highlight__run-output--error {
+  color: #a00;
+}
+
 /* for COPY */
 .highlight__copy-button {
   float: right;


### PR DESCRIPTION
## 概要

Ruby のサンプルコードブロックに RUN ボタンを追加し、ruby.wasm でブラウザ内
実行できるようにします。#177 (@hanachin さん、2022 年 draft) のアイデアの
再実装です（supersedes #177）。

`statichtml --run-ruby-wasm=WASM_URL` を指定したビルドでのみ有効になります。
どの版でどの ruby.wasm を使うか（使わないか）はビルドオーケストレータの
責務です（#215 の `--eol-warning` と同じ分担。doctree / generated-documents
の対応 PR で 3.2〜4.0 に版一致の wasm を指定し、wasm ビルドが存在しない
3.1 以前・凍結版・未リリース版はボタンなしのまま）。

動作: 各 `pre.highlight.ruby` に RUN ボタンが付き（COPY の左）、クリックで
ruby.wasm をロード（初回のみ、~30MB gzip・ブラウザキャッシュ）→ サンプルを
実行 → 直下の出力欄に stdout/stderr を表示。例外はエラー表示。実行後は
コードが編集可能になり Ctrl+Enter / Cmd+Enter で再実行できます（2 コミット目、
分離可能）。

## #177 draft からの主な変更

| #177 の問題 | 本 PR |
|---|---|
| 改名前パッケージ `ruby-wasm-wasi`@latest を CDN 参照（未固定・改名済で化石化） | 現行 `@ruby/wasm-wasi` / `@ruby/X.Y-wasm-wasi` を**完全バージョン固定**で参照。@latest なし。wasm URL は版ごとにビルド側が注入 |
| `dataset.loading = false` が文字列 "false"（truthy）になり、ロード失敗後ボタンが恒久無反応 | 状態は closure 内の実 boolean のみ。ロード失敗はモジュールキャッシュを破棄して **RETRY 可能**（qjs で回帰テスト済み） |
| ブロックごとに VM 生成＋fs.writeSync 多重モンキーパッチ（メモリ膨張・出力混線） | wasm module は 1 回だけ compile、**実行ごとに新規 VM**（状態リーク構造的に不可）。出力は Ruby 側 StringIO プレリュードで回収（安定 API のみ使用） |
| run.mjs が無いテーマで FileUtils.cp が ENOENT → ビルド全体が落ちる | warning を出して skip |
| server 用 layout のみ修正 | template.offline / template の両 layout 対応 |

## テスト・検証（TDD）

- `test/test_run_ruby_wasm.rb`（新規）: meta タグ・module script が指定時のみ
  出ること、URL の HTML エスケープ、`--eol-warning` との共存（実装前 red）
- `test/test_statichtml_command.rb` 拡張: オプションパース・run.mjs コピー・
  テーマに無い場合の warning+skip
- `test/js/test_run.mjs`（新規、QuickJS で実行、`rake test:js`）:
  createOnceLoader の「1 回だけロード」「並行呼び出しの共有」「**失敗後の
  リトライ**」、PRELUDE、formatRunError、truncateOutput。default タスクには
  入れていません（qjs は宣言済み依存ではないため。CI に入れる場合は
  quickjs のインストールが必要）
- フルスイート: 17,554 tests / 17,903 assertions、100% passed
- 実 DB（3.4）E2E: `--run-ruby-wasm` 付き statichtml で 12,719 ページ全てに
  meta タグ＋`js/run.mjs` 配置を確認。フラグなしでは一切出ないことも確認

## ブラウザでの手動確認手順（この後どなたかお願いします）

```bash
bundle exec bitclust --database=/tmp/db-3.4 statichtml \
  --outputdir=/tmp/run-html --templatedir=data/bitclust/template.offline \
  --catalog=data/bitclust/catalog \
  --run-ruby-wasm='https://cdn.jsdelivr.net/npm/@ruby/3.4-wasm-wasi@2.9.3-2.9.4/dist/ruby+stdlib.wasm'
ruby -run -e httpd /tmp/run-html -p 8000
```

- class/Array.html 等で RUN が COPY の左に出る（C API ページには出ない）
- 初回 RUN → LOADING...（wasm DL）→ 出力が `# =>` コメントと一致
- COPY の内容にボタン文言・出力が混入しない
- DevTools で Offline → RUN → RETRY 表示 → Online → RETRY で成功（リトライ回帰）
- 例外を投げるサンプルはエラー表示（赤字）
- 実行後に編集 → Ctrl+Enter で再実行
- 連打で二重実行しない

## 既知の制約（v1 スコープ）

- `sleep` や無限ループのサンプルは同期実行のためタブをブロックします
  （将来 Web Worker 化で改善可。`gets` は即 nil）
- ファイル・ネットワーク依存のサンプルは例外表示になります（仕様）
- 編集するとシンタックスハイライトの span が徐々に崩れます。COPY は元の
  テキストのままです
- docs.ruby-lang.org に将来 CSP を導入する場合は cdn.jsdelivr.net と
  `wasm-unsafe-eval` の許可が必要です

Supersedes #177（マージ後クローズしてよいと思います）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
