### PR TITLE
dlist の用語に {#id} でアンカーを付けられるようにする

### DIFF
--- a/lib/bitclust/mdcompiler.rb
+++ b/lib/bitclust/mdcompiler.rb
@@ -49,7 +49,9 @@ module BitClust
     INDENTED_FENCE_RE = /\A([ \t]+)(`{3,})/
     # dd 段落の継続行（インデント行。ただしインデントフェンスの手前で止まる）
     DD_TEXT_RE = /\A[ \t](?![ \t]*`{3})/
-    DLIST_RE = /\A- \*\*(.+?)\*\*:(?:\s|$)/
+    # 用語の後ろに {#id} があればアンカー id として扱う（用語集の各用語への
+    # リンク用。rurema/doctree#2634）。id は $2 に入る。
+    DLIST_RE = /\A- \*\*(.+?)\*\*:(?:[ \t]*\{#([\w-]+)\})?(?:\s|$)/
     INFO_RE = /\A- \*\*(?:param|arg|return|raise)\*\*/
     SEE_RE = /\A- \*\*SEE\*\*/
     # @undef など変換器が生のまま渡す未知メタデータ
@@ -271,12 +273,13 @@ module BitClust
           # GFM モード: `term` のコードスパンは <code> として描画し、
           # 中身の参照はその中で解決する（<code><a>...</a></code>。spec/eval）
           term = ($1 || raise)
+          id = $2   # {#id} があれば dt にアンカーを付ける（term の再マッチ前に退避）
           if gfm? && term =~ /\A`(.+)`\z/
             inner = ($1 || raise).strip
-            line dt("<code>#{rd_compile_text(MarkdownToRRD.restore_inline(inner))}</code>")
+            line dt("<code>#{rd_compile_text(MarkdownToRRD.restore_inline(inner))}</code>", id)
           else
             term = strip_code_span(term).strip
-            line dt(compile_text(term))
+            line dt(compile_text(term), id)
           end
           inline = l.sub(DLIST_RE, '').strip
           @f.ungets("  #{inline}\n") unless inline.empty?

--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -273,8 +273,8 @@ module BitClust
       line '</dd>'
     end
 
-    def dt(s)
-      "<dt>#{s}</dt>"
+    def dt(s, id = nil)
+      id ? %Q(<dt id="#{escape_html(id)}">#{s}</dt>) : "<dt>#{s}</dt>"
     end
 
     def stop_on_syntax_error?

--- a/sig/bitclust/rdcompiler.rbs
+++ b/sig/bitclust/rdcompiler.rbs
@@ -81,7 +81,7 @@ module BitClust
     # empty lines do not separate paragraphs.
     def dd_without_p: () -> void
 
-    def dt: (String s) -> String
+    def dt: (String s, ?String? id) -> String
 
     METHOD_ATTRIBUTE_LINE_RE: ::Regexp
 

--- a/test/test_mdcompiler.rb
+++ b/test/test_mdcompiler.rb
@@ -158,6 +158,18 @@ class TestMDCompiler < Test::Unit::TestCase
     RD
   end
 
+  def test_dlist_term_anchor
+    # 用語の後ろの {#id} は dt のアンカー id になる（用語集の各用語リンク用, rurema/doctree#2634）
+    html = @md.compile("- **アリティー**: {#arity}\n- **`arity`**:\n  仮引数の数。\n")
+    assert_include(html, '<dt id="arity">アリティー</dt>')
+    # {#id} が無い項目には id は付かない
+    assert_not_include(html, '<dt id="arity">arity')
+    # 通常の dlist は従来どおり id 無し
+    plain = @md.compile("- **foo**:\n  bar\n")
+    assert_include(plain, '<dt>foo</dt>')
+    assert_not_include(plain, '<dt id')
+  end
+
   def test_entry_heading
     assert_equivalent_method <<~RD
       --- index(val) -> Integer


### PR DESCRIPTION
Markdown の定義リスト `- **term**:` の用語末尾に `{#id}` を書けるようにし、その id を `<dt>` の id 属性として出力します。用語集(`doc/glossary`)の各用語へ直接リンクできるようにするための機能追加です(rurema/doctree#2634)。

- `DLIST_RE` に任意の `{#id}` を追加し、id を `$2` で拾う
- `dt(s, id)` に id 引数を追加し、id があれば `<dt id="...">` を出力(HTML エスケープあり)
- 通常の dlist(id 無し)は従来どおり id 無しの `<dt>`
- RBS(`dt`)更新、`test_mdcompiler` にアンカー付き dlist のテスト追加。full suite 17620件 pass・`steep check` クリーン

これがマージされたら、doctree 側で `glossary.md` の各用語に `{#slug}` を付与し `Gemfile.lock` を本コミットへバンプする PR(rurema/doctree#2634 の本体)を出します。
