### PR TITLE
Rename js/run.mjs to js/run.js to survive strict MIME checking

### DIFF
--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -23,7 +23,7 @@
 <script src="<%=h custom_js_url('js/search_init.js') %>"></script>
 <% if run_ruby_wasm_url %>
 <meta name="rurema-run-ruby-wasm" content="<%=h run_ruby_wasm_url %>">
-<script type="module" src="<%=h custom_js_url('js/run.mjs') %>"></script>
+<script type="module" src="<%=h custom_js_url('js/run.js') %>"></script>
 <% end %>
 </head>
 <body>

--- a/data/bitclust/template/layout
+++ b/data/bitclust/template/layout
@@ -13,7 +13,7 @@
   <link rel="search" type="application/opensearchdescription+xml" title="<%= _('Ruby %s Reference Manual', ruby_version()) %>" href="<%=h opensearchdescription_url() %>">
 <% if run_ruby_wasm_url %>
   <meta name="rurema-run-ruby-wasm" content="<%=h run_ruby_wasm_url %>">
-  <script type="module" src="<%=h custom_js_url('js/run.mjs') %>"></script>
+  <script type="module" src="<%=h custom_js_url('js/run.js') %>"></script>
 <% end %>
 </head>
 <body>

--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -328,17 +328,17 @@ HERE
       end
 
       # Copy the RUN-button script (statichtml --run-ruby-wasm). A themedir
-      # without js/run.mjs is tolerated: warn and skip instead of aborting the
+      # without js/run.js is tolerated: warn and skip instead of aborting the
       # whole build.
       def copy_run_ruby_wasm_script
-        run_mjs = @manager_config[:themedir] + "js" + "run.mjs"
-        unless run_mjs.file?
-          $stderr.puts "warning: #{run_mjs} not found; RUN button script not copied"
+        run_js = @manager_config[:themedir] + "js" + "run.js"
+        unless run_js.file?
+          $stderr.puts "warning: #{run_js} not found; RUN button script not copied"
           return
         end
         jsdir = @outputdir + "js"
         FileUtils.mkdir_p(jsdir) unless jsdir.directory?
-        FileUtils.cp(run_mjs.to_s, jsdir.to_s, :verbose => @verbose, :preserve => true)
+        FileUtils.cp(run_js.to_s, jsdir.to_s, :verbose => @verbose, :preserve => true)
       end
 
       def create_html_file(entry, manager, outputdir, db)

--- a/test/js/test_run.mjs
+++ b/test/js/test_run.mjs
@@ -1,8 +1,8 @@
-// QuickJS-based tests for the pure logic in theme/default/js/run.mjs.
+// QuickJS-based tests for the pure logic in theme/default/js/run.js.
 // Run with: qjs test/js/test_run.mjs   (see the "test:js" rake task)
 // Importing the module doubles as a syntax/eval smoke test: its DOM setup is
 // guarded by `typeof window !== 'undefined'`.
