### PR TITLE
meta description の改行由来の空白とブラケットリンクを整形する

### DIFF
--- a/lib/bitclust/classentry.rb
+++ b/lib/bitclust/classentry.rb
@@ -425,7 +425,7 @@ module BitClust
     end
 
     def description
-      display_text(source.split(/\n\n+/, 2)[0].strip)
+      description_text(source.split(/\n\n+/, 2)[0].strip)
     end
 
     def clear_cache

--- a/lib/bitclust/docentry.rb
+++ b/lib/bitclust/docentry.rb
@@ -84,7 +84,7 @@ module BitClust
     end
 
     def description
-      display_text(source.split(/\n\n/, 2)[0].strip)
+      description_text(source.split(/\n\n/, 2)[0].strip)
     end
   end
 end

--- a/lib/bitclust/entry.rb
+++ b/lib/bitclust/entry.rb
@@ -165,6 +165,25 @@ module BitClust
     end
     private :display_text
 
+    # BitClust::RDCompiler::BracketLink と同等の正規表現(/n なし)
+    BracketLink = /\[\[[\w-]+?:[!-~]+?(?:\[\] )?\]\]/
+
+    # meta description など、コンパイラを通さずマークアップも解釈されない
+    # 場所に使うテキスト。非 ASCII 文字間の改行は削除し(ブラウザでは
+    # 空白扱いになり日本語文中に不自然な空白が見えるため)、残りの改行は
+    # 空白に変換、ブラケットリンクはリンク先名のみにする
+    def description_text(text)
+      text = display_text(text)
+      return text unless text
+      text = text.split("\n").map(&:strip).join("\n")
+        .gsub(/(\P{ascii})\n(?=\P{ascii})/) { $1 || raise }
+        .tr("\n", ' ')
+      text.gsub(BracketLink) {|link|
+        ((link[2..-3] || raise).split(':', 2).last || raise).rstrip
+      }
+    end
+    private :description_text
+
     def type_id
       self.class.type_id
     end

--- a/lib/bitclust/functionentry.rb
+++ b/lib/bitclust/functionentry.rb
@@ -79,7 +79,7 @@ module BitClust
     end
 
     def description
-      display_text(source.split(/\n\n+/, 2)[0].strip)
+      description_text(source.split(/\n\n+/, 2)[0].strip)
     end
   end
 end

--- a/lib/bitclust/libraryentry.rb
+++ b/lib/bitclust/libraryentry.rb
@@ -80,7 +80,7 @@ module BitClust
     end
 
     def description
-      display_text(source.split(/\n\n+/, 2)[0])
+      description_text(source.split(/\n\n+/, 2)[0])
     end
 
     def check_link(path = [])

--- a/lib/bitclust/methodentry.rb
+++ b/lib/bitclust/methodentry.rb
@@ -216,7 +216,7 @@ module BitClust
     end
 
     def description
-      display_text(source.split(/\n\n+/, 3)[1])
+      description_text(source.split(/\n\n+/, 3)[1])
     end
   end
 end

--- a/sig/bitclust/entry.rbs
+++ b/sig/bitclust/entry.rbs
@@ -42,6 +42,12 @@ module BitClust
     # サブクラスで定義されている
     def self.type_id: () -> Symbol
 
+    BracketLink: ::Regexp
+
+    def display_text: (String? text) -> String?
+
+    def description_text: (String? text) -> String?
+
     def type_id: () -> Symbol
 
     # for entry_class.type_id

--- a/test/test_entry.rb
+++ b/test/test_entry.rb
@@ -72,3 +72,73 @@ HERE
     assert(hoge.instance_method?('fugafuga', false))
   end
 end
