### PR TITLE
[[ISO:8601]]/[[JIS:X 0301]] をリンクにせず平文で表示する

### DIFF
--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -451,19 +451,29 @@ module BitClust
     end
 
     BracketLink = /\[\[[\w-]+?:[!-~]+?(?:\[\] )?\]\]/n
+    # BitClust には ISO/JIS へのリンク機能がないため、[[ISO:8601]]/[[JIS:X 0301]] は
+    # リンクにせず平文で表示する (rurema/bitclust#236)。引数に空白を含む JIS も拾う。
+    StandardRef = /\[\[(?:ISO|JIS):[!-~][!-~ ]*?\]\]/n
     NeedESC = /[&"<>]/
 
     def compile_text(str)
       escape_table = HTMLUtils::ESC
-      str.gsub(/(#{NeedESC})|(#{BracketLink})/o) {
+      str.gsub(/(#{NeedESC})|(#{StandardRef})|(#{BracketLink})/o) {
         # @type var char: '&' | '"' | '<' | '>'
         if    char = _ = $1 then escape_table[char]
-        elsif tok  = $2 then bracket_link(tok[2..-3] || raise)
-        elsif tok  = $3 then seems_code(tok)
+        elsif tok  = $2 then standard_ref(tok[2..-3] || raise)
+        elsif tok  = $3 then bracket_link(tok[2..-3] || raise)
         else
           raise 'must not happen'
         end
       }
+    end
+
+    def standard_ref(link)
+      # 例: "ISO:8601" -> "ISO 8601", "JIS:X 0301" -> "JIS X 0301"
+      type, _arg = link.split(':', 2)
+      arg = _arg&.strip or raise
+      escape_html("#{type} #{arg}")
     end
 
     def bracket_link(link, label = nil, frag = nil)

--- a/sig/bitclust/rdcompiler.rbs
+++ b/sig/bitclust/rdcompiler.rbs
@@ -118,9 +118,13 @@ module BitClust
 
     BracketLink: ::Regexp
 
+    StandardRef: ::Regexp
+
     NeedESC: ::Regexp
 
     def compile_text: (String str) -> String
+
+    def standard_ref: (String link) -> String
 
     def bracket_link: (String link, ?String? label, ?String? frag) -> String
 

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -706,6 +706,8 @@ HERE
        "man header"          => ['[[man:sys/socket.h(header)]]', '<a class="external" href="http://www.opengroup.org/onlinepubs/009695399/basedefs/sys/socket.h.html">sys/socket.h(header)</a>'],
        "man system call"     => ['[[man:fopen(3linux)]]', '<a class="external" href="http://man7.org/linux/man-pages/man3/fopen.3.html">fopen(3linux)</a>'],
        "RFC"                 => ['[[RFC:2822]]',      '<a class="external" href="https://tools.ietf.org/html/rfc2822">[RFC2822]</a>'],
+       "ISO standard"        => ['[[ISO:8601]]',      'ISO 8601'],
+       "JIS standard"        => ['[[JIS:X 0301]]',    'JIS X 0301'],
        "special var $~"      => ['[[m:$~]]',          '<a href="dummy/method/Kernel/v/=7e">$~</a>'],
        "special var $,"      => ['[[m:$,]]',          '<a href="dummy/method/Kernel/v/=2c">$,</a>'],
        "extra close bracket" => ['[[c:String]]]', '<a href="dummy/class/String">String</a>]'],


### PR DESCRIPTION
BitClust には ISO/JIS へのリンク機能がないため、Date/DateTime の `[[ISO:8601]]` `[[JIS:X 0301]]` がリンクにならず、生の角括弧のまま表示されていた(#236)。方針としてリンクは諦め、`ISO 8601` / `JIS X 0301` という平文で描画する。凍結された古いバージョン(RD ソースを編集できない)にも効くよう、コンパイラ側で対応した。

- `StandardRef` で `[[ISO:...]]`/`[[JIS:...]]` を捕捉。`JIS X 0301` のように引数に空白を含むものも拾えるよう、既存 `BracketLink`(`[!-~]` が空白を除外)とは別の正規表現にした。
- `standard_ref` で scheme 名+引数を空白区切りの平文へ変換(HTML エスケープあり)。
- `test_bracket_link` に ISO/JIS の行を追加。RBS(`StandardRef`/`standard_ref`)も追加し `steep check` はクリーン。

補足: 従来 `[[ISO:8601]]` は `bracket_link` の `else` で literal 再出力、`[[JIS:X 0301]]` は `BracketLink` に match すらせず素通り、という二経路だった。両方を `StandardRef` に集約した。

doctree 側の現行 Markdown ソースは平文へ置換済み(別 PR、rurema/doctree#2173)。

fix #236
