### PR TITLE
Rouge を導入して ruby 以外の言語のシンタックスハイライトに対応する

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
       nkf
       progressbar (>= 1.9.0, < 2.0)
       rack
+      rouge
       webrick
     bitclust-dev (1.4.0)
       bitclust-core (= 1.4.0)
@@ -78,6 +79,8 @@ GEM
     rbs (3.10.3)
       logger
       tsort
+    rouge (5.0.0)
+      strscan (~> 3.1)
     rr (3.1.2)
     securerandom (0.4.1)
     steep (1.9.4)
@@ -181,6 +184,7 @@ CHECKSUMS
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
   rbs (3.10.3) sha256=70627f3919016134d554e6c99195552ae3ef6020fe034c8e983facc9c192daa6
   refe2 (1.4.0)
+  rouge (5.0.0) sha256=e2de9bba2f9cb88f8a73bca3643b560b2b398f32f91bf716f584477bc0175ebc
   rr (3.1.2) sha256=cc4a5cc91f012327d317dc661154419f9d36d8f9c05031ac46accd89ceb0ff1b
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   steep (1.9.4) sha256=09a941469b55d31cdc70a3812b5c1d4102d361f628f5fe5497b6a9aabc3cee05

--- a/bitclust-core.gemspec
+++ b/bitclust-core.gemspec
@@ -31,6 +31,7 @@ EOD
   s.add_development_dependency "test-unit-notify"
   s.add_development_dependency "test-unit-rr"
   s.add_runtime_dependency "rack"
+  s.add_runtime_dependency "rouge"
   s.add_runtime_dependency "progressbar", ">= 1.9.0", "< 2.0"
   s.add_runtime_dependency "webrick"
   s.add_runtime_dependency "drb"

--- a/lib/bitclust/mdcompiler.rb
+++ b/lib/bitclust/mdcompiler.rb
@@ -347,21 +347,7 @@ module BitClust
         @f.until_terminator(terminator) do |code_line|
           src << code_line
         end
-        if lang == "ruby"
-          begin
-            filename = (caption&.size || 0) > 2 ? caption : @f.name or raise
-            string BitClust::SyntaxHighlighter.new(src, filename).highlight
-          rescue BitClust::SyntaxHighlighter::Error => ex
-            $stderr.puts ex.message
-            if stop_on_syntax_error?
-              exit(false)
-            else
-              string src
-            end
-          end
-        else
-          string src
-        end
+        string highlight_source(src, lang, caption)
         line '</code></pre>'
       elsif fence.size == 3
         line '<pre>'

--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -14,6 +14,7 @@ require 'bitclust/htmlutils'
 require 'bitclust/textutils'
 require 'bitclust/messagecatalog'
 require 'bitclust/syntax_highlighter'
+require 'rouge'
 require 'stringio'
 
 module BitClust
@@ -271,6 +272,29 @@ module BitClust
       @option[:stop_on_syntax_error]
     end
 
+    # lang 指定付きコードブロックのハイライト HTML を返す。
+    # ruby(rb などの Rouge 上の alias を含む)は構文チェックを兼ねる
+    # Ripper ベースの SyntaxHighlighter、その他の言語は Rouge を使う。
+    # Rouge が知らない言語はエスケープのみ(従来この経路と ruby の構文
+    # エラー時フォールバックはエスケープされずに出力されていたのを修正)
+    def highlight_source(src, lang, caption)
+      lexer = ::Rouge::Lexer.find(lang)
+      if lexer && lexer.tag == 'ruby'
+        begin
+          filename = (caption&.size || 0) > 2 ? caption : @f.name or raise
+          BitClust::SyntaxHighlighter.new(src, filename).highlight
+        rescue BitClust::SyntaxHighlighter::Error => ex
+          $stderr.puts ex.message
+          exit(false) if stop_on_syntax_error?
+          escape_html(src)
+        end
+      elsif lexer
+        ::Rouge::Formatters::HTML.new.format(lexer.lex(src))
+      else
+        escape_html(src)
+      end
+    end
+
     def emlist
       command = @f.gets
       if %r!\A//emlist\[(?<caption>[^\[\]]+?)?\]\[(?<lang>\w+?)\]! =~ command
