### PR TITLE
実行可能サンプル(RUN)を Web Worker 化して停止・タイムアウトに対応

### DIFF
--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -327,18 +327,26 @@ HERE
                      :verbose => @verbose, :preserve => true)
       end
 
-      # Copy the RUN-button script (statichtml --run-ruby-wasm). A themedir
-      # without js/run.js is tolerated: warn and skip instead of aborting the
-      # whole build.
+      # Scripts for the RUN-button feature (statichtml --run-ruby-wasm):
+      # run.js sets up the button and compiles the wasm module on the main
+      # thread; run-worker.js is the module Worker it spawns per execution
+      # (see theme/default/js/run.js for why: STOP/timeout both just
+      # Worker#terminate() it). Both are required for the feature to work.
+      RUN_RUBY_WASM_JS_FILES = %w[run.js run-worker.js].freeze
+
+      # Copy the RUN-button scripts. A themedir missing one of them is
+      # tolerated: warn and skip instead of aborting the whole build.
       def copy_run_ruby_wasm_script
-        run_js = @manager_config[:themedir] + "js" + "run.js"
-        unless run_js.file?
-          $stderr.puts "warning: #{run_js} not found; RUN button script not copied"
-          return
-        end
         jsdir = @outputdir + "js"
-        FileUtils.mkdir_p(jsdir) unless jsdir.directory?
-        FileUtils.cp(run_js.to_s, jsdir.to_s, :verbose => @verbose, :preserve => true)
+        RUN_RUBY_WASM_JS_FILES.each do |name|
+          src = @manager_config[:themedir] + "js" + name
+          unless src.file?
+            $stderr.puts "warning: #{src} not found; RUN button script not copied"
+            next
+          end
+          FileUtils.mkdir_p(jsdir) unless jsdir.directory?
+          FileUtils.cp(src.to_s, jsdir.to_s, :verbose => @verbose, :preserve => true)
+        end
       end
 
       def create_html_file(entry, manager, outputdir, db)

--- a/sig/bitclust/subcommands/statichtml_command.rbs
+++ b/sig/bitclust/subcommands/statichtml_command.rbs
@@ -121,6 +121,8 @@ module BitClust
 
       def create_index_html: (Pathname outputdir) -> void
 
+      RUN_RUBY_WASM_JS_FILES: Array[String]
+
       def copy_run_ruby_wasm_script: () -> void
 
       SEARCH_JS_FILES: Array[String]

--- a/test/js/test_run.mjs
+++ b/test/js/test_run.mjs
@@ -8,7 +8,7 @@
 // importing either file here never touches a real DOM/Worker.
 import {
   createOnceLoader, formatRunError, truncateOutput,
-  accumulateOutput, STOPPED_NOTE, timeoutNote,
+  accumulateOutput, STOPPED_NOTE, timeoutNote, editableText,
 } from '../../theme/default/js/run.js'
 import { PRELUDE, formatRunError as formatWorkerRunError } from '../../theme/default/js/run-worker.js'
 
