### PR TITLE
CI で rake sig と steep check を回す

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,17 @@
 name: test
 
-on: [push, pull_request]
+# doc/ 等ドキュメントだけの変更では CI を回さない（doctree と同様）
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - 'README.md'
+      - 'ChangeLog'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'README.md'
+      - 'ChangeLog'
 
 jobs:
   ruby-versions:
@@ -32,6 +43,24 @@ jobs:
       run: bundle install
     - name: Run test
       run: bundle exec rake
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
+      with:
+        # 型検査は最新安定版1本で回す（バージョン網羅は build ジョブが担う）。
+        # rbs/steep のバージョンは Gemfile.lock で固定されている
+        ruby-version: '3.4'
+        bundler-cache: true
+    - name: Install RBS collection
+      run: bundle exec rake rbs:install
+    # sig/ が lib/ の全宣言をカバーしているか（rbs subtract の残余ゼロ）+ rbs validate
+    - name: Check sig coverage
+      run: bundle exec rake sig
+    - name: Run steep check
+      run: bundle exec steep check
 
   rurema:
     needs: ruby-versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,12 +50,14 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        # 型検査は最新安定版1本で回す（バージョン網羅は build ジョブが担う）。
-        # rbs/steep のバージョンは Gemfile.lock で固定されている
+        # 型検査は1バージョンで回せば十分（バージョン網羅は build ジョブが担う）。
+        # rbs 3.10 / steep 1.9（Gemfile.lock で固定）の検証済み環境である 3.4 を使う
         ruby-version: '3.4'
         bundler-cache: true
     - name: Install RBS collection
-      run: bundle exec rake rbs:install
+      # --frozen: rbs_collection.lock.yaml のとおりに取得する。
+      # 再解決すると gem_rbs_collection の revision が動き、環境差も出るため
+      run: bundle exec rbs collection install --frozen
     # sig/ が lib/ の全宣言をカバーしているか（rbs subtract の残余ゼロ）+ rbs validate
     - name: Check sig coverage
       run: bundle exec rake sig

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -21,6 +21,16 @@ gems:
   - name: steep
     ignore: true
 
+  # bitclust 自身（path gem）は sig/ を持つため、コレクション解決に
+  # 含まれると Steepfile の signature "sig" と二重ロードになり
+  # DuplicatedDeclaration で steep が失敗する。必ず除外する
+  - name: bitclust-core
+    ignore: true
+  - name: bitclust-dev
+    ignore: true
+  - name: refe2
+    ignore: true
+
   - name: date
   #- name: drb
   - name: erb


### PR DESCRIPTION
## 解決したい問題

#231 で sig/ が lib/ の全宣言をカバーし、`steep check` が
エラー 0・警告 0 になりましたが、CI では型検査を回していないため、
今後の変更で sig の追従漏れや型エラーが入っても検出できません。

## 変更内容

### typecheck ジョブの追加

test.yml に `typecheck` ジョブを追加します(既存ジョブは変更なし):

1. `bundle exec rake rbs:install` — rbs_collection.lock.yaml で
   固定された gem_rbs_collection を取得
2. `bundle exec rake sig` — `rbs prototype rb` → `rbs subtract` の
   **残余ゼロ = sig が lib の全宣言をカバーしていることの検査**
   (新しいクラス/メソッド/ivar を追加して sig を書き忘れると失敗します)
   + `rbs validate`
3. `bundle exec steep check` — 型エラーで失敗

### ドキュメントだけの変更で CI を回さない

doctree の ci.yml と同様に、`on:` へ `paths-ignore` を追加し、
**doc/**・README.md・ChangeLog だけの変更では既存の test / rurema ジョブ含め
ワークフロー全体をスキップ**します(doc/ 配下は設計文書・MARKUP_SPEC 等のみで、
テストフィクスチャやランタイムが参照するファイルはありません)。

## 備考

- Ruby はテストのバージョンマトリクスとは独立に、最新安定版の
  **3.4 固定**です(型検査は1バージョンで十分。バージョン網羅は
  build ジョブが担います)
- rbs / steep のバージョンは Gemfile.lock(rbs 3.10.3 / steep 1.9.4、
  Gemfile で `steep ~> 1.9.0`)で固定されており、`bundler-cache: true` で
  そのまま再現されます。rbs のメジャーアップ時に prototype の出力形が
  変わっても、lock を更新するまで CI は影響を受けません
- sig 書き忘れ時の `rake sig` の失敗は `Errno::ENOTEMPTY`(sig-prototype の
  rmdir 失敗)として現れます。残余ファイルが sig-prototype/ に残るので、
  ローカルで `bundle exec rake sig` を実行すると不足分が確認できます

## 検証

- ローカル(rbs 3.10.3 / steep 1.9.4)で 2→3 の手順を実行し、
  `rake sig` 通過・`steep check` は "No type error detected" を確認
- ワークフロー YAML のパースを確認
- (`rake rbs:install` はこの作業環境のネットワーク制限で最終確認できて
  いないため、CI の初回実行で要確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
