### PR TITLE
旧 @undef 段落の後方互換を削除する

### DIFF
--- a/lib/bitclust/mdcompiler.rb
+++ b/lib/bitclust/mdcompiler.rb
@@ -140,10 +140,6 @@ module BitClust
         when /\A@todo\b/
           # findings#3: rd 側と同じく行頭アンカー付きで
           todo
-        when /\A@undef\b/
-          # 旧 @undef 段落の後方互換(rd 側と同期。移行完了後に削除する)
-          @f.gets
-          undef_message
         when RAW_META_RE
           entry_info
         when /\A\s*\|/

--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -162,11 +162,6 @@ module BitClust
           see
         when /\A@todo\b/
           todo
-        when /\A@undef\b/
-          # 旧 @undef 段落の後方互換(UNKNOWN_META_INFO にすると doctree の
-          # check_format が落ちる)。{: undef} への移行完了後に削除する
-          @f.gets
-          undef_message
         when /\A@[a-z]/
           entry_info
         else

--- a/lib/bitclust/rrdparser.rb
+++ b/lib/bitclust/rrdparser.rb
@@ -486,10 +486,6 @@ module BitClust
                                 :undefined
                               elsif attrs.include?('nomethod')
                                 :nomethod
-                              elsif chunk.source.match?(/^@undef$/)
-                                # 旧 @undef 段落の後方互換。
-                                # doctree の {: undef} への移行完了後に削除する
-                                :undefined
                               else
                                 @kind
                               end

--- a/test/test_mdcompiler.rb
+++ b/test/test_mdcompiler.rb
@@ -255,17 +255,6 @@ class TestMDCompiler < Test::Unit::TestCase
     assert_match(/本文中で @see を説明する行。/, html)
   end
 
-  def test_legacy_undef_paragraph_renders_dedicated_message
-    # 旧 @undef 段落の後方互換(doctree master 移行完了後に削除)。
-    # UNKNOWN_META_INFO にしない(doctree の check_format が落ちるため)
-    rd_src = "--- <(other) -> bool\n\n@undef\n"
-    md_src = BitClust::RRDToMarkdown.convert(rd_src)
-    rd_html = compile_method(@rd, rd_src)
-    assert_not_match(/UNKNOWN_META_INFO/, rd_html)
-    assert_match(/このメソッドは定義されていません/, rd_html)
-    assert_equal rd_html, compile_method(@md, md_src), "md source:\n#{md_src}"
-  end
-
   def test_undef_renders_dedicated_message
     # {: undef} 属性行は専用の説明文を描画する（statichtml は undefined を
     # skip するため露出は server 等の動的経路のみ）

--- a/test/test_rrdparser.rb
+++ b/test/test_rrdparser.rb
@@ -164,20 +164,3 @@ HERE
     assert_equal(:defined, db.get_method(BitClust::MethodSpec.parse('Dummy#test_foo')).kind)
   end
 end
-
-class TestRRDParserLegacyUndef < Test::Unit::TestCase
-  # 旧 @undef の後方互換。doctree master が {: undef} へ移行するまでの
-  # 過渡期用で、移行完了後に削除する
-  def test_legacy_undef_paragraph_still_sets_kind
-    result = BitClust::RRDParser.parse(<<HERE, 'dummy')
-= module Dummy
-== Instance Methods
---- test_undef
-
-@undef
-
-HERE
-    _library, db = result
-    assert_equal(:undefined, db.get_method(BitClust::MethodSpec.parse('Dummy#test_undef')).kind)
-  end
-end


### PR DESCRIPTION
## 概要

メソッド属性行 `{: ...}` 導入 PR で過渡期用に残していた旧 `@undef` 段落の
後方互換(パース+専用メッセージ描画)を削除し、`{: undef}` に一本化します。

## ⚠️ マージ条件

**doctree 側の `{: ...}` 移行 PR(Complex.md の `@undef` 6箇所の変換を含む)が
マージされてから**マージしてください。先にマージすると bitclust CI の rurema ジョブ
(doctree master をビルド)が `[UNKNOWN_META_INFO] @undef:` で fail します。

## テスト

- 後方互換用に追加していたテスト2件を削除
- `ruby test/run_test.rb` 全件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
