### PR TITLE
Markdown 対応で追加されたコードに RBS 型定義を付ける

### DIFF
--- a/lib/bitclust/doc_converter.rb
+++ b/lib/bitclust/doc_converter.rb
@@ -27,7 +27,7 @@ module BitClust
         when /\A(={1,4}\[a:[^\]]+\])\s{2,}(.*)/m
           "#{$1} #{$2}"                          # アンカー見出しの余分なスペース
         when /\A\t+/
-          line.sub(/\A\t+/) { ' ' * $&.length }  # 行頭タブ（doc の散文1行のみ）
+          line.sub(/\A\t+/) { ' ' * ($& || raise).length }  # 行頭タブ（doc の散文1行のみ）
         when /\A\#@include\((?:\.\.\/)+api\/src\//
           # 旧レイアウト ../api/src/X → 新レイアウト ../api/X
           # （manual/ 配下では src 階層が無い。ブリッジが逆変換する）
@@ -54,7 +54,7 @@ module BitClust
         base = File.dirname(f)
         File.read(File.join(doc_root, f))
             .scan(/^\#@include\((?!(?:\.\.\/)+api\/)(.*?)\)/)
-            .map { |t| File.expand_path(base == '.' ? t[0] : File.join(base, t[0]), '/')
+            .map { |t| File.expand_path(base == '.' ? (t[0] || raise) : File.join(base, t[0] || raise), '/')
                            .delete_prefix('/') }
       }
       (pages + (all & referenced)).sort

--- a/lib/bitclust/entity_splitter.rb
+++ b/lib/bitclust/entity_splitter.rb
@@ -29,7 +29,7 @@ module BitClust
     # H1 を含まないゲート（散文の版分岐・gated relations）は触らない。
     def resolve_header_gates(src, scope)
       lines = src.lines
-      out = []
+      out = [] #: Array[String]
       i = 0
       while i < lines.length
         line = lines[i]
@@ -87,7 +87,8 @@ module BitClust
     # ベースセグメントとして返す。連結すると入力に一致する。
     def segments(src)
       lines = src.lines
-      boundaries = []   # [行index, エンティティ名, ゲート付きか]
+      # [行index, エンティティ名, ゲート付きか]
+      boundaries = [] #: Array[[Integer, String?, bool]]
       depth = 0
       lines.each_with_index do |line, i|
         case line
@@ -111,9 +112,9 @@ module BitClust
         next true unless gated
         stop = idx + 1 < boundaries.length ? boundaries[idx + 1][0] : lines.length
         gate_wraps_segment?(lines, start, stop)
-      }.map { |(start, name, _), _| [start, name] }
+      }.map { |(start, name, _), _| [start, name] } #: Array[[Integer, String?]]
       return nil if boundaries.empty?
-      if lines[0...boundaries.first[0]].all? { |l| l =~ BLANK_RE }
+      if (lines[0...(boundaries.first || raise)[0]] || raise).all? { |l| l =~ BLANK_RE }
         boundaries[0] = [0, boundaries[0][1]]   # 先頭の空行は最初のセグメントへ
       else
         boundaries.unshift([0, nil])            # ライブラリ概要部（ベースセグメント）
@@ -121,7 +122,7 @@ module BitClust
 
       boundaries.each_with_index.map do |(start, name), idx|
         stop = idx + 1 < boundaries.length ? boundaries[idx + 1][0] : lines.length
-        [name, lines[start...stop].join]
+        [name, (lines[start...stop] || raise).join]
       end
     end
 
@@ -129,7 +130,7 @@ module BitClust
     # あるか。ゲートがセグメント全体を包むときのみ真
     def gate_wraps_segment?(lines, start, stop)
       depth = 0
-      close = nil
+      close = nil #: Integer?
       (start...stop).each do |i|
         case lines[i]
         when BLOCK_OPEN_RE then depth += 1
@@ -142,7 +143,7 @@ module BitClust
         end
       end
       return false unless close
-      lines[(close + 1)...stop].all? { |l| l =~ BLANK_RE }
+      (lines[(close + 1)...stop] || raise).all? { |l| l =~ BLANK_RE }
     end
 
     # エンティティ名 → 出力ファイル名（拡張子なし）。既存の命名規約に合わせ :: → __
@@ -171,15 +172,15 @@ module BitClust
     def gate_condition(line)
       return nil unless line =~ GATE_OPEN_RE
       # Preprocessor は #@since "1.8.5" のクォート形式も受理する
-      IncludeGraph::Condition.new($1.to_sym, $2.strip.delete_prefix('"').delete_suffix('"'))
+      IncludeGraph::Condition.new(($1 || raise).to_sym, ($2 || raise).strip.delete_prefix('"').delete_suffix('"'))
     end
 
     # i のゲート開始行から対応を取り、{body:, else_body:, next:} を返す。
     # body/else_body は枝の行列、next は #@end の次の行 index。対応が取れなければ nil
     def parse_block(lines, i)
       depth = 0
-      body = []
-      else_body = []
+      body = [] #: Array[String]
+      else_body = [] #: Array[String]
       current = body
       j = i
       while j < lines.length
@@ -213,7 +214,7 @@ module BitClust
 
     # i 以降の最初の非空行が H1 ならその名前を返す
     def first_h1_name(lines, i)
-      first = lines[i..].find { |l| l !~ BLANK_RE }
+      first = (lines[i..] || raise).find { |l| l !~ BLANK_RE }
       first =~ H1_RE ? $1 : nil
     end
   end

--- a/lib/bitclust/include_graph.rb
+++ b/lib/bitclust/include_graph.rb
@@ -40,8 +40,8 @@ module BitClust
     # 分解して境界に寄与させる。分解できない連言子は寄与しない（保守的に広く扱う。
     # 恒偽の証明は Scope#never? が連言子単位で別途行う）
     def self.bounds(conditions)
-      sinces = []
-      untils = []
+      sinces = [] #: Array[bound]
+      untils = [] #: Array[bound]
       conditions.each do |c|
         case c.kind
         when :since then sinces << [Gem::Version.new(c.version), c.version]
@@ -60,7 +60,7 @@ module BitClust
     # <= や否定（#@else 反転）は正確に表現できないので分解しない
     def self.if_bounds(expr)
       return [] if expr.lstrip.start_with?('!')
-      bounds = []
+      bounds = [] #: Array[[Symbol, String?]]
       expr.split(/\band\b/).each do |c|
         case c
         when /version\s*<\s*"([\d.]+)"/ then bounds << [:until, $1]
@@ -142,7 +142,7 @@ module BitClust
       def gate(conditions)
         return nil unless cover?(conditions)
         lo, hi = IncludeGraph.bounds(conditions)
-        gate = {}
+        gate = {} #: IncludeGraph::gate
         gate[:since] = lo[1] if lo && lo[0] > @lo
         gate[:until] = hi[1] if hi && hi[0] < @hi
         gate
@@ -199,7 +199,7 @@ module BitClust
     # LIBRARIES 内の版ゲート（fiber: until 3.1 等）をスコープ適用して付与する。
     # スコープ外のライブラリ（cmath/scanf/sync 等）は含まない。
     def library_front_matter_map(scope)
-      result = {}
+      result = {} #: Hash[String, Hash[String, String]]
       @library_gates.each do |name, gate|
         root = "#{name}.rd"
         scoped = scope.gate(gate)
@@ -227,7 +227,7 @@ module BitClust
     # - 同一ライブラリ内の複数 include サイトは、いずれかが有効なら
     #   エンティティが存在するため、ゲートは区間の hull（弱い方）を取る
     def front_matter_map(scope)
-      result = {}
+      result = {} #: Hash[String, front_matter]
       groupings.each do |path, ms|
         covered = ms.select { |m| scope.cover?(m.conditions) }
         next if covered.empty?
@@ -264,7 +264,7 @@ module BitClust
       return {} if gates.any?(&:empty?)
       sinces = gates.map { |g| g[:since] }
       untils = gates.map { |g| g[:until] }
-      result = {}
+      result = {} #: gate
       result[:since] = sinces.min_by { |v| Gem::Version.new(v) } if sinces.all?
       result[:until] = untils.max_by { |v| Gem::Version.new(v) } if untils.all?
       result
@@ -272,8 +272,8 @@ module BitClust
 
     # LIBRARIES を版ゲート付きで読む。 [[name, [Condition]], ...]
     def read_libraries
-      entries = {}
-      stack = []
+      entries = {} #: Hash[String, Array[Condition]]
+      stack = [] #: Array[Condition]
       File.foreach(File.join(@src_root, 'LIBRARIES')) do |line|
         line = line.chomp
         if line.start_with?('#@#') || apply_directive(stack, line)
@@ -292,7 +292,7 @@ module BitClust
       case line
       when /\A\#@since\s+(\S+)/  then stack.push(Condition.new(:since, $1))
       when /\A\#@until\s+(\S+)/  then stack.push(Condition.new(:until, $1))
-      when /\A\#@if\s*(.*)/      then stack.push(Condition.new(:if, $1.strip))
+      when /\A\#@if\s*(.*)/      then stack.push(Condition.new(:if, ($1 || raise).strip))
       when /\A\#@samplecode\b/   then stack.push(Condition.new(:samplecode, nil))
       when /\A\#@else\b/         then (cond = stack.pop) && stack.push(invert(cond))
       when /\A\#@end\b/          then stack.pop
@@ -313,12 +313,12 @@ module BitClust
     # relpath のファイル内の #@include を条件スタック付きで走査する。
     # base_conditions は LIBRARIES ゲート＋ここまでの include 経路の条件。
     def walk(relpath, library, base_conditions, path_stack)
-      stack = []
+      stack = [] #: Array[Condition]
       File.foreach(File.join(@src_root, relpath)) do |line|
         line = line.chomp
         if line =~ /\A\#@include\s*\((.*?)\)/
           conditions = (base_conditions + stack).reject { |c| c.kind == :samplecode }
-          add_include(relpath, $1, library, conditions, path_stack)
+          add_include(relpath, $1 || raise, library, conditions, path_stack)
         else
           apply_directive(stack, line)
         end

--- a/lib/bitclust/include_pruner.rb
+++ b/lib/bitclust/include_pruner.rb
@@ -33,14 +33,14 @@ module BitClust
 
     def prune(src, targets)
       return src if targets.empty?
-      lookup = {}
+      lookup = {} #: Hash[String?, bool]
       targets.each { |t| lookup[t] = true }
 
       lines = src.lines
       nodes = catch(:unbalanced) { parse(lines) }
       return src if nodes.nil?
 
-      stream = []
+      stream = [] #: stream
       changed = emit(nodes, lookup, stream)
       return src unless changed
       tidy(stream).join
@@ -54,7 +54,7 @@ module BitClust
     end
 
     def parse_nodes(lines, i)
-      nodes = []
+      nodes = [] #: Array[node]
       while i < lines.length
         line = lines[i]
         if line =~ ELSE_RE || line =~ END_RE
@@ -63,7 +63,7 @@ module BitClust
           gate = line !~ CODE_OPEN_RE
           body, j = parse_nodes(lines, i + 1)
           else_line = nil
-          else_body = []
+          else_body = [] #: Array[node]
           if j < lines.length && lines[j] =~ ELSE_RE
             else_line = lines[j]
             else_body, j = parse_nodes(lines, j + 1)
@@ -96,9 +96,9 @@ module BitClust
     end
 
     def emit_block(block, lookup, stream)
-      body = []
+      body = [] #: stream
       body_changed = emit(block.body, lookup, body)
-      else_body = []
+      else_body = [] #: stream
       else_changed = block.else_line ? emit(block.else_body, lookup, else_body) : false
       changed = body_changed || else_changed
 
@@ -124,7 +124,7 @@ module BitClust
     # REMOVED 番兵を取り除きつつ、除去痕の前後が空行同士なら1つに畳み、
     # 先頭に残った空行を削る
     def tidy(stream)
-      result = []
+      result = [] #: Array[String]
       pending = false
       stream.each do |item|
         if item.equal?(REMOVED)

