### PR TITLE
クラスページに「再定義されたメソッド」セクションを追加する

### DIFF
--- a/data/bitclust/catalog/ja_JP.UTF-8
+++ b/data/bitclust/catalog/ja_JP.UTF-8
@@ -84,6 +84,8 @@ Private Instance Methods
 privateメソッド
 Protected Instance Methods
 protectedメソッド
+Redefined Methods
+再定義されたメソッド
 Private Singleton Methods
 private特異メソッド
 Required Libraries

--- a/data/bitclust/template.epub/class
+++ b/data/bitclust/template.epub/class
@@ -59,6 +59,7 @@
      [_('Private Instance Methods'),  ents.private_instance_methods   ],
      [_('Protected Instance Methods'),ents.protected_instance_methods ],
      [_('Module Functions'),          ents.module_functions           ],
+     [_('Redefined Methods'),         ents.redefined                  ],
      [_('Constants'),                 ents.constants                  ],
      [_('Special Variables'),         ents.special_variables          ,'$']] %>
 <%= headline(_("Index")) %>

--- a/data/bitclust/template.lillia/class
+++ b/data/bitclust/template.lillia/class
@@ -63,6 +63,7 @@
      [_('Module Functions'),          ents.module_functions           ],
      [_('Constants'),                 ents.constants                  ],
      [_('Special Variables'),         ents.special_variables          ],
+     [_('Redefined Methods'),         ents.redefined                  ],
      [_('Added Methods'),             ents.added                      ] ]\
     .each do |label, entries|
       unless entries.empty? %>

--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -122,6 +122,7 @@
      [_('Private Instance Methods'),  ents.private_instance_methods   ],
      [_('Protected Instance Methods'),ents.protected_instance_methods ],
      [_('Module Functions'),          ents.module_functions           ],
+     [_('Redefined Methods'),         ents.redefined                  ],
      [_('Undefined Methods for Explanation'), ents.nomethod           ],
      [_('Constants'),                 ents.constants                  ],
      [_('Special Variables'),         ents.special_variables          ,'$']] %>
@@ -148,8 +149,8 @@
 
 <%
 _myself, *ancestors = @entry.ancestors.reject { |c| %w[Object Kernel BasicObject].include?(c.name) }
-displayed_instance_methods = Set.new(ents.instance_methods.flat_map(&:names))
-displayed_singleton_methods = Set.new(ents.singleton_methods.flat_map(&:names))
+displayed_instance_methods = Set.new((ents.instance_methods + ents.redefined.select(&:instance_method?)).flat_map(&:names))
+displayed_singleton_methods = Set.new((ents.singleton_methods + ents.redefined.select(&:singleton_method?)).flat_map(&:names))
 undefined_methods = @entry.partitioned_entries.undefined
 undefined_instance_methods = undefined_methods.select(&:instance_method?)
 undefined_singleton_methods = undefined_methods.select(&:singleton_method?)

--- a/data/bitclust/template/class
+++ b/data/bitclust/template/class
@@ -115,6 +115,41 @@
 <%  end %>
 
 <%
+    [[_('Redefined Methods'),      ents.redefined]]\
+    .each do |label, entries|
+      unless entries.empty?  %>
+<%=     headline(label) %>
+<table class="entries methods">
+<tr>
+  <th><%= _('Signature') %></th>
+  <th><%= _('Description') %></th>
+  <th><%= _('Library') %></th>
+</tr>
+<%
+        headline_push
+        entries.each do |m|
+          foreach_method_chunk(m.source) do |sigs, src| %>
+<tr>
+<td class="signature">
+  <a href="<%=h method_url(m.spec_string) %>"><code>
+  <%= sigs.map {|sig| h(sig.friendly_string) }.join("<br>") %>
+  </code></a>
+</td>
+<td class="description"><%= compile_rd(src) %></td>
+<td class="library"><%= library_link(m.library.name) %></td>
+</tr>
+<%
+          end
+        end
+        headline_pop
+%>
+</table>
+<%
+      end
+    end
+%>
+
+<%
     [[_('Added Methods'),          ents.added]]\
     .each do |label, entries|
       unless entries.empty?  %>

--- a/lib/bitclust/classentry.rb
+++ b/lib/bitclust/classentry.rb
@@ -257,6 +257,7 @@ module BitClust
                        :instance_methods,  :private_instance_methods, :protected_instance_methods,
                        :module_functions,
                        :constants, :special_variables,
+                       :redefined,
                        :added, :undefined, :nomethod)
 
     def partitioned_entries(level = 0)
@@ -268,6 +269,7 @@ module BitClust
       # @type var mf: Array[MethodEntry]
       # @type var c: Array[MethodEntry]
       # @type var v: Array[MethodEntry]
+      # @type var redefined: Array[MethodEntry]
       # @type var added: Array[MethodEntry]
       # @type var undefined: Array[MethodEntry]
       # @type var nomethod: Array[MethodEntry]
