### PR TITLE
インデックスページへのリンクラベルをカタログ経由にしてリンク先タイトルと揃える

### DIFF
--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -32,7 +32,7 @@ module BitClust
       @type = nil
       @method = nil
       @option = opt.dup
-      init_message_catalog(@catalog)
+      init_message_catalog(@catalog || MessageCatalog.new({}, 'C'))
     end
 
     def compile(src)
@@ -449,9 +449,9 @@ module BitClust
         protect(link) {
           case arg
           when '/', '_index'
-            label = 'All libraries'
+            label = _('Library Index')
           when '_builtin'
-            label = 'Builtin libraries'
+            label = _('Builtin Library')
           end
           library_link(arg, label, frag)
         }
@@ -463,7 +463,7 @@ module BitClust
         protect(link) {
           case arg
           when '/', '_index'
-            arg, label = '', 'All C API'
+            arg, label = '', _('Function Index')
           end
           function_link(arg, label || arg, frag)
         }

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -696,9 +696,12 @@ HERE
        "instance method"     => ['[[m:String#dump]]', '<a href="dummy/method/String/i/dump">String#dump</a>'],
        "indexer"             => ['[[m:String#[] ]]',  '<a href="dummy/method/String/i/=5b=5d">String#[]</a>'],
        "C API"               => ['[[f:rb_ary_new3]]', '<a href="dummy/function/rb_ary_new3">rb_ary_new3</a>'],
-       "C API root"          => ['[[f:/]]',           '<a href="dummy/function/">All C API</a>'],
-       "C API index"         => ['[[f:_index]]',      '<a href="dummy/function/">All C API</a>'],
+       "C API root"          => ['[[f:/]]',           '<a href="dummy/function/">Function Index</a>'],
+       "C API index"         => ['[[f:_index]]',      '<a href="dummy/function/">Function Index</a>'],
        "standard library"    => ['[[lib:jcode]]',     '<a href="dummy/library/jcode">jcode</a>'],
+       "library root"        => ['[[lib:/]]',         '<a href="dummy/library/">Library Index</a>'],
+       "library index"       => ['[[lib:_index]]',    '<a href="dummy/library/_index">Library Index</a>'],
+       "builtin library"     => ['[[lib:_builtin]]',  '<a href="dummy/library/_builtin">Builtin Library</a>'],
        "man command"         => ['[[man:tr(1)]]',     '<a class="external" href="http://www.opengroup.org/onlinepubs/009695399/utilities/tr.html">tr(1)</a>'],
        "man header"          => ['[[man:sys/socket.h(header)]]', '<a class="external" href="http://www.opengroup.org/onlinepubs/009695399/basedefs/sys/socket.h.html">sys/socket.h(header)</a>'],
        "man system call"     => ['[[man:fopen(3linux)]]', '<a class="external" href="http://man7.org/linux/man-pages/man3/fopen.3.html">fopen(3linux)</a>'],
@@ -716,6 +719,17 @@ HERE
   def test_bracket_link(data)
     target, expected = data
     assert_equal(expected, @c.send(:compile_text, target), target)
+  end
+
+  data("library root"    => ['[[lib:/]]',        '<a href="dummy/library/">ライブラリ一覧</a>'],
+       "builtin library" => ['[[lib:_builtin]]', '<a href="dummy/library/_builtin">組み込みライブラリ</a>'],
+       "C API root"      => ['[[f:/]]',          '<a href="dummy/function/">関数一覧</a>'])
+  def test_bracket_link_with_catalog(data)
+    target, expected = data
+    prefix = File.expand_path('../data/bitclust/catalog', __dir__)
+    catalog = BitClust::MessageCatalog.load_with_locales(prefix, ['ja_JP.UTF-8'])
+    compiler = BitClust::RDCompiler.new(@u, 1, {:database => @db, :catalog => catalog})
+    assert_equal(expected, compiler.send(:compile_text, target), target)
   end
 
   data("doc"             => ['[[d:hoge/bar]]',            '<a href="dummy/hoge/bar">.*</a>'],


### PR DESCRIPTION
## 解決したい問題

Fixes #100

トップページなどで使われる `[[lib:/]]`・`[[lib:_builtin]]`・`[[f:/]]` のリンクラベルが
`All libraries`・`Builtin libraries`・`All C API` とハードコードされた英語のままで、
日本語版ではリンク先のページタイトルと食い違っていました。

## 変更内容

- `RDCompiler#bracket_link` のハードコードされたラベルを、メッセージカタログの既存キー
  (`Library Index` / `Builtin Library` / `Function Index`)の参照に変更
  - いずれもリンク先ページのタイトル(テンプレート `library-index` / `library` / `function-index` の `@title`)と同じキーなので、表示が必ずリンク先タイトルと一致します
  - ja カタログでの表示: **ライブラリ一覧 / 組み込みライブラリ / 関数一覧**(issue で提案されていた文言と同じ)
- `RDCompiler` に catalog が渡されない場合は空の `MessageCatalog` にフォールバックするようにし、英語キーがそのまま表示される従来相当の挙動を維持(`MDCompiler` も同経路)

## 表示の変化(ja)

| リンク | before | after |
|---|---|---|
| `[[lib:_builtin]]` | Builtin libraries | 組み込みライブラリ |
| `[[lib:/]]` | All libraries | ライブラリ一覧 |
| `[[f:/]]` | All C API | 関数一覧 |

## テスト

- 既存の bracket link テストの期待値を更新し、`[[lib:/]]` / `[[lib:_index]]` / `[[lib:_builtin]]` のケースを追加
- ja カタログを読み込んだ場合に日本語ラベルになることを検証する `test_bracket_link_with_catalog` を追加
- `ruby test/run_test.rb` 全件パス(17560 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