-import { createOnceLoader, PRELUDE, formatRunError, truncateOutput } from '../../theme/default/js/run.mjs'
+import { createOnceLoader, PRELUDE, formatRunError, truncateOutput } from '../../theme/default/js/run.js'
 
 let failures = 0
 function assert(cond, message) {

--- a/test/test_run_ruby_wasm.rb
+++ b/test/test_run_ruby_wasm.rb
@@ -32,13 +32,13 @@ HERE
   def test_run_script_is_loaded_when_enabled
     html = render(:run_ruby_wasm => WASM_URL)
     assert_include(html, META_TAG)
-    assert_include(html, 'js/run.mjs')
+    assert_include(html, 'js/run.js')
   end
 
   def test_run_script_is_not_loaded_by_default
     html = render({})
     assert_not_include(html, 'rurema-run-ruby-wasm')
-    assert_not_include(html, 'run.mjs')
+    assert_not_include(html, 'run.js')
   end
 
   def test_wasm_url_is_html_escaped

--- a/test/test_statichtml_command.rb
+++ b/test/test_statichtml_command.rb
@@ -50,20 +50,20 @@ class TestStatichtmlRunRubyWasm < Test::Unit::TestCase
     assert_equal(url, cmd.instance_variable_get(:@run_ruby_wasm))
   end
 
-  def test_run_mjs_is_copied
+  def test_run_js_is_copied
     Dir.mktmpdir do |dir|
       themedir = File.join(dir, 'theme')
       outputdir = File.join(dir, 'out')
       FileUtils.mkdir_p(File.join(themedir, 'js'))
       FileUtils.mkdir_p(outputdir)
-      File.write(File.join(themedir, 'js', 'run.mjs'), "// run\n")
+      File.write(File.join(themedir, 'js', 'run.js'), "// run\n")
       cmd = build_command(themedir, outputdir)
       cmd.send(:copy_run_ruby_wasm_script)
-      assert_true(File.file?(File.join(outputdir, 'js', 'run.mjs')))
+      assert_true(File.file?(File.join(outputdir, 'js', 'run.js')))
     end
   end
 
-  def test_theme_without_run_mjs_is_tolerated
+  def test_theme_without_run_js_is_tolerated
     Dir.mktmpdir do |dir|
       themedir = File.join(dir, 'theme')
       outputdir = File.join(dir, 'out')
@@ -73,11 +73,11 @@ class TestStatichtmlRunRubyWasm < Test::Unit::TestCase
       orig_stderr, $stderr = $stderr, StringIO.new
       begin
         assert_nothing_raised { cmd.send(:copy_run_ruby_wasm_script) }
-        assert_match(/run\.mjs not found/, $stderr.string)
+        assert_match(/run\.js not found/, $stderr.string)
       ensure
         $stderr = orig_stderr
       end
-      assert_false(File.exist?(File.join(outputdir, 'js', 'run.mjs')))
+      assert_false(File.exist?(File.join(outputdir, 'js', 'run.js')))
     end
   end
 end

--- a/theme/default/js/run.js
+++ b/theme/default/js/run.js
@@ -1,5 +1,8 @@
 // RUN button for Ruby sample code: executes the sample in-browser with
-// ruby.wasm. Enabled per page via
+// ruby.wasm. Named .js rather than .mjs: module scripts are subject to
+// strict MIME checking, and servers whose MIME table lacks an "mjs" entry
+// (e.g. nginx before 1.21.4) serve .mjs as application/octet-stream, which
+// browsers refuse to execute. Enabled per page via
 //   <meta name="rurema-run-ruby-wasm" content="<ruby+stdlib.wasm URL>">
 // which the layout emits when statichtml was invoked with --run-ruby-wasm.
 // The wasm URL is chosen by the build side to match the documented Ruby

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -142,7 +142,7 @@ pre.highlight {
     position: relative;
 }
 
-/* for RUN (js/run.mjs, statichtml --run-ruby-wasm) */
+/* for RUN (js/run.js, statichtml --run-ruby-wasm) */
 .highlight__run-button {
   float: right;
   margin: 0 0 0.25em 0.5em;


### PR DESCRIPTION
## 問題

#216 の RUN ボタンが本番 docs.ruby-lang.org で動きません。ブラウザコンソールに:

```
Failed to load module script: Expected a JavaScript-or-Wasm module script
but the server responded with a MIME type of "application/octet-stream".
Strict MIME type checking is enforced for module scripts per HTML spec.
```

原因は配信側の MIME 設定です。`.mjs` 拡張子が nginx の mime.types に
入ったのは 1.21.4（2021-11）からで、本番サーバーの MIME テーブルには
`mjs` のエントリがなく `application/octet-stream` で配信されます。
通常の `<script>` なら MIME が多少おかしくても実行されますが、
`<script type="module">` は HTML 仕様で厳格な MIME チェックが必須のため、
ロードが拒否されます。

## 方針

`js/run.mjs` を `js/run.js` にリネームします。

- モジュールかどうかを決めるのは `<script type="module">` 属性であって
  拡張子ではないため、`.js` にしても ES モジュールとしての動作は不変です
- `.js` はどのサーバーの MIME テーブルでも JavaScript にマップされるため、
  docs.ruby-lang.org に限らず、statichtml の出力をどこでホストしても
  動作します（サーバー側の nginx 設定変更や Fastly のキャッシュパージに
  依存しない、bitclust 内で完結する修正です）
- ファイル名が変わるので、CDN に `application/octet-stream` で
  キャッシュされた旧 URL の影響も受けません

QuickJS テストランナー `test/js/test_run.mjs` は `.mjs` のままです
（qjs がトップレベルファイルをモジュールとして実行するのに拡張子が必要。
import されるファイルは常にモジュールとしてコンパイルされるため、
`run.js` の import は問題なく動きます）。

## テスト

- `test/test_run_ruby_wasm.rb` / `test/test_statichtml_command.rb` を
  `run.js` 期待に更新（先に red を確認してからリネーム）
- 全スイート 17554 tests, 0 failures
- `qjs test/js/test_run.mjs` パス

## デプロイ

マージ後、generated-documents の daily build で 3.2〜4.1 の全ページが
`js/run.js` 参照で再生成され、`copy_run_ruby_wasm_script` が新ファイルを
配置します。ビルド側（doctree Rakefile / generated-documents）は
`--run-ruby-wasm` フラグしか参照しておらず、ファイル名には依存していない
ため変更不要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