@@ -275,12 +277,13 @@ module BitClust
       i = []; ipv = []; ipt = []
       mf = []
       c = []; v = []
+      redefined = []
       added = []
       undefined = []
       nomethod = []
       entries(level).sort_by(&:name).each do |m|
         case m.kind
-        when :defined, :redefined
+        when :defined
           case m.type
           when :singleton_method
             (m.public? ? s : spv).push m
@@ -297,6 +300,8 @@ module BitClust
           else
             raise "must not happen: m.type=#{m.type.inspect} (#{m.inspect})"
           end
+        when :redefined
+          redefined.push m
         when :added
           added.push m
         when :undefined
@@ -306,7 +311,7 @@ module BitClust
         end
       end
       # steep:ignore:start
-      Parts.new(s,spv, i,ipv,ipt, mf, c, v, added, undefined, nomethod)
+      Parts.new(s,spv, i,ipv,ipt, mf, c, v, redefined, added, undefined, nomethod)
       # steep:ignore:end
     end
 

--- a/sig/bitclust/classentry.rbs
+++ b/sig/bitclust/classentry.rbs
@@ -98,6 +98,7 @@ module BitClust
       attr_accessor module_functions: Array[MethodEntry]
       attr_accessor constants: Array[MethodEntry]
       attr_accessor special_variables: Array[MethodEntry]
+      attr_accessor redefined: Array[MethodEntry]
       attr_accessor added: Array[MethodEntry]
       attr_accessor undefined: Array[MethodEntry]
       attr_accessor nomethod: Array[MethodEntry]
@@ -106,6 +107,7 @@ module BitClust
                        Array[MethodEntry] instance_methods,  Array[MethodEntry] private_instance_methods, Array[MethodEntry] protected_instance_methods,
                        Array[MethodEntry] module_functions,
                        Array[MethodEntry] constants, Array[MethodEntry] special_variables,
+                       Array[MethodEntry] redefined,
                        Array[MethodEntry] added, Array[MethodEntry] undefined, Array[MethodEntry] nomethod) -> void
     end
 

--- a/test/test_class_screen.rb
+++ b/test/test_class_screen.rb
@@ -39,6 +39,11 @@ sub class method
 --- explanatory_method
 {: nomethod}
 説明のために記載しているメソッドです。
+
+= redefine Sub
+== Instance Methods
+--- redefined_instance_method
+redefined instance method
 HERE
 
   def setup
@@ -92,5 +97,10 @@ HERE
     assert_include(@html, 'base_instance_method')
     assert_include(@html, 'Mixinから継承しているメソッド')
     assert_include(@html, 'mixin_instance_method')
+  end
+
+  def test_redefined_method_is_listed_in_its_own_section
+    assert_include(@html, '再定義されたメソッド')
+    assert_include(@html, 'redefined_instance_method')
   end
 end

--- a/test/test_entry.rb
+++ b/test/test_entry.rb
@@ -163,6 +163,25 @@ HERE
     assert_equal([], parts.instance_methods.map(&:name))
   end
 
+  def test_redefined_is_partitioned_separately
+    klass = parse_class(<<HERE)
+= class Hoge
+== Instance Methods
+--- bar
+
+説明です。
+
+= redefine Hoge
+== Instance Methods
+--- baz
+
+再定義の説明です。
+HERE
+    parts = klass.partitioned_entries
+    assert_equal(['baz'], parts.redefined.map(&:name))
+    assert_equal(['bar'], parts.instance_methods.map(&:name))
+  end
+
   def test_description_skips_leading_metadata_paragraph
     klass = parse_class(<<HERE)
 = class Hoge


### PR DESCRIPTION
同名で再定義されたメソッド(kind = `:redefined`。例: mathn が `Integer#/` を再定義)は `partitioned_entries` で `:defined` と合算され、「インスタンスメソッド」等に混ざって表示されていた(#167)。#214 の祖先メソッド節の延長として、独立した「再定義されたメソッド」セクションに分けて表示する。

- `ClassEntry::Parts` に `redefined` バケットを追加、`partitioned_entries` で `:defined`/`:redefined` を別々に振り分け。
- 4 テンプレート(offline/epub/lillia/legacy)に再定義メソッドのセクションを追加。offline では祖先メソッド抑制用の集合にも再定義メソッド名を含め、「継承しているメソッド」との重複を防止。
- カタログに `Redefined Methods`/「再定義されたメソッド」を追加。RBS(Parts)更新。
- `test_entry`(バケット分割)・`test_class_screen`(セクション描画)にテスト追加。フルスイート 17619 tests 0 failures、`steep check` クリーン。

各再定義メソッドの詳細欄には既存の `[redefined by <lib>]` バッジがそのまま付く。`= redefine Integer` 相当で `/` が「再定義されたメソッド」節に出て「インスタンスメソッド」からは消えることを ScreenManager で確認済み。

fix #167