+
+class TestEntryDescription < Test::Unit::TestCase
+  def parse_class(class_source)
+    lib, = BitClust::RRDParser.parse(class_source, 'hoge')
+    lib.fetch_class('Hoge')
+  end
+
+  def test_description_truncates_newline_between_non_ascii
+    klass = parse_class(<<HERE)
+= class Hoge
+これは1行目で
+あとに続きます。
+
+以降の段落は含まれません。
+HERE
+    assert_equal('これは1行目であとに続きます。', klass.description)
+  end
+
+  def test_description_truncates_consecutive_newlines_between_non_ascii
+    klass = parse_class(<<HERE)
+= class Hoge
+あい
+うえ
+おか。
+HERE
+    assert_equal('あいうえおか。', klass.description)
+  end
+
+  def test_description_converts_newline_to_space_around_ascii
+    klass = parse_class(<<HERE)
+= class Hoge
+first line
+second line
+HERE
+    assert_equal('first line second line', klass.description)
+  end
+
+  def test_description_replaces_bracket_link_with_plain_text
+    klass = parse_class(<<HERE)
+= class Hoge
+自身の hostname を文字列で返します。また、[[m:URI::Generic#host]] が設
+定されていない場合は [[c:Array]] を返します。
+HERE
+    assert_equal('自身の hostname を文字列で返します。また、URI::Generic#host が設定されていない場合は Array を返します。',
+                 klass.description)
+  end
+
+  def test_description_replaces_indexer_bracket_link
+    klass = parse_class(<<HERE)
+= class Hoge
+[[m:String#[] ]] を参照。
+HERE
+    assert_equal('String#[] を参照。', klass.description)
+  end
+
+  def test_method_description_is_plain_text
+    klass = parse_class(<<HERE)
+= class Hoge
+== Instance Methods
+--- fuga
+
+[[c:Array]] を日本語で
+返します。
+
+次の段落。
+HERE
+    method = klass.entries.detect {|m| m.name == 'fuga' }
+    assert_equal('Array を日本語で返します。', method.description)
+  end
+end


### PR DESCRIPTION
## 解決したい問題

Fixes #131
Fixes #52

`Entry#description` の値は各ページの `<meta name="description">` にそのまま入りますが、
2つの問題が残っていました。

- **#131**: ソース由来の改行が残り、日本語文中で不自然な空白として見える
  (例: `URI::Generic#hostname` の「が設␊定されていない」。本文側は #61 で対応済みだが description は未対応)
- **#52**: `[[m:...]]` などのブラケットリンク記法が未整形のまま表示される
  (例: doc/spec/literal ページの description)

## 変更内容

`Entry#description_text` を追加し、class / library / doc / method / function の各
`description` で共通に通すようにしました。

1. 各行を strip して連結し、**非 ASCII 文字間の改行は削除**(#61 の本文と同じ規則)。
   連続する日本語行もすべて連結されるよう後読みではなく先読みでマッチします
2. 残った改行(ASCII 語境界)は空白1つに変換
3. ブラケットリンクはリンク先名のみのプレーンテキストに変換
   (`[[m:URI::Generic#host]]` → `URI::Generic#host`、`[[m:String#[] ]]` → `String#[]`)

md ソース DB では従来どおり `MarkdownToRRD.restore_description` で rd インライン形式に
戻した後に同じ整形を適用します(`display_text` 経由)。

## 動作確認

issue #131 の実例を rd / markdown 両ソースの検証 DB で確認:

```
=== db-refe-md (source_format=markdown)
"自身の hostname を文字列で返します。また、URI::Generic#host が設定されていない場合は nil を返します。"
=== db-refe-rd (source_format=rd)
"自身の hostname を文字列で返します。また、URI::Generic#host が設定されていない場合は nil を返します。"
```

## テスト

- `test/test_entry.rb` に `TestEntryDescription` を追加(CJK 改行連結・連続行・ASCII 境界の空白化・ブラケットリンク・インデクサ表記・メソッド description の6ケース)
- `ruby test/run_test.rb` 全件パス(17560 tests)
- `sig/bitclust/entry.rbs` に新規メソッドのシグネチャを追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)