--- a/lib/bitclust/markdown_bridge.rb
+++ b/lib/bitclust/markdown_bridge.rb
@@ -38,7 +38,7 @@ module BitClust
       referenced = files.flat_map { |f|
         base = File.dirname(f)
         File.read(File.join(md_doc_root, f)).scan(/^\#@include\((?!(?:\.\.\/)+api\/)(.*?)\)/)
-            .map { |t| File.expand_path(base == '.' ? t[0] : File.join(base, t[0]), '/')
+            .map { |t| File.expand_path(base == '.' ? (t[0] || raise) : File.join(base, t[0] || raise), '/')
                            .delete_prefix('/') }
       }.to_h { |t| [t, true] }
 
@@ -135,7 +135,7 @@ module BitClust
         [reopen_only ? 1 : 0, path]
       end
       "\n" + sorted.map { |path|
-        m = members[path][:memberships].find { |mm| mm[:library] == libname }
+        m = members[path][:memberships].find { |mm| mm[:library] == libname } || raise
         inc = "\#@include(#{relative(emitted[path], base)})\n"
         inc = "\#@since #{m[:since]}\n#{inc}\#@end\n" if m[:since]
         inc = "\#@until #{m[:until]}\n#{inc}\#@end\n" if m[:until]
@@ -156,7 +156,7 @@ module BitClust
       return rrd unless rrd.include?('#@include')
       base = File.dirname(md_file)
       rrd.gsub(INCLUDE_RE) do
-        pre, target, post = $1, $2, $3
+        pre, target, post = $1, ($2 || raise), $3
         resolved = resolve(base, target, emitted)
         "#{pre}#{resolved ? relative(emitted[resolved], File.dirname(emitted[md_file])) : target}#{post}"
       end

--- a/lib/bitclust/markdown_orchestrator.rb
+++ b/lib/bitclust/markdown_orchestrator.rb
@@ -63,7 +63,7 @@ module BitClust
       dir = library ? relpath.sub(/\.rd\z/, '') : File.dirname(relpath)
       entity_fm =
         if library
-          fm = { 'library' => relpath.sub(/\.rd\z/, '') }
+          fm = { 'library' => relpath.sub(/\.rd\z/, '') } #: IncludeGraph::front_matter
           %w[since until].each { |k| fm[k] = front_matter[k] if front_matter[k] }
           fm
         else
@@ -74,15 +74,15 @@ module BitClust
       units = segments.map do |name, text|
         next Unit.new(output_path(relpath, front_matter), text, front_matter) if name.nil?   # 概要部
 
-        fm = entity_fm.dup
+        seg_fm = entity_fm.dup
         if (unwrapped = WholeFileGate.unwrap_for_scope(text, @scope))
           # エンティティセグメントのゲートは自身の存在ゲート → 常に front matter へ
           text = unwrapped[0]
-          merge_gate(fm, unwrapped[1])
+          merge_gate(seg_fm, unwrapped[1])
         end
         text = rewrite_includes(text, source_dir, dir)
         filename = "#{EntitySplitter.entity_filename(name)}.md"
-        Unit.new(dir == '.' ? filename : File.join(dir, filename), text, fm)
+        Unit.new(dir == '.' ? filename : File.join(dir, filename), text, seg_fm)
       end
       if library && segments.none? { |name, _| name.nil? }
         # 概要部が無くてもライブラリ自体が発見から消えないよう front matter のみ合成
@@ -145,7 +145,7 @@ module BitClust
       return text if source_dir == new_dir || text !~ /\#@include/
       base = File.expand_path(new_dir, '/')
       text.gsub(/^(\#@include\s*\()(.*?)(\))/) do
-        pre, target, post = $1, $2, $3
+        pre, target, post = $1, ($2 || raise), $3
         abs = File.expand_path(source_dir == '.' ? target : File.join(source_dir, target), '/')
         "#{pre}#{Pathname.new(abs).relative_path_from(base)}#{post}"
       end
@@ -182,14 +182,14 @@ module BitClust
     # 関係を持たない H1 の直後や本文の空行・散文ゲートは触らない
     def normalize_header_regions(rrd)
       lines = rrd.lines
-      out = []
+      out = [] #: Array[String]
       i = 0
       while i < lines.length
         line = lines[i]
         out << line
         i += 1
         next unless line =~ EntitySplitter::H1_RE
-        region = []
+        region = [] #: Array[String]
         while i < lines.length &&
               (lines[i] =~ RELATION_RE || lines[i] =~ HEADER_DIR_RE || lines[i] =~ BLANK_LINE_RE)
           region << lines[i]
@@ -197,10 +197,10 @@ module BitClust
         end
         last_rel = region.rindex { |l| l =~ RELATION_RE }
         if last_rel
-          head = region[0..last_rel].reject { |l| l =~ BLANK_LINE_RE }
-                                    .map { |l| l =~ RELATION_RE ? "#{l.rstrip}\n" : l }
+          head = (region[0..last_rel] || raise).reject { |l| l =~ BLANK_LINE_RE }
+                                               .map { |l| l =~ RELATION_RE ? "#{l.rstrip}\n" : l }
           out.concat(head)
-          out.concat(region[(last_rel + 1)..])
+          out.concat(region[(last_rel + 1)..] || raise)
         else
           out.concat(region)
         end

--- a/lib/bitclust/markdown_to_rrd.rb
+++ b/lib/bitclust/markdown_to_rrd.rb
@@ -63,7 +63,8 @@ module BitClust
         "\x01#{saved.size - 1}\x01#{ends_nl ? "\n" : ''}"
       end
       out = +''
-      fence = nil #: [Integer, Integer | nil]?  len と indent（emlist 形は nil）
+      # len と indent（emlist 形は nil）
+      fence = nil #: [Integer, Integer | nil]?
       text.each_line do |l|
         nl = l.end_with?("\n")
         if fence
@@ -101,9 +102,9 @@ module BitClust
       when /\A(\#{1,6}) (.*?) \{#(\w+)\}([ \t]*\n?)\z/m
         # アンカーは restore_inline の裸参照復元（[a:x]→[[a:x]]）を
         # 避けるため \x00 で包み、最後に [a:x] へ戻す
-        "#{'=' * $1.length}\x00#{$3}\x00 #{$2}#{$4}"
+        "#{'=' * ($1 || raise).length}\x00#{$3}\x00 #{$2}#{$4}"
       when /\A(\#{1,6}) (.*)\z/m
-        "#{'=' * $1.length} #{$2}"
+        "#{'=' * ($1 || raise).length} #{$2}"
       when /\A- \*\*(param|arg|raise)\*\*(\s+)`([^`]+)` --(.*)\z/m
         "@#{$1}#{$2}#{$3}#{$4}"
       when /\A- \*\*return\*\* --(.*)\z/m
@@ -138,7 +139,7 @@ module BitClust
     def parse_front_matter
       return unless @index < @lines.length && @lines[@index] =~ /\A---\s*$/
       advance  # skip opening ---
-      yaml_lines = []
+      yaml_lines = [] #: Array[String]
       while @index < @lines.length
         line = current_line
         if line =~ /\A---\s*$/
@@ -163,12 +164,16 @@ module BitClust
     # クラス関係（include/extend/alias; H1 直後）の body 行を組み立てる。
     # YAML.safe_load は #@ をコメントとして落とすため生行を使う。
     def parse_front_matter_raw(yaml_lines)
-      blocks = {}   # list key => [[:item, val] | [:dir, line]]
+      # list key => [[:item, val] | [:dir, line]]
+      blocks = {} #: Hash[String?, Array[[Symbol, String]]]
       category = nil
-      category_block = nil  # ゲート付き category（rd 行の組み立て済み列）
+      # ゲート付き category（rd 行の組み立て済み列）
+      category_block = nil #: Array[String]?
       cat_depth = 0
-      pending = []  # category ゲート候補のトップレベル #@ 行
-      leading = []  # メタ領域先頭の #@# コメント行（irb.rd の Author 行）
+      # category ゲート候補のトップレベル #@ 行
+      pending = [] #: Array[String]
+      # メタ領域先頭の #@# コメント行（irb.rd の Author 行）
+      leading = [] #: Array[String]
       key = nil
       yaml_lines.each do |l|
         case l
@@ -179,16 +184,16 @@ module BitClust
         when /\Acategory:\s*(.*)$/
           if pending.any?
             # ゲート付き category（cmath 型）: #@ 行ごと復元する
-            category_block = pending.dup << "category #{$1.strip}\n"
+            category_block = pending.dup << "category #{($1 || raise).strip}\n"
             cat_depth = pending.count { |p| p =~ /\A\#@(?:since|until|if)\b/ } -
                         pending.count { |p| p =~ /\A\#@end\b/ }
             pending = []
           else
-            category = $1.strip
+            category = ($1 || raise).strip
           end
           key = nil
         when /\A\s+- (.+?)\s*$/
-          blocks[key] << [:item, $1] if key
+          blocks[key] << [:item, $1 || raise] if key
         when /\A\#@\#/
           key ? blocks[key] << [:dir, l] : leading << l
         when /\A\#@/
@@ -268,9 +273,9 @@ module BitClust
         when /\A\*\*(\d+)\.\*\*\s/
           convert_bold_number(line)
         when /\A(\s*)- /
-          convert_list_item(line, $1)
+          convert_list_item(line, $1 || raise)
         when /\A(\s{0,3})(\d+)\.\s/
-          convert_ordered_list_item(line, $2.to_i, $1)
+          convert_ordered_list_item(line, $2.to_i, $1 || raise)
         when /\A:\s/
           convert_dlist_passthrough(line)
         when /\A {4,}/
@@ -290,7 +295,7 @@ module BitClust
     def convert_code_block(line)
       # バッククォートの個数を取得
       line =~ /\A(`{3,})/
-      fence = $1
+      fence = $1 || raise
       fence_len = fence.length
 
       # 4個以上のバッククォート（言語指定なし）→ インデントコードに復元
@@ -317,11 +322,11 @@ module BitClust
       lang = nil
       fence_len = 3
       if line =~ /\A(`{3,})(\w*)/
-        fence_len = $1.length
-        lang = $2.empty? ? nil : $2
+        fence_len = ($1 || raise).length
+        lang = ($2 || raise).empty? ? nil : $2
       end
       if line =~ /title="((?:[^"\\]|\\.)*)"/
-        title = $1.gsub(/\\(["\\])/, '\1')
+        title = ($1 || raise).gsub(/\\(["\\])/, '\1')
       end
 
       if lang == 'ruby'
@@ -500,10 +505,10 @@ module BitClust
       # - **term**:\n  line1\n  line2 → : term\n  line1\n  line2
       if line =~ /\A- \*\*(.+?)\*\*: (.+)$/
         # 構造の `term` は GNU 引用復元より先に unwrap する
-        @out << ": #{convert_inline_refs(strip_code_span($1))}\n  #{convert_inline_refs($2)}\n"
+        @out << ": #{convert_inline_refs(strip_code_span($1 || raise))}\n  #{convert_inline_refs($2 || raise)}\n"
         advance
       elsif line =~ /\A- \*\*(.+?)\*\*:\s*$/
-        @out << ": #{convert_inline_refs(strip_code_span($1))}\n"
+        @out << ": #{convert_inline_refs(strip_code_span($1 || raise))}\n"
         advance
         # 継続行を収集（空行を挟む場合も含む）。rd 側と対称:
         # RDCompiler の dd_with_p はインデント段落とコードブロックを
@@ -542,7 +547,7 @@ module BitClust
 
     def convert_dlist_item(line)
       if line =~ /\A- \*\*(.+?)\*\* -- (.*)$/
-        @out << ": #{$1}\n  #{convert_inline_refs($2)}\n"
+        @out << ": #{$1}\n  #{convert_inline_refs($2 || raise)}\n"
       end
       advance
     end
@@ -576,7 +581,7 @@ module BitClust
     def convert_list_item(line, indent)
       rrd_indent = indent.empty? ? ' ' : indent
       line =~ /\A\s*-(\s+)/
-      content_indent = (indent.empty? ? 1 : indent.length) + 1 + $1.length
+      content_indent = (indent.empty? ? 1 : indent.length) + 1 + ($1 || raise).length
       @out << convert_inline_refs(line.sub(/\A\s*-(\s+)/, "#{rrd_indent}*\\1"))
       advance
       # 継続行を収集（空行・リスト項目・#@ で停止）。
@@ -619,9 +624,9 @@ module BitClust
       while @index < @lines.length
         line = current_line
         if line =~ /\A( {4,})\S/
-          n = $1.length
+          n = ($1 || raise).length
           deindent = [n - 3, 1].max
-          @out << (' ' * deindent) + line[n..]
+          @out << (' ' * deindent) + (line[n..] || raise)
           advance
         elsif line =~ /\A\s*$/
           if @index + 1 < @lines.length && @lines[@index + 1] =~ /\A {4,}\S/
@@ -709,7 +714,7 @@ module BitClust
           # [ の開始を検出（[[ は除外）— エスケープを考慮して ] を探す
           j = find_closing_bracket(line, i + 1)
           if j
-            inner = line[i+1...j]
+            inner = line[i+1...j] || raise
             if inner =~ /\A[a-zA-Z][a-zA-Z-]*:/
               result << convert_md_ref_to_rrd(inner)
               i = j + 1
@@ -717,7 +722,7 @@ module BitClust
             end
           end
         end
-        result << line[i]
+        result << (line[i] || raise)
         i += 1
       end
       result

--- a/lib/bitclust/markdown_tree.rb
+++ b/lib/bitclust/markdown_tree.rb
@@ -44,7 +44,7 @@ module BitClust
       warn_case_collisions(files)
       infos = files.to_h { |f| [f, parse_file(f)] }
 
-      referenced = {}
+      referenced = {} #: Hash[String, bool]
       infos.each do |path, info|
         info[:includes].each do |target|
           if (resolved = resolve(path, target, infos))
@@ -92,7 +92,7 @@ module BitClust
           @warnings << "entity with no library: #{path}"
         else
           info[:memberships].each do |m|
-            next if @libraries.key?(m[:library])
+            next if @libraries.key?(m[:library] || raise)
             @warnings << "entity refers to unknown library #{m[:library]}: #{path}"
           end
         end
@@ -108,6 +108,7 @@ module BitClust
     # front matter（raw 走査。#@ を含むため YAML パーサは使わない）と本文
     # （フェンス外の H1・H1 直後の関係行・#@include）を読む
     def parse_file(path)
+      # @type var info: file_info
       info = { kinds: [], library: nil, library_file: false, memberships: [],
                front_matter_relations: false, body_relations: false, includes: [] }
       lines = File.readlines(File.join(@root, path))
@@ -115,7 +116,7 @@ module BitClust
       if lines[0] =~ /\A---\s*\z/
         i = 1
         in_library_block = false
-        gate_stack = []
+        gate_stack = [] #: Array[[Symbol, String?]]
         while i < lines.length && lines[i] !~ /\A---\s*\z/
           line = lines[i]
           if in_library_block
@@ -137,7 +138,7 @@ module BitClust
           case line
           when /\Atype:\s*library\s*\z/ then info[:library_file] = true
           when /\Aname:\s*(\S+)/ then info[:name] = $1
-          when /\Alibrary:\s*\z/ then in_library_block = true; gate_stack = []
+          when /\Alibrary:\s*\z/ then in_library_block = true; gate_stack = [] #: Array[[Symbol, String?]]
           when /\Alibrary:\s*(\S+)/ then info[:memberships] << { library: $1 }
           when /\Asince:\s*"?([^"\s]+)"?/ then info[:since] = $1
           when /\Auntil:\s*"?([^"\s]+)"?/ then info[:until] = $1
@@ -153,7 +154,7 @@ module BitClust
       in_header = false
       h1_gated = false
       gate_depth = 0
-      lines[i..].each do |line|
+      (lines[i..] || raise).each do |line|
         if line =~ FENCE_RE
           in_fence = !in_fence
           in_header = false
@@ -169,11 +170,11 @@ module BitClust
         end
 
         if line =~ ENTITY_H1_RE
-          info[:kinds] << [$1, $2]
+          info[:kinds] << [$1 || raise, $2 || raise]
           in_header = true
           h1_gated = gate_depth > 0
         elsif line =~ INCLUDE_RE
-          info[:includes] << $1
+          info[:includes] << ($1 || raise)
           in_header = false
         elsif in_header
           case line

--- a/lib/bitclust/mdcompiler.rb
+++ b/lib/bitclust/mdcompiler.rb
@@ -214,10 +214,10 @@ module BitClust
         end
         case header
         when /\A- \*\*(param|arg)\*\*\s+`([^`]+)`( --(?:.*))?$/m
-          line "<dt class='#{@type.to_s}-param'>[PARAM] #{name_html($2)}:</dt>"
+          line "<dt class='#{@type.to_s}-param'>[PARAM] #{name_html($2 || raise)}:</dt>"
           rest = $3 ? ($3 || raise).sub(/\A --/, '') : +"\n"
         when /\A- \*\*raise\*\*\s+`([^`]+)`( --(?:.*))?$/m
-          line "<dt>[EXCEPTION] #{name_html($1)}:</dt>"
+          line "<dt>[EXCEPTION] #{name_html($1 || raise)}:</dt>"
           rest = $2 ? ($2 || raise).sub(/\A --/, '') : +"\n"
         when /\A- \*\*return\*\*( --(?:.*))?$/m
           line "<dt>[RETURN]</dt>"
@@ -370,7 +370,7 @@ module BitClust
         # #@since/#@else ゲートで分断されたインデントブロックは前処理後に
         # 隣接フェンスとして現れるため、続けてマージする（rd では連続
         # インデント行として1つの <pre> になる。ArgumentError 等）
-        segments = [[fence.size - 3, collect_fence_lines(terminator)]]
+        segments = [[fence.size - 3, collect_fence_lines(terminator)]] #: Array[[Integer, Array[String]]]
         loop do
           # rd の pre は空白行を跨ぐ（list は /\A\S/ まで継続）ため、
           # フェンス間の空白のみ行も次が 4+ フェンスならブロックの一部

--- a/lib/bitclust/mdparser.rb
+++ b/lib/bitclust/mdparser.rb
@@ -70,7 +70,7 @@ module BitClust
     # コードフェンス内の行頭 `# コメント` 等が H1/H2 と衝突しないよう、
     # フェンス内は無条件に本文として消費する
     def md_break(f)
-      lines = []
+      lines = [] #: Array[String?]
       fence_len = nil
       while (line = f.peek)
         if fence_len
@@ -105,7 +105,7 @@ module BitClust
     # （include/extend/alias/require/sublibrary）のみ。#@ 行は
     # Preprocessor で版解決済みの残り（#@# コメント等）なので読み飛ばす
     def read_front_matter(f)
-      fm = {}
+      fm = {} #: front_matter
       return fm unless f.peek && f.peek =~ /\A---\s*$/
       f.gets
       key = nil
@@ -266,6 +266,7 @@ module BitClust
       f.while_match(H2_RE) do |line|
         case line.sub(/\A##/, '').strip
         when /\A((?:public|private|protected)\s+)?(?:(class|singleton|instance)\s+)?methods?\z/i
+          # @type var visibility: :public | :private | :protected
           visibility = ($1 || 'public').downcase.strip.intern
           @context.visibility = visibility
           t = ($2 || 'instance').downcase.sub(/class/, 'singleton')

--- a/lib/bitclust/methoddatabase.rb
+++ b/lib/bitclust/methoddatabase.rb
@@ -261,7 +261,7 @@ module BitClust
       referenced = files.flat_map { |f|
         base = File.dirname(f)
         File.read(f).scan(/^\#@include\((.*?)\)/).map { |t|
-          p = File.expand_path(t[0], base)
+          p = File.expand_path(t[0] || raise, base)
           [p, "#{p}.md", p.sub(/\.rd\z/, '.md')]
         }.flatten
       }.to_set

--- a/lib/bitclust/methodsignature.rb
+++ b/lib/bitclust/methodsignature.rb
@@ -66,7 +66,7 @@ module BitClust
       when "[]="    # aset
         params = @params&.split(',')
         if params && params.size >= 2
-          val = params.pop
+          val = params.pop || raise
           "self[#{params.join(',').strip}] = #{val.strip}"
         else
           # Signatures like []=(*idxary) in historic documents cannot be

--- a/lib/bitclust/rrd_to_markdown.rb
+++ b/lib/bitclust/rrd_to_markdown.rb
@@ -99,22 +99,25 @@ module BitClust
       # 本文が「require の C 版です。」のように require で始まる場合の誤認を防ぐ
       return if @capi
       scan = @index
-      tokens = []       # [:cat, val] | [:req, val] | [:sub, val] | [:dir, line] | [:cmt, line] | [:blank]
+      # [:cat, val] | [:req, val] | [:sub, val] | [:dir, line] | [:cmt, line] | [:blank]
+      # （tuple の長さが混在するため untyped の列で扱う）
+      tokens = [] #: Array[untyped]
       nest = 0
-      checkpoint = nil  # 直近の「nest==0 の空行直後」= [scan, tokens.size]。
-                        # メタ確定をここまでで打ち切れる安全な切れ目
-                        # （md→rd の再生成がメタ群の後に空行を出すため、空行が必須）
+      # 直近の「nest==0 の空行直後」= [scan, tokens.size]。
+      # メタ確定をここまでで打ち切れる安全な切れ目
+      # （md→rd の再生成がメタ群の後に空行を出すため、空行が必須）
+      checkpoint = nil #: [Integer, Integer]?
       while scan < @lines.length
         l = @lines[scan]
         case l
         when /\Acategory\s+(.*)$/
           # 版条件つき category は「単一値の存在ゲート」のみ対応（値の差し替えは
           # 据え置き）。判定は build_metadata_front_matter のグループ検査で行う
-          tokens << [:cat, $1.strip]; scan += 1
+          tokens << [:cat, ($1 || raise).strip]; scan += 1
         when /\Arequire\s+(.*)$/
-          tokens << [:req, $1.strip]; scan += 1
+          tokens << [:req, ($1 || raise).strip]; scan += 1
         when /\Asublibrary\s+(.*)$/
-          tokens << [:sub, $1.strip]; scan += 1
+          tokens << [:sub, ($1 || raise).strip]; scan += 1
         when /\A\#@(?:since|until|if)\b/
           tokens << [:dir, l]; nest += 1; scan += 1
         when /\A\#@else\b/
@@ -133,7 +136,7 @@ module BitClust
         when /\A\#@/
           # #@todo 等 → チェックポイントまでで確定
           return unless checkpoint
-          scan, tokens = checkpoint[0], tokens[0, checkpoint[1]]
+          scan, tokens = checkpoint[0], tokens[0, checkpoint[1]] || raise
           nest = 0
           break
         else
@@ -141,7 +144,7 @@ module BitClust
           # 版分岐の途中で body に到達（set.rd/thread.rd の版分岐つき散文）
           # → チェックポイントまでで確定し、版分岐ごと body に渡す
           return unless checkpoint
-          scan, tokens = checkpoint[0], tokens[0, checkpoint[1]]
+          scan, tokens = checkpoint[0], tokens[0, checkpoint[1]] || raise
           nest = 0
           break
         end
@@ -150,10 +153,10 @@ module BitClust
       # 前置きコメント（rss.rd の「#@# = rss」）→ 最初の cmt 以降を body へ戻す
       # （連鎖先頭の空行はメタ領域の終端空行として残す）
       chain_start = (tokens.rindex { |t| !%i[cmt blank].include?(t[0]) } || -1) + 1
-      if (first_cmt = tokens[chain_start..].index { |t| t[0] == :cmt })
+      if (first_cmt = (tokens[chain_start..] || raise).index { |t| t[0] == :cmt })
         drop = tokens.length - (chain_start + first_cmt)
         scan -= drop
-        tokens = tokens[0...-drop]
+        tokens = tokens[0...-drop] || raise
       end
       return unless tokens.any? { |t| %i[cat req sub].include?(t[0]) }
       return if nest != 0               # ファイル全体の版ゲート内で EOF → 据え置き
@@ -179,8 +182,10 @@ module BitClust
       end
       toks = tokens.reject { |t| t[0] == :blank }
 
-      category = nil   # [:scalar, val] | [:block, md行列]
-      blocks = {}      # 'require' / 'sublibrary' => 組み立て済み md 行
+      # [:scalar, val] | [:block, md行列]
+      category = nil #: [Symbol, untyped]?
+      # 'require' / 'sublibrary' => 組み立て済み md 行
+      blocks = {} #: Hash[String, Array[String]]
       i = 0
       while i < toks.length
         kind, val = toks[i]
@@ -202,8 +207,8 @@ module BitClust
         when :dir
           # 完結した単一種のゲートブロックを読む
           depth = 0
-          group = []
-          gkinds = []
+          group = [] #: Array[[Symbol, String]]
+          gkinds = [] #: Array[Symbol]
           j = i
           loop do
             return false unless toks[j]
@@ -363,7 +368,7 @@ module BitClust
       elsif line =~ /\A\/\/emlist\{/
         # no caption, no lang
       end
-      parts = []
+      parts = [] #: Array[String]
       parts << "```"
       parts << (lang || "")
       if caption && !caption.empty?
@@ -448,7 +453,7 @@ module BitClust
     def convert_param(line)
       l = line.chomp
       if l =~ /\A@param(\s+)(\S+)(\s+)(.*)\z/
-        @out << "- **param**#{$1}`#{$2}` --#{$3}#{convert_inline_refs($4)}\n"
+        @out << "- **param**#{$1}`#{$2}` --#{$3}#{convert_inline_refs($4 || raise)}\n"
       elsif l =~ /\A@param(\s+)(\S+)\z/
         @out << "- **param**#{$1}`#{$2}` --\n"
       end
@@ -459,7 +464,7 @@ module BitClust
     def convert_raise(line)
       l = line.chomp
       if l =~ /\A@raise(\s+)(\S+)(\s+)(.*)\z/
-        @out << "- **raise**#{$1}`#{$2}` --#{$3}#{convert_inline_refs($4)}\n"
+        @out << "- **raise**#{$1}`#{$2}` --#{$3}#{convert_inline_refs($4 || raise)}\n"
       elsif l =~ /\A@raise(\s+)(\S+)\z/
         @out << "- **raise**#{$1}`#{$2}` --\n"
       end
@@ -543,9 +548,9 @@ module BitClust
     def convert_ulist_item(line)
       # B4: 元のインデント幅と * 後のスペースを保持
       line =~ /\A(\s+)\*(\s+)(.*)/
-      indent = $1
-      space = $2
-      text = $3
+      indent = $1 || raise
+      space = $2 || raise
+      text = $3 || raise
       content_indent = indent.length + 1 + space.length
       @out << "#{indent}-#{space}#{convert_inline_refs(text.chomp)}\n"
       advance
@@ -571,9 +576,9 @@ module BitClust
     def convert_olist_item(line)
       # B4: 元のインデント幅を保持
       line =~ /\A(\s+)\((\d+)\)\s+(.*)/
-      indent = $1
-      num = $2
-      text = $3
+      indent = $1 || raise
+      num = $2 || raise
+      text = $3 || raise
       @out << "#{indent}#{num}. #{convert_inline_refs(text.chomp)}\n"
       advance
       # 継続行を収集（ulist と同じ。RDCompiler の項目継続はインデント深さ不問）
@@ -653,7 +658,7 @@ module BitClust
 
     def convert_indented_code(line)
       # 行を収集してベースインデントを取得
-      code_lines = []
+      code_lines = [] #: Array[String]
       while @index < @lines.length
         line = current_line
         if line =~ /\A(\s+)\S/
@@ -678,7 +683,7 @@ module BitClust
       # ベースインデント（空行以外の最小インデント）を検出
       base_indent = code_lines
         .reject { |l| l =~ /\A\s*$/ }
-        .map { |l| l =~ /\A(\s+)/; $1.length }
+        .map { |l| l =~ /\A(\s+)/; ($1 || raise).length }
         .min || 1
 
       fence = '`' * (3 + base_indent)
@@ -687,7 +692,7 @@ module BitClust
         if l =~ /\A\s*$/
           @out << l
         else
-          @out << l[base_indent..]  # ベースインデントを除去
+          @out << (l[base_indent..] || raise)  # ベースインデントを除去
         end
       end
       @out << "#{fence}\n"
@@ -704,7 +709,8 @@ module BitClust
     def collect_header_relations
       return unless @single_entity
       scan = @index
-      tokens = []       # [:blank] | [:rel, kind, val] | [:dir, line]
+      # [:blank] | [:rel, kind, val] | [:dir, line]（tuple の長さが混在するため untyped の列で扱う）
+      tokens = [] #: Array[untyped]
       nest = 0
       saw_rel = false
       region_end = @index
@@ -712,7 +718,7 @@ module BitClust
         l = @lines[scan]
         case l
         when /\A(include|extend|alias)\s+(.+)$/
-          tokens << [:rel, $1, $2.strip]; scan += 1; saw_rel = true; region_end = scan
+          tokens << [:rel, $1, ($2 || raise).strip]; scan += 1; saw_rel = true; region_end = scan
         when /\A\#@(?:since|until|if)\b/
           tokens << [:dir, l]; nest += 1; scan += 1
         when /\A\#@else\b/
@@ -741,7 +747,8 @@ module BitClust
     # 1ブロック内の種別混在（データ上存在しない）は据え置き。
     def build_header_front_matter(tokens)
       toks = tokens.reject { |t| t[0] == :blank }
-      chunks = []   # [kind, 組み立て済み行の配列]
+      # [kind, 組み立て済み行の配列]
+      chunks = [] #: Array[[untyped, Array[String]]]
       i = 0
       while i < toks.length
         t = toks[i]
@@ -752,8 +759,8 @@ module BitClust
         end
         # #@ ブロック: 対応する #@end までを1チャンクに
         depth = 0
-        lines = []
-        kinds = []
+        lines = [] #: Array[String]
+        kinds = [] #: Array[String]
         while i < toks.length
           tt = toks[i]
           if tt[0] == :dir
@@ -843,8 +850,8 @@ module BitClust
       inner = inner.sub(/\.#/, '?.')
       # メソッド名内の [ ] をバックスラッシュエスケープ
       if inner =~ /\A([\w-]+:)(.*)/n
-        prefix = $1
-        target = $2
+        prefix = $1 || raise
+        target = $2 || raise
         target = target.gsub('\\', '\\\\\\\\').gsub('[', '\\[').gsub(']', '\\]')
         inner = prefix + target
       end

--- a/lib/bitclust/screen.rb
+++ b/lib/bitclust/screen.rb
@@ -323,7 +323,8 @@ module BitClust
     # URL of the ruby.wasm module used by the in-browser RUN button on Ruby
     # sample code (statichtml --run-ruby-wasm). nil disables the feature.
     def run_ruby_wasm_url
-      @conf[:run_ruby_wasm]
+      url = @conf[:run_ruby_wasm] #: String?
+      url
     end
 
     private
@@ -483,7 +484,8 @@ module BitClust
       opt = {:catalog => message_catalog()}.merge(@conf) #: RDCompiler::option
       if markdown_source?
         require 'bitclust/mdcompiler'
-        MDCompiler.new(@urlmapper, @hlevel, opt.merge(:gfm => true))
+        gfm_opt = opt.merge(:gfm => true) #: RDCompiler::option
+        MDCompiler.new(@urlmapper, @hlevel, gfm_opt)
       else
         RDCompiler.new(@urlmapper, @hlevel, opt)
       end
@@ -734,7 +736,8 @@ module BitClust
       h = {:force => true, :catalog => message_catalog() }.merge(@conf) #: RDCompiler::option
       if markdown_source?
         require 'bitclust/mdcompiler'
-        MDCompiler.new(@urlmapper, @hlevel, h.merge(:gfm => true))
+        gfm_opt = h.merge(:gfm => true) #: RDCompiler::option
+        MDCompiler.new(@urlmapper, @hlevel, gfm_opt)
       else
         RDCompiler.new(@urlmapper, @hlevel, h)
       end

--- a/lib/bitclust/search_index_generator.rb
+++ b/lib/bitclust/search_index_generator.rb
@@ -45,7 +45,7 @@ module BitClust
     # Builds the search index as an array of entry hashes.
     # +db+ is a MethodDatabase; +fdb+ is an optional FunctionDatabase (C API).
     def build_index(db, fdb = nil)
-      index = []
+      index = [] #: Array[entry]
       index.concat(class_entries(db))
       index.concat(method_entries(db))
       index.concat(library_entries(db))
@@ -67,7 +67,7 @@ module BitClust
     # scanning versions in ascending order — independent of the caller's
     # argument order, so the generated file diffs stay stable.
     def self.merge(version_indexes)
-      merged = {}
+      merged = {} #: Hash[Array[String?], merged_entry]
       sorted = version_indexes.sort_by { |version, _| Gem::Version.new(version) }
       sorted.each do |version, index|
         index.each do |e|
@@ -98,8 +98,8 @@ module BitClust
     end
 
     def method_entries(db)
-      seen = {}
-      result = []
+      seen = {} #: Hash[String, bool]
+      result = [] #: Array[entry]
       db.methods.each do |entry|
         next if entry.undefined?
 

--- a/lib/bitclust/subcommands/init_command.rb
+++ b/lib/bitclust/subcommands/init_command.rb
@@ -20,7 +20,7 @@ module BitClust
       STANDARD_PROPERTIES = %w( encoding version )
 
       def exec(argv, options)
-        prefix = options[:prefix]
+        prefix = options[:prefix] || raise
         db = MethodDatabase.new(prefix)
         db.init
         db.transaction {

--- a/lib/bitclust/subcommands/searchpage_command.rb
+++ b/lib/bitclust/subcommands/searchpage_command.rb
@@ -61,7 +61,7 @@ module BitClust
       end
 
       def exec(argv, options)
-        error("no --outputdir given") unless @outputdir
+        outputdir = @outputdir or error("no --outputdir given")
         error("no database given (pass one path per version)") if argv.empty?
 
         generator = SearchIndexGenerator.new(suffix: @suffix,
@@ -72,30 +72,29 @@ module BitClust
           version = db.properties['version'] or
             error("#{path}: no version property (not a bitclust database?)")
           $stderr.puts "indexing #{path} (#{version})" if @verbose
-          [version, generator.build_index(db, fdb)]
+          [version, generator.build_index(db, fdb)] #: [String, Array[SearchIndexGenerator::entry]]
         }
         versions = version_indexes.map {|version, _| version }
                                   .sort_by {|v| Gem::Version.new(v) }
 
-        jsdir = @outputdir + "js"
+        jsdir = outputdir + "js"
         FileUtils.mkdir_p(jsdir)
-        File.write(jsdir + "search_data.js",
-                   SearchIndexGenerator.merged_js(version_indexes))
+        (jsdir + "search_data.js").write(SearchIndexGenerator.merged_js(version_indexes))
         VENDORED_JS_FILES.each do |js|
           FileUtils.cp(@themedir + "js" + js, jsdir.to_s, :preserve => true)
         end
         # Ship the MIT notice for the vendored Aliki files alongside them.
         FileUtils.cp(@themedir + "js" + "NOTICE", jsdir.to_s, :preserve => true)
         FileUtils.cp(@themedir + "js" + "search_page.js", jsdir.to_s, :preserve => true)
-        FileUtils.cp(@themedir + "search.css", @outputdir.to_s, :preserve => true)
-        File.write(@outputdir + "index.html", render_page(versions))
+        FileUtils.cp(@themedir + "search.css", outputdir.to_s, :preserve => true)
+        (outputdir + "index.html").write(render_page(versions))
         $stderr.puts "generated search page for #{versions.join(', ')}" if @verbose
       end
 
       private
 
       def render_page(versions)
-        template = File.read(@templatedir + "index.html")
+        template = (@templatedir + "index.html").read
         template.sub('%%SEARCH_VERSIONS%%', JSON.generate(versions))
       end
     end

--- a/lib/bitclust/subcommands/update_command.rb
+++ b/lib/bitclust/subcommands/update_command.rb
@@ -48,7 +48,7 @@ module BitClust
                                                : (prepare_markdowntree; argv)
           else
             @db.transaction {
-              @db.update_by_markdowntree(@markdowntree)
+              @db.update_by_markdowntree(@markdowntree || raise)
             }
             return
           end
@@ -81,11 +81,11 @@ module BitClust
         require 'bitclust/markdown_bridge'
         @bridge_dir = Dir.mktmpdir('bitclust-md-bridge')
         root = File.join(@bridge_dir, 'api/src')
-        bridge = MarkdownBridge.build(@markdowntree, root)
+        bridge = MarkdownBridge.build(@markdowntree || raise, root)
         @location_map = { root => [@markdowntree, bridge.source_map] }
         # markdowntree と同じ渡され方（相対/絶対）を保った隣接 doc パス。
         # copy_doc は stdlibtree 相対（../../doc/...）の location を記録する
-        doc = File.join(File.dirname(@markdowntree), 'doc')
+        doc = File.join(File.dirname(@markdowntree || raise), 'doc')
         if File.directory?(doc)
           if Dir.glob(File.join(doc, '**/*.md')).any?
             doc_map = MarkdownBridge.build_doc(doc, File.join(@bridge_dir, 'doc'))
@@ -109,8 +109,8 @@ module BitClust
         # （関数の filename が旧経路と同じ「eval.c」等になる）
         src = File.join(@bridge_dir, 'src')
         FileUtils.mkdir_p(src)
-        capi_map = {}
-        files = Dir.glob(File.join(@markdowntree, '*.md')).sort.map do |f|
+        capi_map = {} #: Hash[String, String]
+        files = Dir.glob(File.join(@markdowntree || raise, '*.md')).sort.map do |f|
           name = "#{File.basename(f, '.md')}.rd"
           rd = File.join(src, name)
           File.write(rd, MarkdownToRRD.convert(File.read(f), capi: true))
@@ -126,11 +126,11 @@ module BitClust
       # md を指すようにするため。行番号はブリッジ rd 基準の近似で、
       # front matter 等の分だけ md とずれることがある
       def remap_source_locations
+        db = @db
         entries =
-          if @db.is_a?(FunctionDatabase)
-            @db.functions
+          if db.is_a?(FunctionDatabase)
+            db.functions
           else
-            db = @db
             db.is_a?(MethodDatabase) or raise
             db.libraries + db.classes + db.methods + db.docs
           end
@@ -143,10 +143,12 @@ module BitClust
       end
 
       def remap_location(loc)
+        file = loc.file
+        file.is_a?(String) or raise
         @location_map.each do |bridge_root, (md_root, map)|
           prefix = "#{bridge_root}/"
-          next unless loc.file.start_with?(prefix)
-          rel = loc.file.delete_prefix(prefix)
+          next unless file.start_with?(prefix)
+          rel = file.delete_prefix(prefix)
           rel = map[rel] || rel if map
           return Location.new(File.join(md_root, rel), loc.line)
         end

--- a/lib/bitclust/whole_file_gate.rb
+++ b/lib/bitclust/whole_file_gate.rb
@@ -41,7 +41,7 @@ module BitClust
       lines = src.lines
       open_idx, close_idx, cond, has_else = parse(lines)
       return nil if open_idx.nil? || close_idx.nil? || has_else || cond.nil?
-      content = lines[(open_idx + 1)...close_idx]
+      content = lines[(open_idx + 1)...close_idx] || raise
       i = 0
       i += 1 while content[i] && content[i] =~ BLANK_RE
       meta_start = i
@@ -56,14 +56,14 @@ module BitClust
         j += 1
       end
       return nil unless meta_end
-      rest = content[meta_end..]
+      rest = content[meta_end..] || raise
       rest.shift while rest.first && rest.first =~ BLANK_RE
       return nil if rest.empty?
       gate_line = lines[open_idx]
       # 種別（category/require/sublibrary）ごとに独立ブロックへ分ける
       # （メタデータ収集器の「#@ ブロックは単一種のみ」の制約に合わせる）
-      runs = []
-      content[meta_start...meta_end].each do |l|
+      runs = [] #: Array[[String?, Array[String]]]
+      (content[meta_start...meta_end] || raise).each do |l|
         next if l =~ BLANK_RE
         kind = l[/\A(category|require|sublibrary)/, 1]
         if runs.last && runs.last[0] == kind
@@ -73,10 +73,10 @@ module BitClust
         end
       end
       meta_blocks = runs.flat_map { |_, ls| [gate_line] + ls + ["\#@end\n", "\n"] }
-      (lines[0...open_idx] +
+      ((lines[0...open_idx] || raise) +
         meta_blocks +
         [gate_line] + rest + ["\#@end\n"] +
-        lines[(close_idx + 1)..]).join
+        (lines[(close_idx + 1)..] || raise)).join
     end
 
     # スコープの下で解除できる全体ゲートなら [解除後の src, front matter に
@@ -84,20 +84,20 @@ module BitClust
     def unwrap_for_scope(src, scope)
       lines = src.lines
       open_idx, close_idx, cond, has_else = parse(lines)
-      return nil if open_idx.nil? || close_idx.nil? || has_else
+      return nil if open_idx.nil? || close_idx.nil? || has_else || cond.nil?
 
       gate =
         case cond.kind
         when :if
           return nil unless provably_true_if?(cond.version, scope)
-          {}
+          {} #: IncludeGraph::gate
         else
           scoped = scope.gate([cond])
           return nil unless scoped   # スコープ外 → 据え置き
           scoped
         end
 
-      body = lines[0...open_idx] + lines[(open_idx + 1)...close_idx] + lines[(close_idx + 1)..]
+      body = (lines[0...open_idx] || raise) + (lines[(open_idx + 1)...close_idx] || raise) + (lines[(close_idx + 1)..] || raise)
       body.shift while body.first && body.first =~ BLANK_RE
       [body.join, gate]
     end
@@ -107,11 +107,11 @@ module BitClust
     def parse(lines)
       open_idx = lines.index { |l| l !~ BLANK_RE }
       return [nil] unless open_idx && lines[open_idx] =~ GATE_OPEN_RE
-      cond = IncludeGraph::Condition.new($1.to_sym, $2.strip)
+      cond = IncludeGraph::Condition.new(($1 || raise).to_sym, ($2 || raise).strip)
 
       nest = 0
       has_else = false
-      close_idx = nil
+      close_idx = nil #: Integer?
       (open_idx...lines.length).each do |i|
         case lines[i]
         when BLOCK_OPEN_RE then nest += 1
@@ -126,7 +126,7 @@ module BitClust
       end
       return [nil] if close_idx.nil?
       # 閉じ行の後に非空行があれば全体ゲートではない
-      return [nil] if lines[(close_idx + 1)..].any? { |l| l !~ BLANK_RE }
+      return [nil] if (lines[(close_idx + 1)..] || raise).any? { |l| l !~ BLANK_RE }
       [open_idx, close_idx, cond, has_else]
     end
 

--- a/sig/bitclust/capi_converter.rbs
+++ b/sig/bitclust/capi_converter.rbs
@@ -1,0 +1,12 @@
+module BitClust
+  # refm/capi（C API リファレンス）の Markdown 変換。
+  #
+  # capi の構造は「--- シグネチャ + 本文」の列のみで、見出し・include・
+  # ライブラリ等のクロスファイル情報が無い（FunctionReferenceParser 参照）。
+  # front matter は使わず、シグネチャは capi モードの変換
+  # 「--- <C sig>」↔「### <C sig>」（def 等のキーワード無し。C の
+  # シグネチャは型から始まるため自己記述的）で表す。本文の記法は api と共通。
+  module CapiConverter
+    def self?.convert: (String rrd) -> String
+  end
+end

--- a/sig/bitclust/database.rbs
+++ b/sig/bitclust/database.rbs
@@ -10,7 +10,7 @@ module BitClust
     type properties_type = ::Hash[propkey_type, String]
 
     # 'source' is internal use only
-    type database_propkey = 'version' | 'encoding' | 'source'
+    type database_propkey = 'version' | 'encoding' | 'source' | 'source_format'
     type database_properties = Hash[database_propkey, String]
 
     def self.dummy: (?database_properties params) -> instance

--- a/sig/bitclust/doc_converter.rbs
+++ b/sig/bitclust/doc_converter.rbs
@@ -1,0 +1,22 @@
+module BitClust
+  # refm/doc（散文ページ）の Markdown 変換。
+  #
+  # doc ページにはクロスファイル情報（library 所属等）が無いため、
+  # オーケストレータは不要で、reduce（正規化）+ 単一ファイル変換のみ。
+  # タイトルは H1 が担い、front matter は使わない。
+  #
+  # reduce は意味を変えない表記ゆれを md→rd の再生成形に合わせる正規化と、
+  # クロスツリー include（api 断片の transclude）の manual レイアウトへの
+  # 書き換えを行う。md→rd 変換は reduce の結果を復元する（検証の期待値）。
+  module DocConverter
+    def self?.reduce: (String rrd) -> String
+
+    def self?.convert: (String rrd) -> String
+
+    # 変換対象ファイルの一覧（doc ルート相対）。
+    # 旧パイプライン（copy_doc）は **/*.rd だけをページとして読むため、
+    # .rd 以外は doc 内 include から参照される断片のみを対象にし、
+    # 参照されない死にファイル（news/1.8.0.rd-2 等）は凍結側に残す
+    def self?.files: (String doc_root) -> Array[String]
+  end
+end

--- a/sig/bitclust/entity_splitter.rbs
+++ b/sig/bitclust/entity_splitter.rbs
@@ -1,0 +1,57 @@
+module BitClust
+  # マルチエンティティ RRD のエンティティ単位分割（O3）。
+  #
+  # 関係を持つマルチエンティティファイルをエンティティ単位のセグメントへ
+  # 分割する（判断はオーケストレータが行う。ここは純テキスト変換）。
+  module EntitySplitter
+    H1_RE: ::Regexp
+
+    GATE_OPEN_RE: ::Regexp
+
+    BLOCK_OPEN_RE: ::Regexp
+
+    BLANK_RE: ::Regexp
+
+    # parse_block の結果。body/else_body は枝の行列、next は #@end の次の行 index
+    type block = { body: Array[String], else_body: Array[String], next: Integer }
+
+    # エンティティ単位のセグメント [エンティティ名, テキスト]。
+    # ライブラリ概要部（ベースセグメント）は名前が nil
+    type segment = [String?, String]
+
+    # スコープ定数（スコープ内で常に真/偽）な版ゲートのうち、エンティティ H1 を
+    # 含むブロックを解決する
+    def self?.resolve_header_gates: (String src, IncludeGraph::Scope scope) -> String
+
+    # ゲート行のスコープ定数評価: 常真なら true、常偽なら false、
+    # 定数でない／ゲートでないなら nil
+    def self?.constant_truth: (String line, IncludeGraph::Scope scope) -> bool?
+
+    # samplecode の内容を除いて、エンティティ H1 行を含むか
+    def self?.contains_entity_h1?: (Array[String] lines) -> bool
+
+    # エンティティ単位のセグメント列を返す。境界が無ければ nil。
+    # 連結すると入力に一致する
+    def self?.segments: (String src) -> Array[segment]?
+
+    # start のゲート開き行に対応する #@end がセグメント終端（末尾の空行は許容）に
+    # あるか
+    def self?.gate_wraps_segment?: (Array[String] lines, Integer start, Integer stop) -> bool
+
+    # エンティティ名 → 出力ファイル名（拡張子なし）。:: → __
+    def self?.entity_filename: (String name) -> String
+
+    # いずれかのエンティティの H1 直後のヘッダ領域に include/extend/alias があるか
+    def self?.header_relations?: (String src) -> bool
+
+    def self?.gate_condition: (String line) -> IncludeGraph::Condition?
+
+    # i のゲート開始行から対応を取る。対応が取れなければ nil
+    def self?.parse_block: (Array[String] lines, Integer i) -> block?
+
+    def self?.first_content_is_h1?: (Array[String] branch_lines) -> bool
+
+    # i 以降の最初の非空行が H1 ならその名前を返す
+    def self?.first_h1_name: (Array[String] lines, Integer i) -> String?
+  end
+end

--- a/sig/bitclust/entry.rbs
+++ b/sig/bitclust/entry.rbs
@@ -44,9 +44,11 @@ module BitClust
 
     BracketLink: ::Regexp
 
-    def display_text: (String? text) -> String?
+    def display_text: (String text) -> String
+                    | (String? text) -> String?
 
-    def description_text: (String? text) -> String?
+    def description_text: (String text) -> String
+                        | (String? text) -> String?
 
     def type_id: () -> Symbol
 

--- a/sig/bitclust/functiondatabase.rbs
+++ b/sig/bitclust/functiondatabase.rbs
@@ -23,6 +23,10 @@ module BitClust
 
     def update_by_file: (String path, String filename) -> void
 
+    # C API の Markdown ツリー（manual/capi）を直接パースして更新する（M3）。
+    # filename は旧経路と同じ「eval.c」等（basename から .md を除いた形）
+    def update_by_markdowntree: (String md_root) -> void
+
     def search_functions: (string pattern) -> Array[FunctionEntry]
 
     def open_function: (String id) { (FunctionEntry) -> void } -> FunctionEntry

--- a/sig/bitclust/include_graph.rbs
+++ b/sig/bitclust/include_graph.rbs
@@ -1,0 +1,113 @@
+module BitClust
+  # doctree の #@include グラフを版ゲート付きで解析する
+  class IncludeGraph
+    # 版条件。kind は :since / :until / :if（#@end との対応取りのため
+    # :samplecode も積まれるが、snapshot 前に必ず除外される）。
+    # version は :since/:until ではバージョン文字列、:if では条件式文字列
+    # （:samplecode のみ nil で構築されるため new は String? を受ける）
+    class Condition < ::Struct[untyped]
+      attr_accessor kind: Symbol
+      attr_accessor version: String
+
+      def self.new: (Symbol kind, String? version) -> instance
+                  | ...
+    end
+
+    # grouping ファイルの1所属
+    class Membership < ::Struct[untyped]
+      attr_accessor library: String
+      attr_accessor conditions: Array[Condition]
+
+      def self.new: (String library, Array[Condition] conditions) -> instance
+                  | ...
+    end
+
+    # [Gem::Version, 原文字列] の境界の組。原文字列は $1 由来の String? を含む
+    type bound = [Gem::Version, String?]
+
+    # front matter に書く構造ゲート（キーは :since / :until のみ）
+    type gate = Hash[Symbol, String?]
+
+    # 注入する front matter。単一所属は 'library' => 名前、
+    # 複数所属は 'library' => ゲート付きリスト（MARKUP_SPEC §1.2）
+    type front_matter = Hash[String, String? | Array[Hash[String, String]]]
+
+    ENTITY_H1_RE: ::Regexp
+
+    def self.analyze: (String src_root) -> instance
+
+    def self.interval: (Array[Condition] conditions) -> [Gem::Version?, Gem::Version?]
+
+    def self.bounds: (Array[Condition] conditions) -> [bound?, bound?]
+
+    def self.if_bounds: (String expr) -> Array[[Symbol, String?]]
+
+    # 対象版範囲 [lo, hi)
+    class Scope
+      attr_reader lo: Gem::Version
+
+      attr_reader hi: Gem::Version
+
+      def initialize: (String lo, String hi) -> void
+
+      def cover?: (Array[Condition] conditions) -> bool
+
+      def always?: (Condition cond) -> bool
+
+      def never?: (Condition cond) -> bool
+
+      def never_conjunct?: (String conjunct) -> bool
+
+      def gate: (Array[Condition] conditions) -> gate?
+    end
+
+    attr_reader warnings: Array[String]
+
+    @src_root: String
+
+    @memberships: Hash[String, Array[Membership]]
+
+    @kinds: Hash[String, :grouping | :fragment]
+
+    @grouping_sites: Hash[String, Array[String]]
+
+    @library_gates: Hash[String, Array[Condition]]
+
+    def initialize: (String src_root) -> void
+
+    def analyze: () -> self
+
+    def memberships: (String relpath) -> Array[Membership]
+
+    def groupings: () -> Hash[String, Array[Membership]]
+
+    def fragments: () -> Array[String]
+
+    def grouping_include_sites: () -> Hash[String, Array[String]]
+
+    def library_front_matter_map: (Scope scope) -> Hash[String, Hash[String, String]]
+
+    def front_matter_map: (Scope scope) -> Hash[String, front_matter]
+
+    private
+
+    # 複数サイトのゲートの hull。実引数は Scope#gate の結果（cover? で
+    # フィルタ済みのため実際には非 nil）で、nil 合流を steep が解けないため
+    # untyped で受け渡す
+    def hull: (Array[untyped] gates) -> untyped
+
+    def read_libraries: () -> Hash[String, Array[Condition]]
+
+    def apply_directive: (Array[Condition] stack, String line) -> bool
+
+    def invert: (Condition cond) -> Condition
+
+    def walk: (String relpath, String library, Array[Condition] base_conditions, Array[String] path_stack) -> void
+
+    def add_include: (String from, String target, String library, Array[Condition] conditions, Array[String] path_stack) -> void
+
+    def resolve: (String from, String target) -> String?
+
+    def classify: (String relpath) -> (:grouping | :fragment)
+  end
+end

--- a/sig/bitclust/include_pruner.rbs
+++ b/sig/bitclust/include_pruner.rbs
@@ -1,0 +1,55 @@
+module BitClust
+  # RRD テキストから指定 target の #@include 行を除去する純変換（rd→rd）
+  module IncludePruner
+    INCLUDE_RE: ::Regexp
+
+    GATE_OPEN_RE: ::Regexp
+
+    CODE_OPEN_RE: ::Regexp
+
+    ELSE_RE: ::Regexp
+
+    END_RE: ::Regexp
+
+    BLANK_RE: ::Regexp
+
+    # ブロック除去・空行畳み込みの位置を示す番兵（固有の Object インスタンス）
+    REMOVED: Object
+
+    # パース結果のノード。行（String）か入れ子ブロック
+    type node = String | Block
+
+    # 展開後のストリーム。行（String）と REMOVED 番兵が混在するため
+    # 要素は untyped（番兵は equal? でのみ識別する）
+    type stream = Array[untyped]
+
+    # 版ゲート/サンプルコードブロック（#@... 〜 #@end）
+    class Block < ::Struct[untyped]
+      attr_accessor open: String
+      attr_accessor body: Array[node]
+      attr_accessor else_line: String?
+      attr_accessor else_body: Array[node]
+      attr_accessor end_line: String
+      attr_accessor gate: bool
+
+      def self.new: (String open, Array[node] body, String? else_line,
+                     Array[node] else_body, String end_line, bool gate) -> instance
+                  | ...
+    end
+
+    # lookup のキーは $1 由来の String? を受けるため nilable
+    def self?.prune: (String src, Array[String] targets) -> String
+
+    def self?.parse: (Array[String] lines) -> Array[node]
+
+    def self?.parse_nodes: (Array[String] lines, Integer i) -> [Array[node], Integer]
+
+    def self?.emit: (Array[node] nodes, Hash[String?, bool] lookup, stream stream) -> bool
+
+    def self?.emit_block: (Block block, Hash[String?, bool] lookup, stream stream) -> bool
+
+    def self?.blank_only?: (stream stream) -> bool
+
+    def self?.tidy: (stream stream) -> Array[String]
+  end
+end

--- a/sig/bitclust/markdown_bridge.rbs
+++ b/sig/bitclust/markdown_bridge.rbs
@@ -1,0 +1,88 @@
+module BitClust
+  # md ツリー → 旧形式の rd ツリー（LIBRARIES + .rd）を生成するブリッジ。
+  #
+  # 既存の update 機構（LIBRARIES → RRDParser/Preprocessor）を一切変更せずに
+  # md ツリーから DB を組み立てるための変換層。MarkdownTree の発見結果から:
+  # - LIBRARIES を再生成（ライブラリの since/until は #@ ゲートとして再具現化）
+  # - ライブラリ .rd = 変換済み本文 + メンバーへの #@include を再生成
+  # - メンバー = 変換済み本文を front matter の since/until で #@ ラップ
+  #   （版指定ビルドで構造ゲートが効くように）
+  # - 断片 = そのまま変換
+  # 出力ファイル名は「md 名から .md を剥いだもの」（ライブラリのみ .rd 付き）に
+  # 統一し、本文中の #@include ターゲットも emit 名へ書き換える
+  # （Preprocessor はリテラルパスで解決するため）。
+  class MarkdownBridge
+    @md_root: String
+
+    @out_root: String
+
+    @tree: MarkdownTree
+
+    @warnings: Array[String]
+
+    # 出力相対パス（emit 名） => 入力 md 相対パス
+    @source_map: Hash[String, String]
+
+    # 名前はパス由来とは限らない（ファイル名衝突回避で改名された
+    # rdoc/rdoc.lib.md は front matter の name: が正）ので、パスから引く
+    # （md 相対パス => ライブラリ名）
+    @lib_by_path: Hash[String, String]
+
+    # md ツリー内の全ディレクトリ相対パス（emit_name の衝突判定用。build で設定）
+    @dirs: Array[String]
+
+    INCLUDE_RE: ::Regexp
+
+    def self.build: (String md_root, String out_root) -> instance
+
+    # doc（散文ページ）の md ツリー → 旧形式の doc/*.rd。
+    # - クロスツリー include（api 断片の transclude）は旧レイアウト
+    #   （../api/src/）へ戻す（ブリッジの api ツリーは api/src に置かれるため）
+    # - doc 内ローカル include から参照される断片（spec/regexp19 等）は
+    #   拡張子なしで emit する（copy_doc は **/*.rd だけをページとして読む）
+    # 戻り値は source_map（出力相対パス => 入力 md 相対パス）
+    def self.build_doc: (String md_doc_root, String out_doc_root) -> Hash[String, String]
+
+    attr_reader warnings: Array[String]
+
+    # 出力相対パス（emit 名） => 入力 md 相対パス。
+    # source_location を manual/ の md へ再マップするために使う
+    attr_reader source_map: Hash[String, String]
+
+    def initialize: (String md_root, String out_root) -> void
+
+    def build: () -> self
+
+    private
+
+    # ライブラリは <name>.rd（update_by_stdlibtree の解決規約）。
+    # 非ライブラリは拡張子なし（doc ツリーが `../api/src/_builtin/pack-template` の
+    # ように元式の拡張子なし名で断片を transclude しているため）。
+    # ただし同名ディレクトリと衝突する場合は .rd を付ける（scanf.md と scanf/）
+    def emit_name: (String f) -> String
+
+    # LIBRARIES: 名前順。ライブラリの版ゲートは #@ で再具現化する
+    def libraries_manifest: () -> String
+
+    # ライブラリのメンバー（membership がこのライブラリを指すエンティティ）への
+    # #@include をライブラリ .rd のディレクトリ相対で再生成する。
+    # reopen/redefine だけのファイルは後ろに並べる（reopen が dynamic include する
+    # module は同ライブラリ内で先に定義されている必要がある: json/rake）。
+    # 多重所属（ゲート付き library リスト）は membership のゲートで
+    # include サイトをラップする（旧 LIBRARIES 世界のゲート付き include と同義）
+    def member_includes: (String libname, Hash[String, String] emitted) -> String
+
+    # front matter の構造ゲート（since/until）を #@ ラッパーとして再具現化する
+    def wrap_gate: (String rrd, MarkdownTree::entity_info entity) -> String
+
+    # 本文中の #@include ターゲットを emit 名（相対）へ書き換える。
+    # 解決できないターゲットはそのまま（発見段階で警告済み）
+    def rewrite_includes: (String rrd, String md_file, Hash[String, String] emitted) -> String
+
+    def resolve: (String base, String target, Hash[String, String] emitted) -> String?
+
+    def relative: (String path, String from_dir) -> String
+
+    def write: (String rel, String content) -> void
+  end
+end

--- a/sig/bitclust/markdown_orchestrator.rbs
+++ b/sig/bitclust/markdown_orchestrator.rbs
@@ -1,0 +1,119 @@
+module BitClust
+  # RRD ツリー → Markdown ツリー変換のクロスファイル方針を束ねるオーケストレータ。
+  #
+  # 単一ファイル記法変換（RRDToMarkdown）はそのままに、include グラフの解析結果から
+  # 各ファイルへ次を適用する:
+  # - grouping include の prune（エンティティ取り込みは front matter 発見へ移行）
+  # - ファイル全体を包む版ゲートの解除（front matter の since/until へ移行）
+  # - front matter 注入（member: library/構造ゲート、library ルート: type/版ゲート）
+  #
+  # スコープ（対象版範囲）はパラメータ。旧版サルベージ時は別スコープで再実行する。
+  class MarkdownOrchestrator
+    # relpath → 注入する front matter（IncludeGraph の解析結果 +
+    # library ルートの type/版ゲートをマージしたもの）
+    @extra: Hash[String, IncludeGraph::front_matter]
+
+    @prune_sites: Hash[String, Array[String]]
+
+    attr_reader scope: IncludeGraph::Scope
+
+    attr_reader graph: IncludeGraph
+
+    def initialize: (String src_root, ?scope: IncludeGraph::Scope) -> void
+
+    def warnings: () -> Array[String]
+
+    # 変換対象か。LIBRARIES は front matter による発見に置き換わるため対象外
+    def convert?: (String relpath) -> bool
+
+    # 1つの出力 .md ファイルに対応する単位。
+    # path = 出力相対パス、rrd = rd 側到達点（md→rd 検証の期待値）、
+    # front_matter = 注入する front matter
+    class Unit < ::Struct[untyped]
+      attr_accessor path: String
+      attr_accessor rrd: String
+      attr_accessor front_matter: IncludeGraph::front_matter
+
+      def self.new: (String path, String rrd, IncludeGraph::front_matter front_matter) -> instance
+                  | ...
+    end
+
+    # relpath の RRD を出力単位の列に還元する。
+    # ヘッダ関係（include/extend/alias）を持つマルチエンティティファイルは
+    # エンティティ単位に分割する（関係の front matter 一元化のため）。
+    # 関係を持たない束ね（Errno 族等）と lib+単一エンティティ兼用ファイルは
+    # 1 単位のまま。ライブラリファイルの分割ではエンティティを <libname>/ 配下に
+    # 置き、library と版ゲートを注入する
+    def units: (String relpath, String rrd) -> Array[Unit]
+
+    def convert_unit: (Unit unit) -> String
+
+    # relpath の RRD を新パイプライン形の Markdown へ変換する（分割なしファイル用）
+    def convert: (String relpath, String rrd) -> String
+
+    # 変換の rd 側到達点（prune + 全体ゲート解除 + 定数 H1 ゲート解決後の RRD）と
+    # front matter。MarkdownToRRD.convert(convert(...)) はこの RRD と一致する
+    def reduce: (String relpath, String rrd) -> [String, IncludeGraph::front_matter]
+
+    private
+
+    # 分割すべきならセグメント列（EntitySplitter.segments と同形の
+    # [エンティティ名, テキスト] の列。名前 nil はライブラリ概要部）を、
+    # そうでなければ nil を返す。
+    # 条件: エンティティ（名前付きセグメント）が2つ以上 + いずれかがヘッダ関係を持つ。
+    # lib+単一エンティティ兼用（pathname 型、仕様が認める形）は分割しない
+    def split_segments: (String reduced) -> Array[[String?, String]]?
+
+    # セグメントの置き場所が元ファイルと異なるディレクトリになる場合
+    # （lib 分割 → <libname>/ 配下）、相対 #@include を新ディレクトリから
+    # 解決できるよう書き換える
+    def rewrite_includes: (String text, String source_dir, String new_dir) -> String
+
+    # 出力 .md の相対パス（.rd は差し替え、その他は付加）
+    def md_path: (String relpath) -> String
+
+    # ライブラリファイルの出力パス。他ファイルの出力と大文字小文字のみで
+    # 衝突する場合（rdoc/rdoc.md と rdoc/RDoc.md）は basename に .lib を挟んで
+    # 回避する（macOS/Windows の case-insensitive FS でチェックアウト不能に
+    # なるため）。名前がパスから導出できなくなるので front matter の name: で保持する
+    def output_path: (String relpath, IncludeGraph::front_matter front_matter) -> String
+
+    RELATION_RE: ::Regexp
+
+    HEADER_DIR_RE: ::Regexp
+
+    BLANK_LINE_RE: ::Regexp
+
+    # H1 直後のヘッダ関係領域を md→rd の再生成形に正規化する:
+    # 最後の関係行までの空行を除き、関係行の末尾空白を落とす。
+    # 関係を持たない H1 の直後や本文の空行・散文ゲートは触らない
+    def normalize_header_regions: (String rrd) -> String
+
+    # 「=class Encoding」のようなスペース無し H1（RRDParser は受理）を
+    # 正規形「= class」に直す。単一ファイル変換器は正規形のみ扱う
+    def normalize_entity_h1: (String rrd) -> String
+
+    # 「---critical=(bool)」のようなスペース無しシグネチャ（RDCompiler は
+    # /\A---/ で受理）を正規形「--- name」に直す。コードブロック内に
+    # 行頭 --- は現れない前提（roundtrip 検証が破れを検出する）
+    def normalize_signature_spacing: (String rrd) -> String
+
+    # ファイル全体ゲートを front matter へ解除してよいか。
+    # - 常真ゲート（gate == {}）: 常に解除（従来どおり）
+    # - 断片・スコープ外（front matter なし）: 据え置き。front matter を付けると
+    #   #@include 展開の途中に `---` が現れてパースが壊れる（_builtin/Fiber.current）
+    # - type: library ルート: LIBRARIES 由来境界に包含される場合のみ（下記）
+    # - メンバー: エンティティ自身の存在ゲートなので常に解除
+    def unwrap_allowed?: (IncludeGraph::front_matter front_matter, IncludeGraph::gate gate) -> bool
+
+    # ライブラリルートのファイル全体ゲートが LIBRARIES 由来の既存境界に
+    # 包含されるか。包含されないゲート（cmath: LIBRARIES は until のみ +
+    # ファイルは #@since 1.9.1）をマージすると「ライブラリの存在」まで
+    # 狭めてしまう（旧世界ではスコープ下限の版にも存在して内容が空）
+    def gate_subsumed?: (IncludeGraph::front_matter front_matter, IncludeGraph::gate gate) -> bool
+
+    # ファイル全体ゲートと注入済みゲート（include サイト / LIBRARIES 由来）の交差を取る
+    # （since は max、until は min。両者は同じ制約の別表現なので通常は一致する）
+    def merge_gate: (IncludeGraph::front_matter front_matter, IncludeGraph::gate gate) -> void
+  end
+end

--- a/sig/bitclust/markdown_to_rrd.rbs
+++ b/sig/bitclust/markdown_to_rrd.rbs
@@ -1,0 +1,143 @@
+module BitClust
+  # Markdown（MARKUP_SPEC 形式）のドキュメントを RRD 形式へ復元する変換器
+  class MarkdownToRRD
+    @src: String
+
+    @capi: bool
+
+    @lines: Array[String]
+
+    @out: Array[String]
+
+    @index: Integer
+
+    @front_matter: Hash[String, untyped]
+
+    # クラス関係（H1 直後、RRD 文法順 alias → extend → include）。
+    # front matter が無いソースでは未設定（nil）だが、参照側は常に
+    # 真偽ガード付きなので実用上 non-nil として扱う
+    @class_relations: Array[String]
+
+    # ライブラリメタ（H1 前）。@class_relations と同じく実用上 non-nil
+    @library_metadata_body: Array[String]
+
+    def self.convert: (String markdown, ?capi: bool) -> String
+
+    # md テキスト断片のインライン記法を rd 形式へ復元する
+    # （[type:target] → [[type:target]]、\[ エスケープ解除）。
+    # MDCompiler がテキストノードの処理を共有するための公開 API
+    def self.restore_inline: (String text) -> String
+
+    # md テキストノードを旧経路と同じ表示形（rd のインライン形式）へ戻す
+    def self.restore_text: (String text) -> String
+
+    # entry#description（コンパイラ非経由テキスト）と RefsDatabase のラベル用:
+    # インラインに加えて行頭構造も旧表示形へ戻す
+    def self.restore_description: (String text) -> String
+
+    # description 内のフェンスを旧経路の表示形へ戻す。
+    # フェンス内容は \x01<idx>\x01 プレースホルダで saved に退避される
+    def self.restore_display_fences: (String text, Array[String] saved) -> String
+
+    # 行頭構造（見出し・メタデータ行）の rd 表示形への復元
+    def self.restore_display_line: (String l) -> String
+
+    # capi: C API リファレンスモード。### は見出しではなくシグネチャ
+    def initialize: (String markdown, ?capi: bool) -> void
+
+    def convert: () -> String
+
+    private
+
+    def parse_front_matter: () -> void
+
+    def emit_library_metadata: () -> void
+
+    # front matter を生行で走査し、#@ ディレクティブを保持したまま
+    # ライブラリメタとクラス関係の body 行を組み立てる
+    def parse_front_matter_raw: (Array[String] yaml_lines) -> void
+
+    def process_body: () -> void
+
+    def convert_code_block: (String line) -> void
+
+    def convert_method_signature: (String line) -> void
+
+    def convert_module_function_signature: (String line) -> void
+
+    def convert_const_signature: (String line) -> void
+
+    def convert_gvar_signature: (String line) -> void
+
+    # kind は process_body の $1（param/return/raise）
+    def convert_metadata: (String line, String? kind) -> void
+
+    # greedy: rd 側の @param 系継続（RDCompiler の dd_without_p 相当）と対称
+    def collect_md_continuation_lines: (?greedy: bool) -> void
+
+    def convert_see: (String line) -> void
+
+    def convert_see_list_upper: (String line) -> void
+
+    def convert_see_list: (String line) -> void
+
+    def convert_see_passthrough: (String line) -> void
+
+    def convert_heading_with_anchor: (String line, String prefix) -> void
+
+    # 見出しテキストのバッククォート復元（参照変換は通さない）
+    def restore_heading_backticks: (String text) -> String
+
+    def convert_h3_heading: (String line) -> void
+
+    def convert_h4_heading: (String line) -> void
+
+    def convert_h5_heading: (String line) -> void
+
+    def strip_code_span: (String text) -> String
+
+    def convert_dlist_colon_item: (String line) -> void
+
+    def convert_dlist_item: (String line) -> void
+
+    def convert_bold_number: (String line) -> void
+
+    def convert_ordered_list_item: (String line, Integer num, String indent) -> void
+
+    def convert_list_item: (String line, String indent) -> void
+
+    def convert_dlist_passthrough: (String line) -> void
+
+    def convert_indented_code: (String line) -> void
+
+    def convert_h2: (String line) -> void
+
+    # capi の C シグネチャ（キーワード無し ###）を復元する
+    def convert_capi_signature: (String line) -> void
+
+    # rd→md がエスケープした行頭 # のリテラル本文を復元する
+    def convert_escaped_hash_line: (String line) -> void
+
+    def convert_h1: (String line) -> void
+
+    def raw_passthrough: (String line) -> void
+
+    def passthrough: (String line) -> void
+
+    # テキスト行のコードスパンを rd の元表記へ復元する
+    def strip_code_spans: (String text) -> String
+
+    # Markdown のブラケットリンク: エスケープされた \[ \] を含むパターン
+    def convert_inline_refs: (String line) -> String
+
+    def convert_bare_refs: (String line) -> String
+
+    def find_closing_bracket: (String line, Integer start) -> Integer?
+
+    def convert_md_ref_to_rrd: (String ref) -> String
+
+    def current_line: () -> String
+
+    def advance: () -> void
+  end
+end

--- a/sig/bitclust/markdown_tree.rbs
+++ b/sig/bitclust/markdown_tree.rbs
@@ -1,0 +1,64 @@
+module BitClust
+  # 新パイプラインのファイル発見（MARKUP_SPEC §1.1）
+  class MarkdownTree
+    # ゲート付き所属（{ library:, since:, until: }）。項目は動的なキー
+    # （gate_stack 由来の Symbol）で代入されるためレコードではなく Hash。
+    # 値は $1 由来の String? を受ける
+    type membership = Hash[Symbol, String?]
+
+    # @libraries の値（name => { path:, since:, until: }）
+    type library_info = { path: String, since: String?, until: String? }
+
+    # @entities の値。kinds の要素は [種別, 名前]（ENTITY_H1_RE の $1/$2）
+    type entity_info = { names: Array[String], kinds: Array[[String, String]],
+                         library: String?, memberships: Array[membership],
+                         since: String?, until: String? }
+
+    # parse_file が返す1ファイル分の生情報。name/since/until/fragment は
+    # 出現したときのみ設定される
+    type file_info = { kinds: Array[[String, String]], library: String?,
+                       library_file: bool, memberships: Array[membership],
+                       front_matter_relations: bool, body_relations: bool,
+                       includes: Array[String],
+                       ?name: String?, ?since: String?, ?until: String?,
+                       ?fragment: bool? }
+
+    ENTITY_H1_RE: ::Regexp
+
+    RELATION_LINE_RE: ::Regexp
+
+    RELATION_KEY_RE: ::Regexp
+
+    INCLUDE_RE: ::Regexp
+
+    FENCE_RE: ::Regexp
+
+    BLANK_RE: ::Regexp
+
+    def self.scan: (String root) -> instance
+
+    attr_reader libraries: Hash[String, library_info]
+
+    attr_reader entities: Hash[String, entity_info]
+
+    attr_reader fragments: Array[String]
+
+    attr_reader warnings: Array[String]
+
+    @root: String
+
+    def initialize: (String root) -> void
+
+    def scan: () -> self
+
+    private
+
+    def validate: (String path, file_info info) -> void
+
+    def parse_file: (String path) -> file_info
+
+    def warn_case_collisions: (Array[String] files) -> void
+
+    def resolve: (String from, String target, Hash[String, file_info] infos) -> String?
+  end
+end

--- a/sig/bitclust/mdcompiler.rbs
+++ b/sig/bitclust/mdcompiler.rbs
@@ -1,0 +1,108 @@
+module BitClust
+  # Markdown ソース → HTML のネイティブコンパイラ。
+  # 行レベルのディスパッチだけを Markdown 記法に差し替え、
+  # HTML の出力部品は RDCompiler から継承する
+  class MDCompiler < RDCompiler
+    # RDCompiler の宣言と同型。rbs subtract は親クラスの宣言を
+    # 参照しないため、残余ゼロにするためにここでも宣言する
+    @item_stack: Array[String?]
+
+    private
+
+    # RDCompiler のテキストコンパイル（エスケープ・参照解決）を
+    # GFM モードのセグメント処理から呼ぶための別名
+    alias rd_compile_text compile_text
+
+    def gfm?: () -> bool?
+
+    # メソッド系シグネチャ（キーワード付き h3）
+    METHOD_SIGNATURE_RE: ::Regexp
+
+    def signature_re: () -> ::Regexp
+
+    MD_ITEM_RE: ::Regexp
+
+    FENCE_RE: ::Regexp
+
+    DLIST_RE: ::Regexp
+
+    INFO_RE: ::Regexp
+
+    SEE_RE: ::Regexp
+
+    # @undef など変換器が生のまま渡す未知メタデータ
+    RAW_META_RE: ::Regexp
+
+    # 生のまま残った #@samplecode が前処理で //emlist になったもの
+    EMLIST_LEFTOVER_RE: ::Regexp
+
+    def library_file: () -> void
+
+    def entry_chunk: () -> void
+
+    # md シグネチャ行を rd 形式（--- ...）へ落とし、既存のシグネチャ処理を継承する
+    def method_signature: (String sig_line, bool first) -> void
+
+    def headline: (String line) -> void
+
+    def read_paragraph: (LineInput f) -> Array[String]
+
+    def read_entry_paragraph: (LineInput f) -> Array[String]
+
+    def paragraph: () -> void
+
+    def entry_paragraph: () -> void
+
+    def unescape_hash: (String line) -> String
+
+    # - **param** `name` -- desc / - **return** -- desc / - **raise** `Ex` -- desc
+    # および生の @xxx（未知メタデータ）
+    def entry_info: () -> void
+
+    # - **SEE** [m:X], [m:Y]（継続行あり）
+    def see: () -> void
+
+    # - **`term`**: / - **term**: の定義リスト（説明はインデント行）
+    def dlist: () -> void
+
+    def strip_code_span: (String text) -> String
+
+    # param 名・raise 例外名: GFM モードでは <code> で包む
+    def name_html: (String name) -> String
+
+    # GFM テーブルの区切り行（|---|:--:|... ）
+    TABLE_DELIM_RE: ::Regexp
+
+    # GFM テーブル。テーブルでなければ何も消費せず false を返す
+    def try_table: () -> bool
+
+    def parse_table_aligns: (String delim) -> Array[String?]
+
+    def table_row: (String row, String tag, Array[String?] aligns) -> void
+
+    # 行をセルに分割（先頭/末尾の | を除去、\| はリテラルの |）
+    def split_table_row: (String row) -> Array[String]
+
+    # フェンスドコードブロック
+    def code_fence: () -> void
+
+    def collect_fence_lines: (Regexp terminator) -> Array[String]
+
+    # 箇条書き（- item / N. item、ネスト・継続行あり）
+    def item_list: (?::Integer level) -> void
+
+    # RDCompiler の dd_with_p / dd_without_p の md 版
+    def dd_with_p: () -> void
+
+    def dd_without_p: () -> void
+
+    # テキストノード: インライン記法を rd 形式へ復元してから既存の
+    # コンパイル（エスケープ・リンク解決）を継承する
+    def compile_text: (String str) -> String
+
+    # GFM モードのテキストコンパイル
+    def compile_gfm_text: (String str) -> String
+
+    def restore_rd_text: (String str) -> String
+  end
+end

--- a/sig/bitclust/mdparser.rbs
+++ b/sig/bitclust/mdparser.rbs
@@ -1,0 +1,80 @@
+module BitClust
+  # C API リファレンス（manual/capi）の md を直接パースする。
+  # capi の md は本文見出しを持たず、### 全行がシグネチャ
+  # （--- <C sig> 相当、キーワード無し）。source は本文の md がそのまま入る
+  class MDFunctionParser < FunctionReferenceParser
+    private
+
+    def file_entries: (LineInput f) -> void
+  end
+
+  class MDParser < RRDParser
+    # lib 内の型注釈（#: Array[Chunk]）が親クラスの Chunk を参照できるようにする
+    # （Ruby の定数探索と同じ解決結果）
+    class Chunk = RRDParser::Chunk
+
+    # front matter（YAML のサブセット）。値はスカラー（String）とリスト
+    # （Array[String]）がキーごとに混在するため untyped。キーは $1 由来の
+    # String? を受けるため nilable
+    type front_matter = Hash[String?, untyped]
+
+    def self.split_doc: (String source) -> [String, String]
+
+    # メソッド系シグネチャ（キーワード付き h3）
+    SIG_RE: ::Regexp
+
+    # H1（エンティティ見出し）。エスケープされた行頭リテラル \# は除外
+    H1_RE: ::Regexp
+
+    # H2（レベル2セクション見出し）
+    H2_RE: ::Regexp
+
+    # klass.source / library.source の終端（H1・H2・シグネチャ）
+    BREAK_RE: ::Regexp
+
+    # RRDParser と同じ（rbs subtract がスーパークラスの宣言を見ないため再掲）
+    @context: RRDParser::Context
+
+    @front_matter: front_matter
+
+    def parse: (File | StringIO f, String libname, ?Database::database_properties params) -> LibraryEntry
+
+    private
+
+    # BREAK_RE まで行を収集する。要素は実際には非 nil（peek で確認済みの行のみ
+    # gets する）だが、LineInput#gets の型に合わせて String?
+    def md_break: (LineInput f) -> Array[String?]
+
+    def merge_front_matter: (front_matter fm) -> void
+
+    def read_front_matter: (LineInput f) -> front_matter
+
+    def do_parse: (LineInput f) -> void
+
+    RELATION_KEYS: Array[String]
+
+    def read_classes: (LineInput f) -> void
+
+    def parse_level1_header: (String line) -> [String?, String?, String?]
+
+    def read_aliases: (LineInput f) -> void
+
+    def read_includes: (LineInput f, ?bool reopen) -> void
+
+    def read_extends: (LineInput f, ?bool reopen) -> void
+
+    def read_class_body: (LineInput f) -> void
+
+    def read_reopen_body: (LineInput f) -> void
+
+    def read_object_body: (LineInput f) -> void
+
+    def read_level2_blocks: (LineInput f) -> void
+
+    def read_chunks: (LineInput f) -> Array[Chunk]
+
+    def read_chunk: (LineInput f) -> Chunk
+
+    def method_signature: (String line) -> RRDParser::Signature
+  end
+end

--- a/sig/bitclust/methoddatabase.rbs
+++ b/sig/bitclust/methoddatabase.rbs
@@ -59,11 +59,41 @@ module BitClust
 
     def update_by_file: (String path, String libname) -> LibraryEntry
 
+    # Markdown ツリー（manual/api）を直接パースして DB を更新する（M3）。
+    # front matter の library: が所属を表すため、ライブラリごとに
+    # lib ファイル → メンバーファイル（reopen/redefine のみのファイルは後置。
+    # dynamic include の対象 module が先に定義されている必要があるため）の
+    # 順でパースする。版ゲート（since/until）外のライブラリ/メンバーはスキップ。
+    # エントリの source には md 断片が入り、source_location は md の実パスを指す
+    def update_by_markdowntree: (String md_root) -> void
+    # md モード（update --markdowntree）でのみ設定される。実行時は未設定（nil）も
+    # あり得るが、読む側は常に truthy ガード付きなので @root と同じ扱いで非 nil 宣言
+    @md_root: String
+
+    private
+
+    # since は「その版以降」、until は「その版未満」（ブリッジの
+    # #@since/#@until ラッパーと同じ意味論）。
+    # version は properties()["version"]、since/until は MarkdownTree の
+    # front matter 由来のバージョン文字列（Gem::Version へ変換して比較する）
+    def md_version_covers?: (String version, String? since_version, String? until_version) -> bool
+
+    public
+
     def refs: () -> RefsDatabase
 
     def make_refs: () -> RefsDatabase
 
     def copy_doc: () -> void
+
+    private
+
+    # ネイティブ md ツリーの doc ページ登録（manual/api の隣の manual/doc）。
+    # ページ = 他の doc ファイルから #@include 参照されていない .md。
+    # source には md がそのまま入り、source_location は md の実パスを指す
+    def copy_doc_md: () -> void
+
+    public
 
     def docs: () -> Array[DocEntry]
 

--- a/sig/bitclust/parseutils.rbs
+++ b/sig/bitclust/parseutils.rbs
@@ -15,12 +15,14 @@ module BitClust
   end
 
   class Location
-    def initialize: (String? file, Integer line) -> void
+    # line が nil の Location は「行不明」（FunctionReferenceParser の
+    # source_location フォールバック）
+    def initialize: (String? file, Integer? line) -> void
                   | (Pathname file, Integer line) -> void
 
     attr_reader file: (String? | Pathname)
 
-    attr_reader line: Integer
+    attr_reader line: Integer?
 
     def to_s: () -> String
 

--- a/sig/bitclust/rdcompiler.rbs
+++ b/sig/bitclust/rdcompiler.rbs
@@ -2,7 +2,7 @@ module BitClust
   class RDCompiler
     @urlmapper: URLMapper
 
-    @catalog: MessageCatalog
+    @catalog: MessageCatalog?
 
     @hlevel: Integer
 
@@ -16,13 +16,16 @@ module BitClust
       :entry => Entry[MethodDatabase],
       :force => bool,
       :stop_on_syntax_error => bool,
+      ?:gfm => bool,
     }
+    # :catalog は実装上省略可（無ければ MessageCatalog.new({}, 'C') が使われる）
     type option = {
-      :catalog => MessageCatalog,
+      ?:catalog => MessageCatalog,
       ?:database => Database,
       ?:entry => any_entry,
       ?:force => bool,
       ?:stop_on_syntax_error => bool,
+      ?:gfm => bool,
     }
 
     @option: option_internal

--- a/sig/bitclust/rrd_to_markdown.rbs
+++ b/sig/bitclust/rrd_to_markdown.rbs
@@ -1,0 +1,151 @@
+module BitClust
+  class RRDToMarkdown
+    # include グラフ解析（IncludeGraph）が計算して注入する front matter。
+    # 値は scalar（type/name/library/since/until）か、library 多重所属の
+    # ゲート付きリスト（{"name" => .., "since" => .., "until" => ..}）
+    # 値の nil は「境界なし」（呼び出し側の gate 由来）。emit 時に無視される
+    type extra_front_matter = Hash[Symbol | String, String? | Array[Hash[String, String]]]
+
+    @src: String
+
+    @capi: bool
+
+    @extra_front_matter: Hash[String, String? | Array[Hash[String, String]]]
+
+    @lines: Array[String]
+
+    @out: Array[String]
+
+    @index: Integer
+
+    # キーごとに値の形が異なる:
+    # - type/name/library: String | Array[Hash[String, String]]（ゲート付き多重所属）
+    # - since/until/category(scalar): String
+    # - category(ゲート付き)/require/sublibrary/include/extend/alias/leading:
+    #   Array[String]（組み立て済み行）
+    @front_matter: Hash[String, untyped]
+
+    @current_section: (:module_function | nil)
+
+    # front matter はファイル単位。複数エンティティを含むファイルでは
+    # include/extend/alias の帰属が曖昧になるため、単一エンティティ時のみ front matter 化する
+    # （分割前の安全策。分割後は全ファイルが単一エンティティになる）。
+    @single_entity: bool
+
+    def self.convert: (String rrd, ?extra_front_matter: extra_front_matter, ?capi: bool) -> String
+
+    # RDCompiler の dlist 継続は /\A:/（スペース不要）で dt になる
+    # （spec/operator の「:再定義できない演算子」）。dlist 文脈にある
+    # 「:term」だけを正規形「: term」に直す。
+    def self.normalize_dlist_colon_spacing: (String rrd) -> String
+
+    # ファイル単体からは決められない front matter（library 所属・構造 since/until）を
+    # 注入するための口。include グラフを解析したオーケストレータが値を計算して渡す。
+    EXTRA_FRONT_MATTER_KEYS: Array[String]
+
+    # capi: C API リファレンス（refm/capi）モード。シグネチャは C の
+    # 「--- <型付きシグネチャ>」で、def 等のキーワードを付けずに ### へ変換する
+    def initialize: (String rrd, ?extra_front_matter: extra_front_matter, ?capi: bool) -> void
+
+    def convert: () -> String
+
+    private
+
+    SAMPLECODE_RE: ::Regexp
+
+    def collect_library_metadata: () -> void
+
+    # 先頭メタデータ領域の tokens を front matter へ組み立てる。
+    # tokens は [:cat|:req|:sub|:dir|:cmt, String] | [:blank] のトークン列。
+    # チェックポイント巻き戻しのスライス再代入で nilable になるため untyped
+    def build_metadata_front_matter: (untyped tokens) -> bool
+
+    def emit_front_matter: () -> String
+
+    def process_body: () -> void
+
+    def convert_emlist: (String line) -> void
+
+    DIRECTIVE_NEST_RE: ::Regexp
+
+    DIRECTIVE_END_RE: ::Regexp
+
+    def convert_samplecode: (String line) -> void
+
+    def convert_signature: (String line) -> void
+
+    def convert_param: (String line) -> void
+
+    def convert_raise: (String line) -> void
+
+    def convert_return: (String line) -> void
+
+    def convert_see: (String line) -> void
+
+    # greedy: RDCompiler の dd_without_p と同じ貪欲さ（@param 等のメタデータ用）。
+    def collect_continuation_lines: (?greedy: bool) -> void
+
+    # anchor/text は正規表現キャプチャ（$1/$2 = String?）で渡される。
+    # line は行頭 =+ の再マッチ結果（String#[] が nilable）を直接 .length するため untyped
+    def convert_anchored_heading: (untyped line, String? anchor, untyped text) -> void
+
+    def convert_h3: (String line, String? text) -> void
+
+    def convert_h4: (String line, String? text) -> void
+
+    def convert_h5: (String line) -> void
+
+    def convert_ulist_item: (String line) -> void
+
+    def convert_olist_item: (String line) -> void
+
+    def code_like_term?: (String term) -> bool
+
+    def format_dlist_term: (String term) -> String
+
+    # term は process_body の正規表現キャプチャ（$1 = String?）由来
+    def convert_dlist_item: (String line, untyped term) -> void
+
+    def convert_indented_code: (String line) -> void
+
+    def convert_h1: (String line) -> void
+
+    # H1 直後の include/extend/alias を front matter へ集約する。
+    def collect_header_relations: () -> void
+
+    # tokens（[:rel, kind, val] | [:dir, line] | [:blank]）を
+    # front matter のブロック行（`  - item\n` / `#@...\n`）へ組み立てる。
+    def build_header_front_matter: (Array[untyped] tokens) -> bool
+
+    def convert_h2: (String line) -> void
+
+    def convert_text_number: (String line) -> void
+
+    def raw_passthrough: (String line) -> void
+
+    def passthrough: (String line) -> void
+
+    # テキスト行の __WORD__ パターンをコードスパンに変換
+    def add_code_spans: (String text) -> String
+
+    # BitClust::RDCompiler::BracketLink と同等の正規表現
+    BRACKET_LINK: ::Regexp
+
+    def convert_inline_refs: (String text) -> String
+
+    # match は MatchData#[]（String?）由来で、[[ ]] 除去のスライスも
+    # nilable になるため untyped
+    def convert_one_ref: (untyped match) -> String
+
+    # 参照に見えるリテラル本文 [ruby-talk:198440] 等（旧 news）をエスケープする
+    def escape_ref_lookalikes: (String bin) -> String
+
+    # GNU 風引用 `token' → コードスパン、残りの生バッククォート → \`
+    def escape_backticks: (String bin) -> String
+
+    # ループ不変条件（@index < @lines.length）の下でのみ呼ばれる
+    def current_line: () -> String
+
+    def advance: () -> void
+  end
+end

--- a/sig/bitclust/runner.rbs
+++ b/sig/bitclust/runner.rbs
@@ -16,6 +16,10 @@ module BitClust
       def help: () -> String
 
       def exec: (Subcommand::argv argv, Subcommand::options options) -> void
+
+      def respond_to?: (Symbol name) -> bool
+
+      def needs_database?: () -> bool
     end
 
     @subcommands: Hash[String, _Subcommand]

--- a/sig/bitclust/screen.rbs
+++ b/sig/bitclust/screen.rbs
@@ -116,6 +116,10 @@ module BitClust
 
     def custom_js_url: (String js) -> ::String
 
+    # 実装は statichtml の URLMapperEx のみ。呼び出し側（TemplateScreen#html_base）は
+    # respond_to? ガード付きで呼ぶため、基底の sig でのみ宣言する
+    def bitclust_html_base: () -> String
+
     def favicon_url: () -> ::String
 
     def library_index_url: () -> ::String
@@ -268,6 +272,11 @@ module BitClust
 
     def custom_js_url: (String js) -> String
 
+    # Relative path from the current page to the site root, used as the
+    # prefix for client-side search result links in statichtml output.
+    # （statichtml の URLMapperEx のみが bitclust_html_base を持つ）
+    def html_base: () -> String
+
     def favicon_url: () -> String
 
     def current_url: () -> bot
@@ -309,6 +318,10 @@ module BitClust
     def compile_function: (FunctionEntry f, ?RDCompiler::opt opt) -> String
 
     def compile_rd: (String src) -> String
+
+    # DB が Markdown ソース（update --markdowntree のネイティブパース）なら
+    # MDCompiler（GFM モード）で描画する
+    def markdown_source?: () -> bool
 
     def rdcompiler: () -> RDCompiler
 

--- a/sig/bitclust/subcommands/searchpage_command.rbs
+++ b/sig/bitclust/subcommands/searchpage_command.rbs
@@ -20,7 +20,7 @@ module BitClust
 
       def needs_database?: () -> bool
 
-      def exec: (argv argv, options options) -> void
+      def exec: (Subcommand::argv argv, Subcommand::options options) -> void
 
       private
 

--- a/sig/bitclust/subcommands/statichtml_command.rbs
+++ b/sig/bitclust/subcommands/statichtml_command.rbs
@@ -123,6 +123,10 @@ module BitClust
 
       def copy_run_ruby_wasm_script: () -> void
 
+      SEARCH_JS_FILES: Array[String]
+
+      def create_search_index: (Pathname outputdir, MethodDatabase db, FunctionDatabase fdb) -> void
+
       def create_html_file: (any_entry entry, ScreenManager manager, Pathname outputdir, Database db) -> void
 
       def create_html_method_file: (String method_name, Array[MethodEntry] entries, ScreenManager manager, Pathname outputdir, MethodDatabase db) -> void

--- a/sig/bitclust/subcommands/update_command.rbs
+++ b/sig/bitclust/subcommands/update_command.rbs
@@ -3,7 +3,18 @@ module BitClust
     class UpdateCommand < Subcommand
       @root: String?
 
+      @markdowntree: String?
+
       @library: String?
+
+      # ブリッジ経路（BITCLUST_MD_BRIDGE=1）でのみ設定される一時ディレクトリ。
+      # 実行時は未設定（nil）もあり得るが、読む側（ensure 節）は truthy ガード付き
+      # なので MethodDatabase の @root と同じ扱いで非 nil 宣言
+      @bridge_dir: String
+
+      # ブリッジ出力 root => [md ツリー root, 出力相対パス => 入力 md 相対パス]。
+      # map が nil（doc が .rd のまま symlink されたケース）なら相対パスをそのまま使う
+      @location_map: Hash[String, [String, Hash[String, String]?]]
 
       def initialize: () -> void
 
@@ -12,6 +23,26 @@ module BitClust
       def exec: (Subcommand::argv argv, Subcommand::options options) -> void
 
       private
+
+      # Markdown ツリーを旧形式の rd ツリーへブリッジし、既存の
+      # stdlibtree 更新機構にそのまま渡す。
+      # doc（散文ページ）は stdlibtree/../../doc から読まれるため、
+      # md ツリー側に doc/ が同居していればレイアウトを合わせる
+      # （manual/api を渡すと manual/doc を拾う。md ならブリッジ変換、
+      # .rd のまま（移行中）なら symlink）。
+      def prepare_markdowntree: () -> void
+
+      # C API の Markdown ツリー（manual/capi）を旧形式の .rd 群へ変換し、
+      # ファイル引数として返す（--capi update <files> の経路に載せる）
+      def prepare_capi_markdowntree: () -> Array[String]
+
+      # source_location のブリッジ一時パスを manual/ の md パスへ再マップする。
+      # 編集リンク（statichtml --edit-base-url）が凍結 refm でなく編集対象の
+      # md を指すようにするため。行番号はブリッジ rd 基準の近似で、
+      # front matter 等の分だけ md とずれることがある
+      def remap_source_locations: () -> void
+
+      def remap_location: (Location loc) -> Location?
 
       def guess_library_name: (String path) -> String
 

--- a/sig/bitclust/whole_file_gate.rbs
+++ b/sig/bitclust/whole_file_gate.rbs
@@ -1,0 +1,39 @@
+module BitClust
+  # ファイル全体を包む単一の版ゲート（#@else 無し）の検出と解除（O4）。
+  #
+  # 旧 RRD ではライブラリ/エンティティ自体の版ゲートをファイル全体の
+  # #@since/#@until/#@if ラップで表現していた。新パイプラインでは
+  # front matter の since/until（構造ゲート）で表現するため、
+  # スコープの下で「常に真」または「since/until で表現できる」ラップは外す。
+  module WholeFileGate
+    GATE_OPEN_RE: ::Regexp
+
+    BLOCK_OPEN_RE: ::Regexp
+
+    BLANK_RE: ::Regexp
+
+    # 常に真と証明できる #@if 条件の形（rss.rd の (version >= "1.8.2")）
+    VERSION_GE_RE: ::Regexp
+
+    # parse の結果: [開き行 idx, 閉じ行 idx, Condition, トップレベル #@else の有無]。
+    # 全体ゲートでなければ [nil]（多重代入で全要素 nil に落ちる）
+    type parse_result = [Integer, Integer, IncludeGraph::Condition, bool] | [nil]
+
+    # ファイル全体を包むゲートの Condition を返す。該当しなければ nil
+    def self?.detect: (String src) -> IncludeGraph::Condition?
+
+    # 据え置きゲートのメタデータ領域（require/sublibrary/category）を、本文と
+    # 分けてそれぞれ同じゲートで包んだ意味等価な正規形に書き換える。
+    # 全体ゲートでない・メタデータが無い・本文が無い場合は nil
+    def self?.regate_metadata: (String src) -> String?
+
+    # スコープの下で解除できる全体ゲートなら [解除後の src, front matter に
+    # 書く gate（{} は不要の意）] を返す。据え置きなら nil
+    def self?.unwrap_for_scope: (String src, IncludeGraph::Scope scope) -> [String, IncludeGraph::gate]?
+
+    def self?.parse: (Array[String] lines) -> parse_result
+
+    # 値は `=~` の Integer? を経由するため nil がありうる（真偽値としてのみ使う）
+    def self?.provably_true_if?: (String condition, IncludeGraph::Scope scope) -> bool?
+  end
+end

--- a/sig/rouge.rbs
+++ b/sig/rouge.rbs
@@ -1,0 +1,17 @@
+# Rouge gem(シンタックスハイライト)の最小スタブ。
+# RDCompiler#highlight_source で使う API のみ定義する。
+module Rouge
+  class Lexer
+    def self.find: (String name) -> singleton(Lexer)?
+
+    def self.tag: (?String? t) -> String
+
+    def self.lex: (String stream, ?Hash[Symbol, untyped] opts) -> untyped
+  end
+
+  module Formatters
+    class HTML
+      def format: (untyped tokens) -> String
+    end
+  end
+end


### PR DESCRIPTION
## 解決したい問題

Markdown 移行(#189 以降)で追加されたコードに RBS 型定義が無く、
型検査の網羅性チェックである `rake sig` が失敗する状態でした
(`rbs subtract` の残余が 18 ファイル分)。`steep check` も
**エラー 471 件・警告 317 件**を報告しており、そのほぼ全てが
markdown 対応の型付け漏れ由来でした(新規クラスの宣言欠落、
既存クラスに追加された markdown 系メソッドの sig 未追記、およびその波及)。

## 変更内容

### sig の新規作成(13 ファイル)

markdown パイプラインの全クラスを既存 sig と同じ流儀
(ivar 宣言・`private` 対応・`type` エイリアス・実型優先)で型付けしました:

- パース/描画: `mdparser`(MDParser / MDFunctionParser)、`mdcompiler`
- 記法変換: `markdown_to_rrd`、`rrd_to_markdown`、`capi_converter`、`doc_converter`
- ツリー/ブリッジ: `markdown_tree`、`markdown_bridge`、`markdown_orchestrator`
- include 解析: `include_graph`、`include_pruner`、`entity_splitter`、`whole_file_gate`

`untyped` は本当に動的な箇所(混在 arity のトークン列など)だけに限定し、
理由をコメントで残しています。

### 既存 sig への追記・修正

- markdown 対応で増えたメンバーの追記:
  `MethodDatabase#update_by_markdowntree`/`#copy_doc_md`、
  `FunctionDatabase#update_by_markdowntree`、
  `TemplateScreen#markdown_source?`/`#html_base`、
  `UpdateCommand#prepare_markdowntree` ほか、
  `StatichtmlCommand#create_search_index`/`SEARCH_JS_FILES`
- `database_propkey` に `'source_format'` を追加
- Rouge の最小スタブ `sig/rouge.rbs` を追加(#223 で導入した
  `Lexer.find`/`tag`/`lex` と `Formatters::HTML#format` のみ)
- 実装と食い違っていた既存 sig の修正:
  `RDCompiler::option` の `:catalog` を省略可へ(実装はフォールバック持ち)、
  `Location` の `line` を `Integer?` へ(行不明の Location が実在)、
  `Entry#display_text`/`#description_text` をオーバーロード化
  (`(String) -> String | (String?) -> String?`)、
  searchpage_command.rbs の型名修飾漏れ(`argv` → `Subcommand::argv`。
  これが原因で同ファイルの lib 側チェック自体が走っていませんでした)

### lib 側(挙動の変更はありません)

- マッチ直後で非 nil が保証される `$1` 等の参照・Array の Range スライスは、
  コードベース既存慣行の **`($1 || raise)` 形**に統一(rrdparser.rb に先例)
- steep が推論できない空リテラルやループ越し代入にインライン注釈
  (`#: Array[String]` / `# @type var`)を追加
- `#: 型` 注釈の直後に説明文が続いて**注釈のパースが壊れていた既存 2 箇所を修復**
  (説明文を前行コメントへ分離)
- rbs core の型が Pathname を受けない `File.read`/`File.write` を
  `Pathname#read`/`#write` に書き換え(searchpage_command)

## 検証

| 検査 | Before | After |
|---|---|---|
| `bundle exec rake sig` | 失敗(残余 18 ファイル) | ✅ 通過 |
| `bundle exec steep check` | エラー 471・警告 317 | ✅ **エラー 0・警告 0** |
| `bundle exec rbs validate` | — | ✅ 通過 |
| `ruby test/run_test.rb` | — | ✅ 17,589 tests / 0 failures |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