@@ -119,6 +119,15 @@ assert(accumulateOutput('', 'first') === 'first',
 assert(STOPPED_NOTE === '(停止しました)', 'STOPPED_NOTE is the stop notice')
 assert(timeoutNote(30) === '(30秒でタイムアウトしました)',
        'timeoutNote formats the configured timeout in seconds')
+
+// editableText: flattening for edit drops the compiler's leading newline
+// (the artifact after <code>) but keeps interior/trailing newlines intact
+assert(editableText('\np 1\np 2\n') === 'p 1\np 2\n',
+       'editableText strips the leading newline artifact')
+assert(editableText('\n\n\np 1\n') === 'p 1\n',
+       'editableText strips all leading blank lines')
+assert(editableText('p 1\n\np 2\n') === 'p 1\n\np 2\n',
+       'editableText keeps interior and trailing newlines')
 
 if (failures > 0) {
   throw new Error(failures + ' JS test(s) failed')

--- a/test/js/test_run.mjs
+++ b/test/js/test_run.mjs
@@ -1,8 +1,16 @@
-// QuickJS-based tests for the pure logic in theme/default/js/run.js.
+// QuickJS-based tests for the pure logic in theme/default/js/run.js and
+// theme/default/js/run-worker.js.
 // Run with: qjs test/js/test_run.mjs   (see the "test:js" rake task)
-// Importing the module doubles as a syntax/eval smoke test: its DOM setup is
-// guarded by `typeof window !== 'undefined'`.
-import { createOnceLoader, PRELUDE, formatRunError, truncateOutput } from '../../theme/default/js/run.js'
+// Importing each module doubles as a syntax/eval smoke test: run.js's DOM
+// setup is guarded by `typeof window !== 'undefined'`, and run-worker.js's
+// Worker setup is guarded by `typeof self !== 'undefined' && typeof
+// WorkerGlobalScope !== 'undefined'` -- neither exists under QuickJS, so
+// importing either file here never touches a real DOM/Worker.
+import {
+  createOnceLoader, formatRunError, truncateOutput,
+  accumulateOutput, STOPPED_NOTE, timeoutNote,
+} from '../../theme/default/js/run.js'
+import { PRELUDE, formatRunError as formatWorkerRunError } from '../../theme/default/js/run-worker.js'
 
 let failures = 0
 function assert(cond, message) {
@@ -52,11 +60,20 @@ function assert(cond, message) {
          'next call after a rejection retries the load')
 }
 
-// PRELUDE captures both streams into one StringIO
-assert(PRELUDE.includes('require "stringio"') &&
-       PRELUDE.includes('$stdout = StringIO.new') &&
+// PRELUDE (run-worker.js) streams both channels to the main thread via the
+// JS bridge, instead of buffering into a StringIO like the old single-eval
+// PRELUDE did.
+assert(PRELUDE.includes('require "js"') &&
+       PRELUDE.includes('JS.global.call(:postOutput, text)') &&
+       PRELUDE.includes('$stdout = JSStreamIO.new') &&
        PRELUDE.includes('$stderr = $stdout'),
-       'PRELUDE redirects $stdout and $stderr into one StringIO')
+       'PRELUDE redirects $stdout and $stderr through postOutput()')
+
+// run-worker.js's formatRunError is the same shape as run.js's copy (each
+// runs in its own realm -- main thread vs. worker -- so it is a small
+// intentional duplication rather than an import cycle across the two files)
+assert(formatWorkerRunError(new Error('boom')) === 'boom',
+       'run-worker.js formatRunError matches run.js formatRunError')
 
 // formatRunError
 assert(formatRunError(new Error('boom')) === 'boom',
@@ -77,6 +94,31 @@ assert(truncateOutput('short') === 'short', 'truncateOutput keeps short output')
   assert(truncated.startsWith('x'.repeat(10)) && truncated.endsWith('... (truncated)'),
          'truncateOutput cuts long output with a marker')
 }
+
+// accumulateOutput: incremental version of truncateOutput, used to append
+// each Worker 'output' message to what is already on screen.
+assert(accumulateOutput('foo', 'bar') === 'foobar',
+       'accumulateOutput appends a chunk to the existing text')
+assert(accumulateOutput('', 'first') === 'first',
+       'accumulateOutput handles an empty starting value')
+{
+  const grown = accumulateOutput('x'.repeat(8), 'y'.repeat(8), 10)
+  assert(grown === 'x'.repeat(8) + 'y'.repeat(2) + '\n... (truncated)',
+         'accumulateOutput truncates once the cap is crossed mid-chunk')
+}
+{
+  // A chunk arriving after the cap was already hit must be a no-op, not a
+  // second "... (truncated)" marker or renewed growth.
+  const alreadyTruncated = truncateOutput('x'.repeat(20), 10)
+  const next = accumulateOutput(alreadyTruncated, 'more output', 10)
+  assert(next === alreadyTruncated,
+         'accumulateOutput drops further chunks once truncated')
+}
+
+// STOPPED_NOTE / timeoutNote: the notes appended to output on STOP / timeout
+assert(STOPPED_NOTE === '(停止しました)', 'STOPPED_NOTE is the stop notice')
+assert(timeoutNote(30) === '(30秒でタイムアウトしました)',
+       'timeoutNote formats the configured timeout in seconds')
 
 if (failures > 0) {
   throw new Error(failures + ' JS test(s) failed')

--- a/test/js/test_run.mjs
+++ b/test/js/test_run.mjs
@@ -8,7 +8,7 @@
 // importing either file here never touches a real DOM/Worker.
 import {
   createOnceLoader, formatRunError, truncateOutput,
-  accumulateOutput, STOPPED_NOTE, timeoutNote, editableText,
+  accumulateOutput, STOPPED_NOTE, DONE_NOTE, timeoutNote, editableText,
 } from '../../theme/default/js/run.js'
 import { PRELUDE, formatRunError as formatWorkerRunError } from '../../theme/default/js/run-worker.js'
 
@@ -115,8 +115,11 @@ assert(accumulateOutput('', 'first') === 'first',
          'accumulateOutput drops further chunks once truncated')
 }
 
-// STOPPED_NOTE / timeoutNote: the notes appended to output on STOP / timeout
+// STOPPED_NOTE / DONE_NOTE / timeoutNote: the notes appended to the output
+// on STOP / normal completion / timeout
 assert(STOPPED_NOTE === '(停止しました)', 'STOPPED_NOTE is the stop notice')
+assert(DONE_NOTE === '(正常終了しました)',
+       'DONE_NOTE marks a normal completion (visible even with empty output)')
 assert(timeoutNote(30) === '(30秒でタイムアウトしました)',
        'timeoutNote formats the configured timeout in seconds')
 

--- a/test/js/test_script.mjs
+++ b/test/js/test_script.mjs
@@ -139,15 +139,25 @@ async function settle() {
   await 0
 }
 
+// group(RUN/COPY 共用コンテナ)経由でボタンを取り出すヘルパー
+function buttonGroupOf(elem) { return elem.childByClass('highlight__button-group') }
+function copyButtonOf(elem) {
+  const group = buttonGroupOf(elem)
+  return group && group.childByClass('highlight__copy-button')
+}
+
 // A ruby sample keeps getting the COPY button (regression)
 {
   const spy = clipboardSpy()
   const pre = new FakeElement('pre', 'highlight ruby')
   pre.appendChild(new FakeElement('code', '', 'puts 1\n'))
   runOnload([pre], spy.navigator)
-  const btn = pre.childByClass('highlight__copy-button')
+  const btn = copyButtonOf(pre)
   assert(btn !== null, 'pre.highlight.ruby gets a COPY button')
-  assert(pre.firstChild === btn, 'COPY button is prepended as the first child')
+  assert(pre.firstChild === buttonGroupOf(pre),
+         'the shared button group is prepended as the first child')
+  assert(buttonGroupOf(pre).firstChild === btn,
+         'COPY button lives inside the button group')
   btn.onclick()
   await settle()
   assert(spy.written.length === 1 && spy.written[0] === 'puts 1\n',
@@ -161,7 +171,7 @@ async function settle() {
   const spy = clipboardSpy()
   const pre = new FakeElement('pre', '', 'ary = []\n')
   runOnload([pre], spy.navigator)
-  const btn = pre.childByClass('highlight__copy-button')
+  const btn = copyButtonOf(pre)
   assert(btn !== null, 'plain <pre> without highlight class gets a COPY button')
   btn.onclick()
   await settle()
@@ -174,7 +184,7 @@ async function settle() {
   const pre = new FakeElement('pre', 'highlight c')
   pre.appendChild(new FakeElement('code', '', 'VALUE v;\n'))
   runOnload([pre], clipboardSpy().navigator)
-  assert(pre.childByClass('highlight__copy-button') !== null,
+  assert(copyButtonOf(pre) !== null,
          'pre.highlight.c gets a COPY button')
 }
 
@@ -183,7 +193,7 @@ async function settle() {
   const div = new FakeElement('div', 'highlight')
   const pre = new FakeElement('pre', '')
   runOnload([div, pre], clipboardSpy().navigator)
-  assert(div.childByClass('highlight__copy-button') === null,
+  assert(copyButtonOf(div) === null,
          'non-pre element does not get a COPY button')
 }
 
@@ -194,7 +204,7 @@ async function settle() {
   pre.appendChild(new FakeElement('span', 'caption', '例'))
   pre.appendChild(new FakeElement('code', '', 'p 42\n'))
   runOnload([pre], spy.navigator)
-  pre.childByClass('highlight__copy-button').onclick()
+  copyButtonOf(pre).onclick()
   await settle()
   assert(spy.written[0] === 'p 42\n',
          'caption text is excluded from the copied text')
@@ -207,7 +217,7 @@ async function settle() {
   const spy = clipboardSpy()
   const pre = new FakeElement('pre', '', '\n\nputs 1\n\n\n')
   runOnload([pre], spy.navigator)
-  pre.childByClass('highlight__copy-button').onclick()
+  copyButtonOf(pre).onclick()
   await settle()
   assert(spy.written[0] === 'puts 1\n',
          'copied text is trimmed (leading newlines dropped, trailing squeezed)')
@@ -224,8 +234,14 @@ async function settle() {
   const output = new FakeElement('pre', 'highlight__run-output')
   let current = 'first output\n'
   const btn = globalThis.window.ruremaAddCopyButton(output, () => current)
-  assert(output.firstChild === btn,
-         'the hook prepends a COPY button to the given element')
+  assert(output.firstChild === buttonGroupOf(output) &&
+         buttonGroupOf(output).childByClass('highlight__copy-button') === btn,
+         'the hook puts the COPY button into a prepended button group')
+  // 既にグループがある要素にもう一度呼んでも、グループは1つのまま再利用される
+  globalThis.window.ruremaAddCopyButton(output, () => current)
+  assert(output.children.filter(
+           c => c.className === 'highlight__button-group').length === 1,
+         'an existing button group is reused instead of stacking a second one')
   btn.onclick()
   await settle()
   current = 'second output\n'
@@ -253,7 +269,7 @@ async function settle() {
   globalThis.navigator = {}   // clipboard なし
   ;(0, eval)(source)
   globalThis.window.onload()
-  const btn = pre.childByClass('highlight__copy-button')
+  const btn = copyButtonOf(pre)
   btn.onclick()
   await settle()
   assert(captured === 'fallback code\n',

--- a/test/js/test_script.mjs
+++ b/test/js/test_script.mjs
@@ -37,11 +37,16 @@ class FakeElement {
     if (name === 'class') this.className = value
   }
   select() {}
+  // 実 DOM 同様、挿入時は元の親から外して付け替える(parentNode も追跡)
   appendChild(child) {
+    if (child.parentNode) child.parentNode.removeChild(child)
+    child.parentNode = this
     this.children.push(child)
     return child
   }
   insertBefore(child, ref) {
+    if (child.parentNode) child.parentNode.removeChild(child)
+    child.parentNode = this
     const i = this.children.indexOf(ref)
     if (ref == null || i < 0) this.children.push(child)
     else this.children.splice(i, 0, child)
@@ -49,11 +54,20 @@ class FakeElement {
   }
   removeChild(child) {
     const i = this.children.indexOf(child)
-    if (i >= 0) this.children.splice(i, 1)
+    if (i >= 0) {
+      this.children.splice(i, 1)
+      child.parentNode = null
+    }
     return child
   }
   get firstChild() {
     return this.children.length > 0 ? this.children[0] : null
+  }
+  get previousElementSibling() {
+    if (!this.parentNode) return null
+    const siblings = this.parentNode.children
+    const i = siblings.indexOf(this)
+    return i > 0 ? siblings[i - 1] : null
   }
   get textContent() {
     return this.ownText + this.children.map(c => c.textContent).join('')
@@ -108,13 +122,17 @@ function makeDocument(elements) {
 const here = import.meta.url.replace(/^file:\/\//, '').replace(/\/[^/]*$/, '')
 const source = std.loadFile(here + '/../../theme/default/script.js')
 
+// script.js は pre の直前(親の子リスト)にツールバーを差し込むので、
+// テスト対象の要素は root(body 相当)にぶら下げて親を持たせる
 function runOnload(elements, navigatorFake) {
+  const root = new FakeElement('div')
+  elements.forEach((e) => root.appendChild(e))
   globalThis.document = makeDocument(elements)
   globalThis.window = { setTimeout() { return 0 } }
   globalThis.navigator = navigatorFake || {}
   ;(0, eval)(source)
   globalThis.window.onload()
-  return elements
+  return root
 }
 
 // Clipboard API を捕捉する navigator フェイク
@@ -139,8 +157,16 @@ async function settle() {
   await 0
 }
 
-// group(RUN/COPY 共用コンテナ)経由でボタンを取り出すヘルパー
-function buttonGroupOf(elem) { return elem.childByClass('highlight__button-group') }
+// pre の直前のツールバー行 → ボタン置き場 → COPY を辿るヘルパー
+function toolbarOf(elem) {
+  const prev = elem.previousElementSibling
+  if (prev && prev.className.split(' ').indexOf('highlight__toolbar') >= 0) return prev
+  return null
+}
+function buttonGroupOf(elem) {
+  const toolbar = toolbarOf(elem)
+  return toolbar && toolbar.childByClass('highlight__button-group')
+}
 function copyButtonOf(elem) {
   const group = buttonGroupOf(elem)
   return group && group.childByClass('highlight__copy-button')
@@ -154,10 +180,12 @@ function copyButtonOf(elem) {
   runOnload([pre], spy.navigator)
   const btn = copyButtonOf(pre)
   assert(btn !== null, 'pre.highlight.ruby gets a COPY button')
-  assert(pre.firstChild === buttonGroupOf(pre),
-         'the shared button group is prepended as the first child')
+  assert(toolbarOf(pre) !== null,
+         'a toolbar row is inserted just before the pre (outside of it)')
+  assert(pre.childByClass('highlight__button-group') === null,
+         'no button container is injected inside the pre itself')
   assert(buttonGroupOf(pre).firstChild === btn,
-         'COPY button lives inside the button group')
+         'COPY button lives inside the toolbar button group')
   btn.onclick()
   await settle()
   assert(spy.written.length === 1 && spy.written[0] === 'puts 1\n',
@@ -223,25 +251,42 @@ function copyButtonOf(elem) {
          'copied text is trimmed (leading newlines dropped, trailing squeezed)')
 }
 
+// pre の直前に caption(タブ)があれば、ツールバーの左端に取り込まれる
+{
+  const caption = new FakeElement('span', 'caption', '例')
+  const pre = new FakeElement('pre', 'highlight ruby')
+  pre.appendChild(new FakeElement('code', '', 'p 42\n'))
+  const root = runOnload([caption, pre], clipboardSpy().navigator)
+  const toolbar = toolbarOf(pre)
+  assert(toolbar !== null && toolbar.firstChild === caption,
+         'a sibling caption is moved to the left edge of the toolbar')
+  assert(root.children.indexOf(caption) < 0,
+         'the caption is no longer a direct sibling of the pre')
+  assert(toolbar.childByClass('highlight__button-group') !== null,
+         'the button group sits in the same toolbar row as the caption')
+}
+
 // RUN 出力など、後から生成される pre にもボタンを付けられる公開フック。
 // getText はクリック時に評価されるので、内容が変わる要素にも使える
 {
   const spy = clipboardSpy()
   const pre = new FakeElement('pre', '')
-  runOnload([pre], spy.navigator)
+  const root = runOnload([pre], spy.navigator)
   assert(typeof globalThis.window.ruremaAddCopyButton === 'function',
          'window.ruremaAddCopyButton is exposed for dynamically created pre')
+  // 実際の run.js と同様、DOM に挿入してからフックを呼ぶ
   const output = new FakeElement('pre', 'highlight__run-output')
+  root.appendChild(output)
   let current = 'first output\n'
   const btn = globalThis.window.ruremaAddCopyButton(output, () => current)
-  assert(output.firstChild === buttonGroupOf(output) &&
+  assert(toolbarOf(output) !== null &&
          buttonGroupOf(output).childByClass('highlight__copy-button') === btn,
-         'the hook puts the COPY button into a prepended button group')
-  // 既にグループがある要素にもう一度呼んでも、グループは1つのまま再利用される
+         'the hook inserts a toolbar with the COPY button before the element')
+  // 既にツールバーがある要素にもう一度呼んでも、ツールバーは1つのまま再利用される
   globalThis.window.ruremaAddCopyButton(output, () => current)
-  assert(output.children.filter(
-           c => c.className === 'highlight__button-group').length === 1,
-         'an existing button group is reused instead of stacking a second one')
+  assert(root.children.filter(
+           c => c.className === 'highlight__toolbar').length === 2,
+         'an existing toolbar is reused (one for the sample, one for the output)')
   btn.onclick()
   await settle()
   current = 'second output\n'
@@ -255,6 +300,8 @@ function copyButtonOf(elem) {
 // Clipboard API が無い環境では textarea + execCommand にフォールバックする
 {
   const pre = new FakeElement('pre', '', 'fallback code\n')
+  const root = new FakeElement('div')
+  root.appendChild(pre)
   const elements = [pre]
   globalThis.document = makeDocument(elements)
   let captured = null

--- a/test/test_run_worker_prelude.rb
+++ b/test/test_run_worker_prelude.rb
@@ -1,0 +1,83 @@
+require 'test/unit'
+
+# theme/default/js/run-worker.js の PRELUDE(Ruby コード)の検証。
+# Kernel#puts/print/p は $stdout が IO でないとき #write 経由で書き込むが、
+# マニュアルのサンプルは $stderr.puts や $stdout.putc のように IO のメソッドを
+# 直接呼ぶこともある(旧実装の StringIO はそれらを備えていた)。JS ブリッジを
+# スタブした実 Ruby で PRELUDE を eval し、両方の経路の出力を確認する。
+class TestRunWorkerPrelude < Test::Unit::TestCase
+  WORKER_JS = File.expand_path('../theme/default/js/run-worker.js', __dir__)
+
+  module JSStub
+    OUTPUT = []
+    def self.global
+      self
+    end
+
+    def self.call(name, text)
+      raise ArgumentError, "unexpected JS call: #{name}" unless name == :postOutput
+      OUTPUT << text.to_s
+    end
+  end
+
+  def setup
+    src = File.read(WORKER_JS)
+    prelude = src[/export const PRELUDE = `\n(.*?)\n`/m, 1]
+    assert_not_nil(prelude, 'PRELUDE not found in run-worker.js')
+    # ruby.wasm 上でだけ存在する js gem をスタブに差し替える
+    @prelude = prelude.sub(/\Arequire "js"\n/, '')
+    JSStub::OUTPUT.clear
+    Object.const_set(:JS, JSStub)
+  end
+
+  def teardown
+    Object.send(:remove_const, :JS) if Object.const_defined?(:JS)
+    Object.send(:remove_const, :JSStreamIO) if Object.const_defined?(:JSStreamIO)
+  end
+
+  def run_with_prelude
+    orig_stdout = $stdout
+    orig_stderr = $stderr
+    begin
+      eval(@prelude, TOPLEVEL_BINDING)
+      yield
+    ensure
+      $stdout = orig_stdout
+      $stderr = orig_stderr
+    end
+    JSStub::OUTPUT.join
+  end
+
+  def test_kernel_methods_stream_through_post_output
+    out = run_with_prelude do
+      puts 'hello'
+      print 'a', 'b'
+      p 123
+    end
+    assert_equal("hello\nab123\n", out)
+  end
+
+  def test_direct_io_methods_match_old_stringio_behavior
+    out = run_with_prelude do
+      $stdout.puts 'direct'
+      $stderr.puts 'err'
+      $stdout.putc 'XY'
+      $stdout.print 'pr'
+      $stdout.printf('%05d', 42)
+      $stdout << 'chained' << '!'
+      $stdout.flush
+      $stdout.puts ['a', ['b']]
+      $stdout.puts
+    end
+    assert_equal("direct\nerr\nXpr00042chained!a\nb\n\n", out)
+  end
+
+  def test_stream_reports_not_a_tty_and_accepts_sync
+    run_with_prelude do
+      assert_false($stdout.tty?)
+      assert_false($stderr.isatty)
+      assert_true($stdout.sync)
+      $stdout.sync = true
+    end
+  end
+end

--- a/test/test_statichtml_command.rb
+++ b/test/test_statichtml_command.rb
@@ -57,9 +57,11 @@ class TestStatichtmlRunRubyWasm < Test::Unit::TestCase
       FileUtils.mkdir_p(File.join(themedir, 'js'))
       FileUtils.mkdir_p(outputdir)
       File.write(File.join(themedir, 'js', 'run.js'), "// run\n")
+      File.write(File.join(themedir, 'js', 'run-worker.js'), "// worker\n")
       cmd = build_command(themedir, outputdir)
       cmd.send(:copy_run_ruby_wasm_script)
       assert_true(File.file?(File.join(outputdir, 'js', 'run.js')))
+      assert_true(File.file?(File.join(outputdir, 'js', 'run-worker.js')))
     end
   end
 
@@ -74,10 +76,35 @@ class TestStatichtmlRunRubyWasm < Test::Unit::TestCase
       begin
         assert_nothing_raised { cmd.send(:copy_run_ruby_wasm_script) }
         assert_match(/run\.js not found/, $stderr.string)
+        assert_match(/run-worker\.js not found/, $stderr.string)
       ensure
         $stderr = orig_stderr
       end
       assert_false(File.exist?(File.join(outputdir, 'js', 'run.js')))
+      assert_false(File.exist?(File.join(outputdir, 'js', 'run-worker.js')))
+    end
+  end
+
+  # A themedir with run.js but not yet upgraded with run-worker.js (or vice
+  # versa) should still copy whichever file it does have, rather than
+  # aborting or silently skipping both.
+  def test_partial_theme_copies_what_it_has
+    Dir.mktmpdir do |dir|
+      themedir = File.join(dir, 'theme')
+      outputdir = File.join(dir, 'out')
+      FileUtils.mkdir_p(File.join(themedir, 'js'))
+      FileUtils.mkdir_p(outputdir)
+      File.write(File.join(themedir, 'js', 'run.js'), "// run\n")
+      cmd = build_command(themedir, outputdir)
+      orig_stderr, $stderr = $stderr, StringIO.new
+      begin
+        cmd.send(:copy_run_ruby_wasm_script)
+        assert_match(/run-worker\.js not found/, $stderr.string)
+      ensure
+        $stderr = orig_stderr
+      end
+      assert_true(File.file?(File.join(outputdir, 'js', 'run.js')))
+      assert_false(File.exist?(File.join(outputdir, 'js', 'run-worker.js')))
     end
   end
 end

--- a/theme/default/js/run-worker.js
+++ b/theme/default/js/run-worker.js
@@ -1,0 +1,111 @@
+// Module Worker that runs one RUN-button sample. Loaded by theme/default/js/run.js
+// via `new Worker(url, { type: 'module' })`; one Worker instance per execution
+// (see run.js for why: a fresh VM per run needs no cross-run state, and it
+// makes terminate()-to-stop trivial). Named .js rather than .mjs for the same
+// MIME-serving reason as run.js (see the comment at the top of that file).
+//
+// Protocol:
+//   main -> worker: { module: WebAssembly.Module, code: string }
+//   worker -> main: { type: 'output', text: string }   (zero or more, in order)
+//   worker -> main: { type: 'done' }                   (exactly one, on success)
+//   worker -> main: { type: 'error', message: string } (exactly one, on failure)
+// Exactly one of 'done'/'error' is posted, always last. The main thread may
+// also just call worker.terminate() (STOP button / timeout); the worker does
+// not need to post anything in that case.
+
+const VM_ESM_URL = 'https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.9.3-2.9.4/dist/browser/+esm'
+
+// Same idea as run.js's old (pre-Worker) PRELUDE -- redirect $stdout/$stderr
+// -- but instead of buffering into a StringIO for one bulk read at the end,
+// each write is forwarded to the main thread immediately via postOutput()
+// so long-running or infinite-output samples show progress instead of
+// growing an in-wasm string forever. $stderr shares the same sink so
+// interleaving still reads naturally, matching the previous StringIO-based
+// behavior. Ruby only ever hands the JS bridge a plain string, so
+// $stdout.write calls self.postOutput(), a small helper defined below
+// (rather than calling self.postMessage directly from Ruby) so that
+// postMessage itself stays the single place that emits the { type: ... }
+// envelope; main.onmessage never has to disambiguate a bare string from a
+// control message.
+//
+// Kernel#puts/print/p reach a non-IO $stdout through its #write, but the
+// manual's samples also call IO methods on $stdout/$stderr *directly*
+// ($stderr.puts, $stdout.putc, $stdout.print, $stdout.flush, $stderr.tty?,
+// ...). The old StringIO provided those for free, so the common ones are
+// implemented here; their semantics are covered by test/test_run_worker_prelude.rb,
+// which evals this prelude in a real Ruby with the JS bridge stubbed.
+export const PRELUDE = `
+require "js"
+class JSStreamIO
+  def write(*parts)
+    text = parts.join
+    JS.global.call(:postOutput, text)
+    text.bytesize
+  end
+  def <<(obj)
+    write(obj)
+    self
+  end
+  def puts(*args)
+    if args.empty?
+      write("\n")
+    else
+      args.flatten.each do |arg|
+        s = arg.to_s
+        s = s + "\n" unless s.end_with?("\n")
+        write(s)
+      end
+    end
+    nil
+  end
+  def print(*args)
+    write(args.join)
+    nil
+  end
+  def printf(*args)
+    write(sprintf(*args))
+    nil
+  end
+  def putc(ch)
+    write(ch.is_a?(String) ? ch[0] : ch.chr)
+    ch
+  end
+  def flush; self; end
+  def sync; true; end
+  def sync=(value); value; end
+  def tty?; false; end
+  alias isatty tty?
+end
+$stdout = JSStreamIO.new
+$stderr = $stdout
+`
+
+export function formatRunError(error) {
+  const text = String((error && error.message) || error)
+  return text.split('\n').slice(0, 20).join('\n')
+}
+
+// Guarded the same way run.js guards its init(): this file is imported by
+// test/js/test_run.mjs under QuickJS, which has neither `self` (as the
+// Worker global) nor a real postMessage/onmessage.
+if (typeof self !== 'undefined' && typeof WorkerGlobalScope !== 'undefined') {
+  self.postOutput = (text) => self.postMessage({ type: 'output', text })
+
+  self.onmessage = async (event) => {
+    const { module, code } = event.data
+    try {
+      const { DefaultRubyVM } = await import(VM_ESM_URL)
+      const { vm } = await DefaultRubyVM(module, { consolePrint: false })
+      vm.eval(PRELUDE)
+      try {
+        vm.eval(code)
+      } catch (e) {
+        self.postMessage({ type: 'error', message: formatRunError(e) })
+        return
+      }
+      self.postMessage({ type: 'done' })
+    } catch (e) {
+      self.postMessage({ type: 'error', message: formatRunError(e) })
+    }
+  }
+}

--- a/theme/default/js/run.js
+++ b/theme/default/js/run.js
@@ -71,6 +71,14 @@ export function timeoutNote(seconds) {
   return `(${seconds}秒でタイムアウトしました)`
 }
 
+// Text used when flattening the highlighted sample for editing. The
+// compiler emits a newline right after <code>, which textContent keeps —
+// left as-is it shows up as an empty first line once the block becomes
+// editable (script.js strips the same artifact for COPY).
+export function editableText(text) {
+  return text.replace(/^\n+/, '')
+}
+
 // Compiles the wasm module once (cached like the old single-VM version) and
 // hands a fresh Worker + that same compiled Module to each run. The Module
 // is a structured-cloneable postMessage payload, so terminate()-ing a run
@@ -102,14 +110,19 @@ function setupBlock(pre, runner) {
   button.type = 'button'
   button.className = 'highlight__run-button'
   button.textContent = 'RUN'
-  // script.js has already prepended the COPY button (its window.onload
-  // handler fires before our load listener); keep COPY rightmost.
-  const copyButton = pre.querySelector('.highlight__copy-button')
-  if (copyButton) {
-    copyButton.after(button)
-  } else {
-    pre.prepend(button)
+  // script.js has already created the shared button group with the COPY
+  // button in it (its window.onload handler fires before our load
+  // listener). Prepend RUN into the same group so COPY stays rightmost,
+  // and so the gaps between/around the buttons belong to the group
+  // (cursor: default) instead of the text area — hovering the cluster no
+  // longer flickers between pointer and text cursors.
+  let group = pre.querySelector('.highlight__button-group')
+  if (!group) {
+    group = document.createElement('span')
+    group.className = 'highlight__button-group'
+    pre.prepend(group)
   }
+  group.prepend(button)
 
   let output
   let outputTextNode
@@ -135,6 +148,26 @@ function setupBlock(pre, runner) {
     outputTextNode.data = text
   }
 
+  // plaintext-only が使えないブラウザ向けの paste フォールバック。
+  // 既定のリッチペーストは改行を <br>/<div> に変えたり先頭の改行を
+  // 落としたりする(貼り付けた内容が前の行にくっつく)ので、text/plain
+  // をキャレット位置にそのまま挿入する
+  const pastePlainText = (event) => {
+    if (!event.clipboardData) return
+    event.preventDefault()
+    const text = event.clipboardData.getData('text/plain')
+    const selection = window.getSelection()
+    if (!selection || selection.rangeCount === 0) return
+    const range = selection.getRangeAt(0)
+    range.deleteContents()
+    const node = document.createTextNode(text)
+    range.insertNode(node)
+    range.setStartAfter(node)
+    range.collapse(true)
+    selection.removeAllRanges()
+    selection.addRange(range)
+  }
+
   // After the first run the sample becomes editable (like a scratchpad);
   // Ctrl+Enter (or Cmd+Enter) re-runs the edited code. The COPY button
   // keeps copying the original text.
@@ -142,9 +175,21 @@ function setupBlock(pre, runner) {
     if (code.isContentEditable) return
     // 編集でハイライトの span に文字が食い込むと、貼り付けた文字が
     // その場の色を引き継いで中途半端に崩れるため、編集可能にする
-    // 時点でプレーンテキスト化して色を消す
-    code.textContent = code.textContent
-    code.contentEditable = 'true'
+    // 時点でプレーンテキスト化して色を消す。コンパイラが <code> の
+    // 直後に置く改行(編集開始時に先頭の空行として見える)もここで除く
+    code.textContent = editableText(code.textContent)
+    // 改行入力・貼り付けが <br>/<div> にならないよう plaintext-only を
+    // 優先する。未対応ブラウザは代入が SyntaxError になるか値が変わらない
+    // ので、従来どおり true にして paste だけ自前で処理する
+    try {
+      code.contentEditable = 'plaintext-only'
+    } catch (e) {
+      // fall through
+    }
+    if (code.contentEditable !== 'plaintext-only') {
+      code.contentEditable = 'true'
+      code.addEventListener('paste', pastePlainText)
+    }
     code.spellcheck = false
     pre.dataset.editing = 'true'
     pre.addEventListener('keydown', (event) => {

--- a/theme/default/js/run.js
+++ b/theme/default/js/run.js
@@ -110,17 +110,24 @@ function setupBlock(pre, runner) {
   button.type = 'button'
   button.className = 'highlight__run-button'
   button.textContent = 'RUN'
-  // script.js has already created the shared button group with the COPY
-  // button in it (its window.onload handler fires before our load
-  // listener). Prepend RUN into the same group so COPY stays rightmost,
-  // and so the gaps between/around the buttons belong to the group
-  // (cursor: default) instead of the text area — hovering the cluster no
-  // longer flickers between pointer and text cursors.
-  let group = pre.querySelector('.highlight__button-group')
+  // script.js has already inserted the toolbar row (with the COPY button
+  // in its button group) right before the pre — its window.onload handler
+  // fires before our load listener. Prepend RUN into the same group so
+  // COPY stays rightmost. The buttons live outside the pre: keeping them
+  // inside required a zero top padding, made the cursor flicker between
+  // pointer and text, and broke the editable-code layout.
+  const toolbar = pre.previousElementSibling
+  let group = toolbar && toolbar.classList.contains('highlight__toolbar')
+    ? toolbar.querySelector('.highlight__button-group')
+    : null
   if (!group) {
+    // script.js が無いテーマ向けの保険: 最小構成のツールバーを自前で作る
+    const ownToolbar = document.createElement('div')
+    ownToolbar.className = 'highlight__toolbar'
     group = document.createElement('span')
     group.className = 'highlight__button-group'
-    pre.prepend(group)
+    ownToolbar.appendChild(group)
+    pre.before(ownToolbar)
   }
   group.prepend(button)
 
@@ -140,6 +147,13 @@ function setupBlock(pre, runner) {
       // 出力は実行のたびに変わるので、クリック時のテキストを渡す
       if (window.ruremaAddCopyButton) {
         window.ruremaAddCopyButton(output, () => outputTextNode.data)
+        // 出力欄のツールバーと出力欄は、入力欄の pre に密着させて
+        // 1つのブロックに見せる(pre 下マージンとツールバー上マージンを消す)
+        const outToolbar = output.previousElementSibling
+        if (outToolbar && outToolbar.classList.contains('highlight__toolbar')) {
+          outToolbar.classList.add('highlight__toolbar--attached')
+          pre.classList.add('highlight--with-output')
+        }
       }
     }
     return output
@@ -197,6 +211,20 @@ function setupBlock(pre, runner) {
         event.preventDefault()
         execute()
       }
+    })
+    // code は内容ぶんの高さしかないので、その外側(pre の padding や
+    // 1行サンプルの下の余白)をクリックしたときも入力欄に入れるよう、
+    // pre 自身へのクリックで code にフォーカスして末尾にキャレットを置く
+    pre.addEventListener('click', (event) => {
+      if (event.target !== pre) return
+      code.focus()
+      const selection = window.getSelection()
+      if (!selection) return
+      const range = document.createRange()
+      range.selectNodeContents(code)
+      range.collapse(false)
+      selection.removeAllRanges()
+      selection.addRange(range)
     })
   }
 

--- a/theme/default/js/run.js
+++ b/theme/default/js/run.js
@@ -1,19 +1,30 @@
 // RUN button for Ruby sample code: executes the sample in-browser with
-// ruby.wasm. Named .js rather than .mjs: module scripts are subject to
-// strict MIME checking, and servers whose MIME table lacks an "mjs" entry
-// (e.g. nginx before 1.21.4) serve .mjs as application/octet-stream, which
-// browsers refuse to execute. Enabled per page via
+// ruby.wasm, off the main thread in a Web Worker (theme/default/js/run-worker.js)
+// so an infinite loop or long sleep in the sample can't freeze the page; a
+// STOP button and a timeout both just Worker.terminate() it. Named .js
+// rather than .mjs: module scripts are subject to strict MIME checking, and
+// servers whose MIME table lacks an "mjs" entry (e.g. nginx before 1.21.4)
+// serve .mjs as application/octet-stream, which browsers refuse to execute.
+// The same reasoning applies to run-worker.js. Enabled per page via
 //   <meta name="rurema-run-ruby-wasm" content="<ruby+stdlib.wasm URL>">
 // which the layout emits when statichtml was invoked with --run-ruby-wasm.
 // The wasm URL is chosen by the build side to match the documented Ruby
-// version; this file only pins the loader library.
-
-// Exact pin of the npm "latest" dist-tag at the time of writing. Note the
-// version scheme: stable @ruby/* packages are published as
-// "<pkg version>-<ruby.wasm version>" (e.g. 2.9.3-2.9.4); plain "2.9.4"
-// does not exist on npm.
-const VM_ESM_URL = 'https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.9.3-2.9.4/dist/browser/+esm'
+// version. This file only compiles that wasm (WebAssembly.compileStreaming
+// needs no loader library, just the bytes); the CDN-hosted @ruby/wasm-wasi
+// loader is pinned and imported inside run-worker.js, which is the only
+// place that actually instantiates a VM from the compiled module.
 const OUTPUT_LIMIT = 64 * 1024
+const RUN_TIMEOUT_MS = 30 * 1000
+
+// Resolved relative to this module's own URL (not the page URL), so it keeps
+// working regardless of how deep the current page is under the site root or
+// how custom_js_url() built run.js's own <script src>. Computed lazily
+// (rather than as a module-level constant) because the `URL` global does
+// not exist under QuickJS, which imports this file for its pure-function
+// tests without ever calling into the browser-only code path below.
+function workerUrl() {
+  return new URL('run-worker.js', import.meta.url)
+}
 
 // Wrap an async loader so concurrent and repeated calls share one in-flight
 // promise, while a rejected attempt clears the cache so the next call
@@ -35,10 +46,6 @@ export function createOnceLoader(loadFn) {
   }
 }
 
-// Collect $stdout/$stderr into one StringIO so the output can be read back
-// after eval; sharing one StringIO preserves stdout/stderr interleaving.
-export const PRELUDE = 'require "stringio"; $stdout = StringIO.new; $stderr = $stdout'
-
 export function formatRunError(error) {
   const text = String((error && error.message) || error)
   return text.split('\n').slice(0, 20).join('\n')
@@ -49,46 +56,45 @@ export function truncateOutput(text, limit = OUTPUT_LIMIT) {
   return text.slice(0, limit) + '\n... (truncated)'
 }
 
-// One runner per page: the wasm module is compiled once and cached, but each
-// run gets a fresh VM so samples never see each other's state. `running`
-// keeps a single VM alive at a time; a run attempted meanwhile returns null.
+// Appends one output chunk to the accumulated text, applying the same
+// display cap as truncateOutput. Once the cap is hit, further chunks are
+// dropped (not just re-truncating the same prefix again and again), so a
+// runaway output loop does the "... (truncated)" marker once and then does
+// O(1) work per chunk instead of O(output length).
+export function accumulateOutput(current, chunk, limit = OUTPUT_LIMIT) {
+  if (current.endsWith('\n... (truncated)')) return current
+  return truncateOutput(current + chunk, limit)
+}
+
+export const STOPPED_NOTE = '(停止しました)'
+export function timeoutNote(seconds) {
+  return `(${seconds}秒でタイムアウトしました)`
+}
+
+// Compiles the wasm module once (cached like the old single-VM version) and
+// hands a fresh Worker + that same compiled Module to each run. The Module
+// is a structured-cloneable postMessage payload, so terminate()-ing a run
+// and starting another never needs to recompile.
 function createRunner(wasmUrl) {
   const loadModule = createOnceLoader(async () => {
-    const [{ DefaultRubyVM }, module] = await Promise.all([
-      import(VM_ESM_URL),
-      WebAssembly.compileStreaming(fetch(wasmUrl)).catch(async () => {
-        // Retry without streaming for servers that send a non-wasm MIME type
-        // (e.g. `ruby -run -e httpd` when testing locally).
-        const response = await fetch(wasmUrl)
-        return WebAssembly.compile(await response.arrayBuffer())
-      }),
-    ])
-    return { DefaultRubyVM, module }
+    return WebAssembly.compileStreaming(fetch(wasmUrl)).catch(async () => {
+      // Retry without streaming for servers that send a non-wasm MIME type
+      // (e.g. `ruby -run -e httpd` when testing locally).
+      const response = await fetch(wasmUrl)
+      return WebAssembly.compile(await response.arrayBuffer())
+    })
   })
-  let running = false
-  return async function run(code, onLoaded) {
-    if (running) return null
-    running = true
-    try {
-      const { DefaultRubyVM, module } = await loadModule()
-      if (onLoaded) onLoaded()
-      const { vm } = await DefaultRubyVM(module, { consolePrint: false })
-      vm.eval(PRELUDE)
-      let error = null
-      try {
-        vm.eval(code)
-      } catch (e) {
-        error = formatRunError(e)
-      }
-      const output = vm.eval('$stdout.string').toString()
-      return { output: truncateOutput(output), error }
-    } finally {
-      running = false
-    }
+  return {
+    loadModule,
+    // One Worker per run (see module comment): terminate() always yields a
+    // clean slate, and samples never see another run's VM state.
+    spawn() {
+      return new Worker(workerUrl(), { type: 'module' })
+    },
   }
 }
 
-function setupBlock(pre, run) {
+function setupBlock(pre, runner) {
   const code = pre.querySelector('code')
   if (!code) return
 
@@ -149,7 +155,41 @@ function setupBlock(pre, run) {
     })
   }
 
+  // Non-null exactly while a run's Worker is alive; STOP terminates it and
+  // the timeout/message handlers all check this to avoid acting twice on
+  // the same run (e.g. a timeout racing a message that just arrived).
+  let current = null
+
+  const finish = (out, label, isError) => {
+    if (current && current.timer) clearTimeout(current.timer)
+    current = null
+    if (isError) out.classList.add('highlight__run-output--error')
+    enableEditing()
+    button.textContent = label
+    button.disabled = false
+    button.removeAttribute('aria-busy')
+  }
+
+  // Final notes (stop / timeout / the run's error message) are appended
+  // directly, bypassing accumulateOutput's 64KB cap: the cap exists to stop
+  // unbounded *output* growth, and these one-shot notes are bounded — they
+  // must stay visible precisely in the runaway-output case where the cap
+  // has already been hit and accumulateOutput would drop them.
+  const appendNote = (text) => {
+    const separator = outputTextNode.data === '' ? '' : '\n'
+    setOutputText(outputTextNode.data + separator + text)
+  }
+
+  const stop = () => {
+    if (!current) return
+    current.worker.terminate()
+    const out = ensureOutput()
+    appendNote(STOPPED_NOTE)
+    finish(out, 'RUN', false)
+  }
+
   const execute = async () => {
+    if (current) return // mid-run click on the (now STOP-labeled) button; use the dedicated STOP path
     if (button.disabled) return
     button.disabled = true
     button.setAttribute('aria-busy', 'true')
@@ -157,29 +197,56 @@ function setupBlock(pre, run) {
     const out = ensureOutput()
     out.classList.remove('highlight__run-output--error')
     setOutputText('')
-    let label = 'RUN'
+
+    let module
     try {
-      const result = await run(code.textContent, () => {
-        button.textContent = 'RUNNING...'
-      })
-      if (result) {
-        setOutputText(result.error
-          ? (result.output === '' ? result.error : result.output + '\n' + result.error)
-          : result.output)
-        if (result.error) out.classList.add('highlight__run-output--error')
-        enableEditing()
-      }
+      module = await runner.loadModule()
     } catch (e) {
-      out.classList.add('highlight__run-output--error')
       setOutputText(formatRunError(e))
-      label = 'RETRY'
-    } finally {
-      button.textContent = label
-      button.disabled = false
-      button.removeAttribute('aria-busy')
+      finish(out, 'RETRY', true)
+      return
     }
+
+    const worker = runner.spawn()
+    const timer = setTimeout(() => {
+      if (!current) return
+      worker.terminate()
+      appendNote(timeoutNote(RUN_TIMEOUT_MS / 1000))
+      finish(out, 'RUN', false)
+    }, RUN_TIMEOUT_MS)
+    current = { worker, timer }
+
+    button.textContent = 'STOP'
+    button.disabled = false
+    button.setAttribute('aria-busy', 'true')
+
+    worker.onmessage = (event) => {
+      const message = event.data
+      if (!current || current.worker !== worker) return
+      if (message.type === 'output') {
+        setOutputText(accumulateOutput(outputTextNode.data, message.text))
+      } else if (message.type === 'done') {
+        finish(out, 'RUN', false)
+      } else if (message.type === 'error') {
+        appendNote(message.message)
+        finish(out, 'RUN', true)
+      }
+    }
+    worker.onerror = (event) => {
+      if (!current || current.worker !== worker) return
+      event.preventDefault()
+      setOutputText(formatRunError(event.message || event))
+      finish(out, 'RETRY', true)
+    }
+    worker.postMessage({ module, code: code.textContent })
   }
-  button.addEventListener('click', execute)
+  button.addEventListener('click', () => {
+    if (current) {
+      stop()
+    } else {
+      execute()
+    }
+  })
 }
 
 function init() {
@@ -187,8 +254,8 @@ function init() {
   if (!meta || !meta.content) return
   const blocks = document.querySelectorAll('pre.highlight.ruby')
   if (blocks.length === 0) return
-  const run = createRunner(meta.content)
-  blocks.forEach((pre) => setupBlock(pre, run))
+  const runner = createRunner(meta.content)
+  blocks.forEach((pre) => setupBlock(pre, runner))
 }
 
 // Guarded so the module stays side-effect-free outside a browser

--- a/theme/default/js/run.js
+++ b/theme/default/js/run.js
@@ -67,6 +67,9 @@ export function accumulateOutput(current, chunk, limit = OUTPUT_LIMIT) {
 }
 
 export const STOPPED_NOTE = '(停止しました)'
+// 出力が空のサンプルでも実行が終わったことがわかるように、
+// 正常終了時も必ずこの注記を出力欄の末尾に付ける
+export const DONE_NOTE = '(正常終了しました)'
 export function timeoutNote(seconds) {
   return `(${seconds}秒でタイムアウトしました)`
 }
@@ -303,6 +306,7 @@ function setupBlock(pre, runner) {
       if (message.type === 'output') {
         setOutputText(accumulateOutput(outputTextNode.data, message.text))
       } else if (message.type === 'done') {
+        appendNote(DONE_NOTE)
         finish(out, 'RUN', false)
       } else if (message.type === 'error') {
         appendNote(message.message)

--- a/theme/default/js/run.js
+++ b/theme/default/js/run.js
@@ -138,8 +138,7 @@ function setupBlock(pre, runner) {
       output = document.createElement('pre')
       output.className = 'highlight__run-output'
       output.setAttribute('aria-live', 'polite')
-      // COPY ボタン(先頭)を残したまま本文を書き換えられるように、
-      // 出力テキストは専用のテキストノードに持つ
+      // 出力テキストは専用のテキストノードに持つ(丸ごと差し替えられる)
       outputTextNode = document.createTextNode('')
       output.appendChild(outputTextNode)
       pre.after(output)
@@ -147,11 +146,16 @@ function setupBlock(pre, runner) {
       // 出力は実行のたびに変わるので、クリック時のテキストを渡す
       if (window.ruremaAddCopyButton) {
         window.ruremaAddCopyButton(output, () => outputTextNode.data)
-        // 出力欄のツールバーと出力欄は、入力欄の pre に密着させて
-        // 1つのブロックに見せる(pre 下マージンとツールバー上マージンを消す)
+        // 出力欄のヘッダー行と出力欄は、入力欄の pre に密着させて
+        // 1つのブロックに見せる(境の 2px の白は CSS 側)。左端には
+        // 出力欄だとわかるように「実行結果」のタブを付ける
         const outToolbar = output.previousElementSibling
         if (outToolbar && outToolbar.classList.contains('highlight__toolbar')) {
           outToolbar.classList.add('highlight__toolbar--attached')
+          const label = document.createElement('span')
+          label.className = 'caption'
+          label.textContent = '実行結果'
+          outToolbar.insertBefore(label, outToolbar.firstChild)
           pre.classList.add('highlight--with-output')
         }
       }

--- a/theme/default/script.js
+++ b/theme/default/script.js
@@ -22,25 +22,48 @@
     })
   }
 
-  // elem 先頭のボタン置き場(RUN/COPY 共用の float コンテナ)を返す。
-  // 無ければ作る。ボタンを個別に float させるとボタン間の隙間で text
-  // カーソルとちらついてクリックしにくいため、1つのコンテナにまとめて
-  // 隙間のカーソル形状はコンテナ(cursor: default)が引き受ける。
-  // js/run.js も同じコンテナに RUN ボタンを入れる
-  function buttonGroup(elem) {
-    const first = elem.firstChild
-    if (first && first.className &&
-        String(first.className).split(' ').indexOf('highlight__button-group') >= 0) {
-      return first
+  function hasClass(elem, name) {
+    return Boolean(elem && elem.className &&
+      String(elem.className).split(' ').indexOf(name) >= 0)
+  }
+
+  function findChildByClass(elem, name) {
+    const children = elem.children
+    for (let i = 0; i < children.length; i++) {
+      if (hasClass(children[i], name)) return children[i]
     }
+    return null
+  }
+
+  // elem(pre)の直前にツールバー行 <div class="highlight__toolbar"> を
+  // 用意し、その右端のボタン置き場(highlight__button-group)を返す。
+  // ボタンを pre の中に float させる方式は、カーソル形状のちらつき・
+  // 編集時のレイアウト崩れ・pre の上 padding を 0 にする必要など無理が
+  // 多かったため、pre の外に出している。コンパイラが pre の直前に置く
+  // caption(タブ)があればツールバー左端に取り込み、pre への密着を保つ。
+  // js/run.js も同じボタン置き場に RUN ボタンを入れる
+  function buttonGroup(elem) {
+    const prev = elem.previousElementSibling
+    if (hasClass(prev, 'highlight__toolbar')) {
+      return findChildByClass(prev, 'highlight__button-group')
+    }
+    const toolbar = document.createElement('div')
+    toolbar.setAttribute('class', 'highlight__toolbar')
     const group = document.createElement('span')
     group.setAttribute('class', 'highlight__button-group')
-    elem.insertBefore(group, elem.firstChild)
+    if (hasClass(prev, 'caption')) {
+      elem.parentNode.insertBefore(toolbar, prev)
+      toolbar.appendChild(prev) // caption をタブとして左端へ移動
+    } else {
+      elem.parentNode.insertBefore(toolbar, elem)
+    }
+    toolbar.appendChild(group)
     return group
   }
 
-  // elem の先頭に COPY ボタンを付ける。getText はクリック時に評価される
-  // ので、RUN の実行結果のように内容が変わる要素にも使える
+  // elem の直前のツールバーに COPY ボタンを付ける。getText はクリック時に
+  // 評価されるので、RUN の実行結果のように内容が変わる要素にも使える。
+  // elem は DOM ツリーに挿入済みであること(直前にツールバーを差し込む)
   function addCopyButton(elem, getText) {
     const btn = document.createElement('span')
     btn.setAttribute('class', 'highlight__copy-button')

--- a/theme/default/script.js
+++ b/theme/default/script.js
@@ -22,6 +22,23 @@
     })
   }
 
+  // elem 先頭のボタン置き場(RUN/COPY 共用の float コンテナ)を返す。
+  // 無ければ作る。ボタンを個別に float させるとボタン間の隙間で text
+  // カーソルとちらついてクリックしにくいため、1つのコンテナにまとめて
+  // 隙間のカーソル形状はコンテナ(cursor: default)が引き受ける。
+  // js/run.js も同じコンテナに RUN ボタンを入れる
+  function buttonGroup(elem) {
+    const first = elem.firstChild
+    if (first && first.className &&
+        String(first.className).split(' ').indexOf('highlight__button-group') >= 0) {
+      return first
+    }
+    const group = document.createElement('span')
+    group.setAttribute('class', 'highlight__button-group')
+    elem.insertBefore(group, elem.firstChild)
+    return group
+  }
+
   // elem の先頭に COPY ボタンを付ける。getText はクリック時に評価される
   // ので、RUN の実行結果のように内容が変わる要素にも使える
   function addCopyButton(elem, getText) {
@@ -35,7 +52,8 @@
         // コピー失敗時は従来どおり何も表示しない
       })
     }
-    elem.insertBefore(btn, elem.firstChild)
+    // COPY は常にグループ右端(RUN は run.js が先頭に prepend する)
+    buttonGroup(elem).appendChild(btn)
     return btn
   }
 

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -138,15 +138,17 @@ pre {
 }
 
 
-/* pre の直前に密着するヘッダー行(script.js が生成)。pre と同じ背景色で
-   コードブロックと一体に見せる(白い帯として浮くと、コードの上の隙間が
-   広く見える)。左端に caption のタブ、右端に RUN/COPY のボタン群を置く */
+/* pre の直前に密着するヘッダー行(script.js が生成)。コード部分より
+   ひと段暗い背景でコードブロックと一体に見せつつ(白い帯として浮くと、
+   コードの上の隙間が広く見える)、コード部分と同色の caption タブや
+   白背景のボタンが埋没しないようにする。左端に caption のタブ、右端に
+   RUN/COPY のボタン群を置く */
 .highlight__toolbar {
   display: flex;
   align-items: flex-end;
   margin: 1em 0 0;
   padding: 0.25em 0.25em 0 0.25em;
-  background-color: #f2f2f2;
+  background-color: #e6e6e6;
 }
 .highlight__toolbar + pre {
   margin-top: 0;
@@ -173,25 +175,24 @@ pre {
   user-select: none;
 }
 
-/* for RUN (js/run.js, statichtml --run-ruby-wasm) */
+/* for RUN (js/run.js, statichtml --run-ruby-wasm)。
+   ヘッダー行の灰色に埋没しないよう、白背景+枠線でボタンらしくする */
 .highlight__run-button {
   margin: 0 0.5em 0.25em 0;
   padding: 0.25em 0.5em;
-  background-color: #DDD;
-  opacity: 0.75;
+  background-color: #fff;
   cursor: pointer;
-  border: 0;
+  border: 1px solid #999;
   border-radius: 4px;
   font: inherit;
 }
 .highlight__run-button:hover {
   background-color: #EE8;
-  opacity: 1;
 }
 .highlight__run-button[disabled] {
   background-color: #070;
+  border-color: #070;
   color: white;
-  opacity: 1;
   cursor: wait;
 }
 .highlight__run-output {
@@ -217,25 +218,25 @@ pre.highlight.ruby[data-editing="true"] > code:focus {
   outline: none;
 }
 
-/* for COPY(highlight__button-group の中に入る) */
+/* for COPY(highlight__button-group の中に入る)。RUN と同じ見た目 */
 .highlight__copy-button {
   display: inline-block;
   margin-bottom: 0.25em;
   padding: 0.25em 0.5em;
-  background: #DDD;
-  opacity: 0.75;
+  background: #fff;
   cursor: pointer;
+  border: 1px solid #999;
   border-radius: 4px;
 }
 .highlight__copy-button:hover {
   background: #EE8;
-  opacity: 1;
 }
 .highlight__copy-button::after {
   content: "COPY"
 }
 .highlight__copy-button.copied {
   background: #070;
+  border-color: #070;
   color: white;
 }
 .highlight__copy-button.copied::after {
@@ -247,11 +248,13 @@ pre.highlight.ruby[data-editing="true"] > code:focus {
 }
 
 /* サンプルコードのキャプション。pre の上に密着したタブとして表示する
-   (上だけ角丸でタブらしく)。script.js がツールバー行の左端に取り込む */
+   (上だけ角丸でタブらしく)。script.js がツールバー行の左端に取り込む。
+   下のコード部分と同じ背景色にして「つながったタブ」に見せる(ヘッダー
+   行のほうがひと段暗いので埋没しない) */
 .caption {
     display: inline-block;
     padding: 0.2em 0.5em;
-    background: #ddd;
+    background: #f2f2f2;
     margin: 1em 0 0;
     border-radius: 6px 6px 0 0;
 }

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -138,23 +138,30 @@ pre {
 }
 
 
-/* pre の直前に密着するツールバー行(script.js が生成)。
-   左端に caption のタブ、右端に RUN/COPY のボタン群を置く */
+/* pre の直前に密着するヘッダー行(script.js が生成)。pre と同じ背景色で
+   コードブロックと一体に見せる(白い帯として浮くと、コードの上の隙間が
+   広く見える)。左端に caption のタブ、右端に RUN/COPY のボタン群を置く */
 .highlight__toolbar {
   display: flex;
   align-items: flex-end;
   margin: 1em 0 0;
+  padding: 0.25em 0.25em 0 0.25em;
+  background-color: #f2f2f2;
 }
 .highlight__toolbar + pre {
   margin-top: 0;
+  /* ヘッダー行が上の余白を兼ねるので、上 padding は控えめにする */
+  padding-top: 0.25em;
 }
-/* RUN の出力欄: 入力欄の pre と出力欄(ツールバー+pre)を密着させて
-   1つのブロックに見せる(js/run.js が付与) */
+/* RUN の出力欄: 入力欄の pre と出力欄(ヘッダー行+pre)を密着させて
+   1つのブロックに見せる(js/run.js が付与)。境には 2px だけ白を挟み、
+   出力欄のヘッダー(「実行結果」タブ+COPY)が入力欄の枠に貼り付いて
+   見えないよう区切る */
 .highlight--with-output {
   margin-bottom: 0;
 }
 .highlight__toolbar--attached {
-  margin-top: 0;
+  margin-top: 2px;
 }
 
 /* ツールバー右端のボタン置き場。ボタン間の隙間のカーソル形状と

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -126,24 +126,41 @@ code, pre, tt {
     font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
 }
 
-/* COPY ボタン(script.js)が全 pre の先頭行に入るため、上 padding は
-   highlight の有無によらず 0 にしてボタンを上端に密着させる */
+/* RUN/COPY ボタンは pre の外のツールバー行(script.js が生成)にあるので、
+   pre の中身は四辺とも均等に padding をとれる(上だけ 0 にして中身が
+   上端に張り付く、以前のボタン内蔵ハックは不要になった) */
 pre {
     line-height: 1.1;
     background-color: #f2f2f2;
-    padding: 0px 1.1em 1.1em 1.1em;
+    padding: 1.1em;
     font-weight: normal;
     overflow: auto;
 }
 
 
-/* RUN/COPY ボタン共用の float コンテナ(script.js が生成)。ボタンを
-   個別に float させるとボタン間・周囲の余白が pre の text カーソル領域の
-   ままになり、ポインタ形状がちらついてクリックしにくいため、隙間の
-   カーソル形状と選択不可はコンテナが引き受ける */
+/* pre の直前に密着するツールバー行(script.js が生成)。
+   左端に caption のタブ、右端に RUN/COPY のボタン群を置く */
+.highlight__toolbar {
+  display: flex;
+  align-items: flex-end;
+  margin: 1em 0 0;
+}
+.highlight__toolbar + pre {
+  margin-top: 0;
+}
+/* RUN の出力欄: 入力欄の pre と出力欄(ツールバー+pre)を密着させて
+   1つのブロックに見せる(js/run.js が付与) */
+.highlight--with-output {
+  margin-bottom: 0;
+}
+.highlight__toolbar--attached {
+  margin-top: 0;
+}
+
+/* ツールバー右端のボタン置き場。ボタン間の隙間のカーソル形状と
+   選択不可はここが引き受ける */
 .highlight__button-group {
-  float: right;
-  margin: 0 -1.1em 0.25em 0.5em;
+  margin-left: auto;
   cursor: default;
   -webkit-user-select: none;
   user-select: none;
@@ -151,12 +168,13 @@ pre {
 
 /* for RUN (js/run.js, statichtml --run-ruby-wasm) */
 .highlight__run-button {
-  margin: 0 0.5em 0 0;
+  margin: 0 0.5em 0.25em 0;
   padding: 0.25em 0.5em;
   background-color: #DDD;
   opacity: 0.75;
   cursor: pointer;
   border: 0;
+  border-radius: 4px;
   font: inherit;
 }
 .highlight__run-button:hover {
@@ -182,9 +200,9 @@ pre {
 pre.highlight.ruby[data-editing="true"]:focus-within {
   outline: auto;
 }
-/* inline-block + width:100% だと float のボタン群と同じ行に入れず
-   ボタンの下へ押し下げられて先頭に空行が見えるため、block にして
-   通常表示と同じく先頭行がボタンの左に回り込むようにする */
+/* 編集時は code をブロック化して pre の内容幅いっぱいをクリック・
+   編集対象にする(内容の外側のクリックは js/run.js が code に
+   フォーカスを移す) */
 pre.highlight.ruby[data-editing="true"] > code {
   display: block;
 }
@@ -195,10 +213,12 @@ pre.highlight.ruby[data-editing="true"] > code:focus {
 /* for COPY(highlight__button-group の中に入る) */
 .highlight__copy-button {
   display: inline-block;
+  margin-bottom: 0.25em;
   padding: 0.25em 0.5em;
   background: #DDD;
   opacity: 0.75;
   cursor: pointer;
+  border-radius: 4px;
 }
 .highlight__copy-button:hover {
   background: #EE8;
@@ -220,15 +240,20 @@ pre.highlight.ruby[data-editing="true"] > code:focus {
 }
 
 /* サンプルコードのキャプション。pre の上に密着したタブとして表示する
-   (pre 内の absolute 配置だと、編集・貼り付けで先頭行と重なるため) */
+   (上だけ角丸でタブらしく)。script.js がツールバー行の左端に取り込む */
 .caption {
     display: inline-block;
     padding: 0.2em 0.5em;
     background: #ddd;
     margin: 1em 0 0;
+    border-radius: 6px 6px 0 0;
 }
+/* JS 無効時など、ツールバー化されず pre の直前に残った場合の密着 */
 .caption + pre {
     margin-top: 0;
+}
+.highlight__toolbar > .caption {
+    margin: 0;
 }
 
 blockquote {

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -137,10 +137,21 @@ pre {
 }
 
 
+/* RUN/COPY ボタン共用の float コンテナ(script.js が生成)。ボタンを
+   個別に float させるとボタン間・周囲の余白が pre の text カーソル領域の
+   ままになり、ポインタ形状がちらついてクリックしにくいため、隙間の
+   カーソル形状と選択不可はコンテナが引き受ける */
+.highlight__button-group {
+  float: right;
+  margin: 0 -1.1em 0.25em 0.5em;
+  cursor: default;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
 /* for RUN (js/run.js, statichtml --run-ruby-wasm) */
 .highlight__run-button {
-  float: right;
-  margin: 0 0 0.25em 0.5em;
+  margin: 0 0.5em 0 0;
   padding: 0.25em 0.5em;
   background-color: #DDD;
   opacity: 0.75;
@@ -171,18 +182,19 @@ pre {
 pre.highlight.ruby[data-editing="true"]:focus-within {
   outline: auto;
 }
+/* inline-block + width:100% だと float のボタン群と同じ行に入れず
+   ボタンの下へ押し下げられて先頭に空行が見えるため、block にして
+   通常表示と同じく先頭行がボタンの左に回り込むようにする */
 pre.highlight.ruby[data-editing="true"] > code {
-  display: inline-block;
-  width: 100%;
+  display: block;
 }
 pre.highlight.ruby[data-editing="true"] > code:focus {
   outline: none;
 }
 
-/* for COPY */
+/* for COPY(highlight__button-group の中に入る) */
 .highlight__copy-button {
-  float: right;
-  margin: 0 -1.1em 0.25em 0.5em;
+  display: inline-block;
   padding: 0.25em 0.5em;
   background: #DDD;
   opacity: 0.75;


### PR DESCRIPTION
## 概要

RUN ボタンの実行を、ページのメインスレッドでの同期 `vm.eval` から Web Worker へ移します(fix #239)。無限ループや長い `sleep` を含むサンプルでタブの UI が完全に固まる問題を解消し、STOP ボタンでの中断・30 秒タイムアウト・出力の逐次表示を追加します。

あわせて、レビューでのブラウザ確認を受けてサンプルブロックの UI を再設計しました。RUN/COPY ボタンは pre の中(float)から pre の外のヘッダー行に移り、「例」の caption や新設の「実行結果」タブと同じ行に並びます。

## 変更内容

### 実行の Web Worker 化

- 新規 `theme/default/js/run-worker.js`(module Worker)を追加。1 回の実行につき 1 Worker を生成し、完了または中断で破棄します。VM は Worker 内で毎回作り直すため、実行同士の状態リークはありません
- wasm のコンパイルはこれまでどおりメインスレッド側で一度だけ行ってキャッシュし(`createOnceLoader`)、`WebAssembly.Module` を構造化クローンで Worker へ `postMessage` します。STOP・タイムアウト後の再実行でもコンパイルのやり直しは不要です
- 実行中は RUN ボタンが STOP に変わり、クリックで `Worker.terminate()` して中断できます。30 秒(`RUN_TIMEOUT_MS`)で自動 terminate します
- `run-worker.js` も `.mjs` ではなく `.js` 命名です(#217 と同じ MIME 判定の理由)

### 出力の逐次表示と注記

- 旧実装の「`$stdout` を `StringIO` に溜めて eval 後に一括読み出し」をやめ、Worker 内の `PRELUDE` が書き込みのたびに `JS.global.call(:postOutput, text)` でメインスレッドへ送ります。出力し続けるループで wasm メモリ内の文字列が膨らみ続ける問題も解消します
- `$stdout`/`$stderr` に入る `JSStreamIO` は `write`/`flush` だけでなく `puts`・`print`・`printf`・`putc`・`<<`・`sync`/`sync=`・`tty?` も実装しています。`Kernel#puts`/`p` は `#write` フォールバックで動きますが、マニュアルのサンプルには `$stderr.puts` などの直接呼び出しが多数あるためです(旧 `StringIO` はこれらを備えていました)
- 表示は 64KB で打ち切り(`accumulateOutput`)。打ち切り後のチャンクは即捨てるので暴走出力でも O(1) です
- 終わり方は必ず注記でわかるようにしました: 正常終了 `(正常終了しました)`・STOP `(停止しました)`・タイムアウト `(30秒でタイムアウトしました)`・例外はエラーメッセージ(赤字)。これらの注記は 1 回きりで長さが有界なので、64KB 打ち切り済みでも必ず末尾に表示されます(出力ゼロのサンプルでも完了がわかります)

### 編集まわり

- 編集開始時のプレーンテキスト化で、コンパイラが `<code>` 直後に置く改行も除去します(`editableText`。編集開始時に先頭の空行として見えていたもの)
- 改行入力・貼り付けが `<br>`/`<div>` にならないよう `contentEditable = 'plaintext-only'` を優先し(Chrome/Safari/Firefox 136+)、未対応ブラウザは従来の `true` + `paste` イベントで `text/plain` をキャレット位置に挿入します。貼り付けた内容が前の行にくっつく問題の解消です
- pre 自身のクリック(padding 部分や 1 行サンプルの下の余白)でも code にフォーカスして末尾にキャレットを置くので、pre 内のどこをクリックしても編集に入れます。Ctrl/Cmd+Enter での再実行は従来どおりです

### サンプルブロックの UI 再設計(レビュー指摘反映)

- script.js が全 pre の直前にヘッダー行 `<div class="highlight__toolbar">` を生成し、COPY(と run.js の RUN)をその右端のボタン置き場に入れます。pre 内への float 配置は、カーソル形状のちらつき・編集時のレイアウト崩れ・pre の上 padding を 0 にするハックなど無理が多いためやめました
- ヘッダー行はコード部分よりひと段暗い `#e6e6e6` でコードブロックと一体に見せます。caption(「例」)はコード部分と同じ `#f2f2f2`・上だけ角丸のタブとしてヘッダー左端に取り込み、RUN/COPY は白背景+枠線+角丸のボタンにして埋没を防いでいます
- pre の padding は四辺均等の `1.1em` に戻しました(上だけ 0 のハック廃止。中身が枠の上端に張り付く問題の解消)。ヘッダー行直後の pre は上 padding を `0.25em` に抑えます
- RUN の出力欄は「2px の白い境」+「実行結果」タブ付きヘッダー+出力 pre の構成で、入力欄に密着した 1 ブロックに見せます(`highlight--with-output`/`highlight__toolbar--attached`)
- ツールバーは JS 生成なので、静的 HTML やコンパイラ出力に変更はありません

### ビルド・型

- `lib/bitclust/subcommands/statichtml_command.rb` の `copy_run_ruby_wasm_script` を `RUN_RUBY_WASM_JS_FILES = %w[run.js run-worker.js]` の一覧コピーに拡張しました。**この一覧への追加漏れは RUN 機能が本番で無言で壊れる原因になるため要注意です**。片方だけ欠けたテーマも警告してスキップします
- `sig/bitclust/subcommands/statichtml_command.rbs` に型を追加

## 実装メモ

- **worker URL の解決**: `new URL('run-worker.js', import.meta.url)` で `run.js` 自身の URL から解決します。ページ階層や `custom_js_url()` の実装に依存せず、テンプレートは無変更です(`URL` が無い QuickJS でのテスト実行を妨げないよう遅延評価)
- **プロトコル**: main→worker `{ module, code }`、worker→main `{ type: 'output', text }`(0 回以上)→ `{ type: 'done' }` または `{ type: 'error', message }`(必ず最後に 1 回)。STOP/タイムアウトは main 側が `terminate()` するだけです
- **Ruby→JS の受け渡し**: `JSStreamIO#write` は worker 内の小さなヘルパー `postOutput()` を呼び、`{ type: ... }` の封筒詰めは run-worker.js の 1 箇所に閉じています
- **ライフサイクル**: 旧実装も VM は実行ごとに使い捨てだったため、Worker 単位に持ち替えても意味論上の後退はありません。ボタン状態はブロックごとの `current` で管理し、done/error/STOP/タイムアウトのどの経路も同じ `finish()` に収束させています

## 検証

- **qjs**: `test/js/test_run.mjs`(純粋関数: `accumulateOutput`・各注記・`editableText`・`PRELUDE` の形・`formatRunError`)、`test/js/test_script.mjs`(ヘッダー行の構造・caption の取り込み・`ruremaAddCopyButton` フック・COPY の動作)全て pass
- **Ruby**: 新規 `test/test_run_worker_prelude.rb` が `PRELUDE` を実 Ruby(JS ブリッジをスタブ)で eval し、`Kernel#puts`/`p` のフォールバック経路と `$stderr.puts` 等の直接呼び出しの両方が旧 `StringIO` と同じ出力になることを検証。`test_statichtml_command.rb` は 2 ファイルコピー+片方欠けテーマのテストを追加。フルスイート `ruby test/run_test.rb` 17596 tests 100% pass
- **ブラウザ(レビューで確認済み)**: RUN→STOP→再実行、無限ループの 30 秒タイムアウト(タブは固まらない)、暴走出力の 64KB 打ち切りと打ち切り後の注記表示、例外時の赤字+RETRY、ヘッダー行・タブ・ボタンの見た目
- wasm 実行の実挙動(CDN の `@ruby/wasm-wasi` を module Worker 内で dynamic import する部分を含む)はレビューでのブラウザ確認に依っています。ローカルでの再現手順:

```bash
bundle exec bitclust --database=/tmp/db-3.4 statichtml \
  --outputdir=/tmp/run-html --templatedir=data/bitclust/template.offline \
  --catalog=data/bitclust/catalog \
  --run-ruby-wasm='https://cdn.jsdelivr.net/npm/@ruby/3.4-wasm-wasi@2.9.3-2.9.4/dist/ruby+stdlib.wasm'
ruby -run -e httpd /tmp/run-html -p 8000
```

fix #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