@@ -283,21 +307,7 @@ module BitClust
         @f.until_terminator(%r<\A//\}>) do |line|
           src << line
         end
-        if lang == "ruby"
-          begin
-            filename = (caption&.size || 0) > 2 ? caption : @f.name or raise
-            string BitClust::SyntaxHighlighter.new(src, filename).highlight
-          rescue BitClust::SyntaxHighlighter::Error => ex
-            $stderr.puts ex.message
-            if stop_on_syntax_error?
-              exit(false)
-            else
-              string src
-            end
-          end
-        else
-          string src
-        end
+        string highlight_source(src, lang, caption)
         line '</code></pre>'
       else
         line '<pre>'

--- a/sig/bitclust/rdcompiler.rbs
+++ b/sig/bitclust/rdcompiler.rbs
@@ -82,6 +82,8 @@ module BitClust
 
     def stop_on_syntax_error?: () -> bool
 
+    def highlight_source: (String src, String lang, String? caption) -> String
+
     def emlist: () -> void
 
     def list: () -> void

--- a/test/test_mdcompiler.rb
+++ b/test/test_mdcompiler.rb
@@ -610,3 +610,50 @@ class TestMDCompiler < Test::Unit::TestCase
     RD
   end
 end
+
+# lang 指定付きコードブロックのハイライト（ruby は Ripper ベースの
+# SyntaxHighlighter、その他の言語は Rouge、未知の言語はエスケープのみ）
+class TestMDCompilerRougeHighlight < Test::Unit::TestCase
+  def setup
+    @dummy = 'dummy'
+    @u = BitClust::URLMapper.new(Hash.new { @dummy })
+    @db = BitClust::MethodDatabase.dummy("version" => "2.0.0")
+    @md = BitClust::MDCompiler.new(@u, 1, { :database => @db, :gfm => true })
+    @rd = BitClust::RDCompiler.new(@u, 1, { :database => @db })
+  end
+
+  def test_c_fence_is_highlighted_with_rouge
+    html = @md.compile("```c\nint x = 1; /* comment */\n```\n")
+    assert_match(/<pre class="highlight c">/, html)
+    assert_match(%r{<span class="kt">int</span>}, html)
+    assert_match(%r{<span class="cm">/\* comment \*/</span>}, html)
+  end
+
+  def test_ruby_alias_rb_uses_bitclust_highlighter
+    ruby_html = @md.compile("```ruby\nputs 1\n```\n")
+    rb_html = @md.compile("```rb\nputs 1\n```\n")
+    assert_equal(ruby_html.sub('highlight ruby', 'highlight rb'), rb_html)
+    # bitclust の SyntaxHighlighter 由来のマークアップ（Rouge の Ruby lexer ではなく）
+    assert_match(%r{<span class="nb">puts</span>}, rb_html)
+  end
+
+  def test_unknown_lang_fence_is_escaped
+    html = @md.compile("```nosuchlang\n<b>&raw</b>\n```\n")
+    assert_match(/<pre class="highlight nosuchlang">/, html)
+    assert_match(/&lt;b&gt;&amp;raw&lt;\/b&gt;/, html)
+    assert_not_match(/<b>/, html)
+  end
+
+  def test_text_fence_is_escaped_without_highlight
+    html = @md.compile("```text\n<b>plain</b>\n```\n")
+    assert_match(/&lt;b&gt;plain&lt;\/b&gt;/, html)
+    assert_not_match(/<b>plain/, html)
+  end
+
+  def test_rd_emlist_with_c_lang_is_equivalent
+    rd_src = "//emlist[キャプション][c]{\nint x = 1;\n//}\n"
+    md_src = BitClust::RRDToMarkdown.convert(rd_src)
+    assert_equal(@rd.compile(rd_src), @md.compile(md_src), "md source:\n#{md_src}")
+    assert_match(%r{<span class="kt">int</span>}, @rd.compile(rd_src))
+  end
+end

--- a/theme/default/syntax-highlight.css
+++ b/theme/default/syntax-highlight.css
@@ -8,6 +8,14 @@
   color: #999999;
   font-weight: bold;
 }
+.highlight .cpf { /* preprocessor file (C の #include <...> など。Rouge 用) */
+  color: #999999;
+  font-weight: bold;
+}
+.highlight .pi { /* YAML などの indicator (Rouge 用) */
+  color: #999999;
+  font-weight: bold;
+}
 .highlight .c1 {
   color: #999988;
   font-style: italic;


### PR DESCRIPTION
## 解決したい問題

#161 のフォローアップです。コードフェンスの言語指定は `ruby` だけがハイライトされ、
他の言語(`c`、`html`、`sh` など)は素通しでした。しかもこの経路は
**HTML エスケープもされていなかった**ため、`<` を含むコードが壊れて表示される
潜在バグがありました(現在 doctree に非 ruby の言語タグ付きブロックが無いため未発現)。

## 変更内容

- **Rouge**(pure-Ruby、200+ 言語対応)を `bitclust-core` の runtime 依存に追加
- lang 指定付きコードブロックのハイライトを共通ヘルパ `highlight_source` に集約
  (rd の `//emlist[][lang]` と md のコードフェンスの両経路)
- **言語解決は `Rouge::Lexer.find` に委任**:
  - 解決先が Ruby lexer の場合(**`rb` などの alias を含む**)→ 従来どおり
    構文チェックを兼ねる Ripper ベースの `SyntaxHighlighter`
  - その他の言語 → `Rouge::Formatters::HTML` でハイライト。
    出力クラス名は Pygments 互換なので**既存の `syntax-highlight.css` がそのまま効きます**
    (不足していた `cpf` / `pi` の2クラスのみ追記)
  - Rouge が知らない言語 → エスケープのみで出力(従来のエスケープ漏れを修正。
    ruby の構文エラー時フォールバックも同様に修正)

## 表示の変化

- ` ```c ` / ` ```sh ` / ` ```yaml ` / ` ```html ` などが色付きになります
- ` ```rb ` が ruby として(Ripper 実装で)ハイライトされるようになります
- ` ```text ` は Rouge の PlainText lexer 経由でエスケープのみ(従来どおり無色)
- doctree 側は現在すべて ruby タグのため、**既存ページの表示に変化はありません**。
  今後 doctree 側でフェンスに言語タグを付けていくと効き始めます

## テスト

- `TestMDCompilerRougeHighlight` を追加: C のハイライト・`rb` alias が Ripper 実装に
  委譲されること・未知言語のエスケープ・text の無色・rd/md の等価性の5ケース
- `ruby test/run_test.rb` 全件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
