### PR TITLE
doc ページの front matter で since/until をサポートする

### DIFF
--- a/lib/bitclust/methoddatabase.rb
+++ b/lib/bitclust/methoddatabase.rb
@@ -265,8 +265,15 @@ module BitClust
           [p, "#{p}.md", p.sub(/\.rd\z/, '.md')]
         }.flatten
       }.to_set
+      version = properties()["version"]
       files.each do |f|
         next if referenced.include?(File.expand_path(f))
+        # front matter の since/until でページ自体をバージョンで出し分ける
+        # （ライブラリ側 update_by_markdowntree と同じ意味論）。範囲外の版では
+        # ページを登録しない（例: doc/spec/safelevel は until: "3.2" で 3.2 以降
+        # 非生成）
+        since_version, until_version = doc_md_version_range(f)
+        next unless md_version_covers?(version, since_version, until_version)
         id = libname2id(f.delete_prefix("#{doc_root}/").sub(/\.md\z/, ''))
         se = DocEntry.new(self, id)
         s = Preprocessor.read(f, properties)
@@ -278,6 +285,25 @@ module BitClust
       end
     end
     private :copy_doc_md
+
+    # doc ページの先頭 front matter から since/until を読む
+    # （MarkdownTree.scan がライブラリ/エンティティで読むのと同じ書式）。
+    # front matter が無い、または since/until を持たなければ [nil, nil]。
+    def doc_md_version_range(path)
+      since_version = nil
+      until_version = nil
+      File.open(path, 'r:UTF-8') do |io|
+        first = io.gets
+        return [nil, nil] unless first && first =~ /\A---\s*$/
+        while (line = io.gets)
+          break if line =~ /\A---\s*$/
+          since_version = $1 if line =~ /\Asince:\s*"?([^"\s]+)"?/
+          until_version = $1 if line =~ /\Auntil:\s*"?([^"\s]+)"?/
+        end
+      end
+      [since_version, until_version]
+    end
+    private :doc_md_version_range
 
     #
     # Doc Entry

--- a/sig/bitclust/methoddatabase.rbs
+++ b/sig/bitclust/methoddatabase.rbs
@@ -93,6 +93,9 @@ module BitClust
     # source には md がそのまま入り、source_location は md の実パスを指す
     def copy_doc_md: () -> void
 
+    # doc ページの先頭 front matter から since/until を読む
+    def doc_md_version_range: (String path) -> [ String?, String? ]
+
     public
 
     def docs: () -> Array[DocEntry]

--- a/test/test_copy_doc_md.rb
+++ b/test/test_copy_doc_md.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'test/unit'
+require 'tmpdir'
+require 'fileutils'
+require 'bitclust'
+require 'bitclust/methoddatabase'
+
+# copy_doc_md: manual/doc 配下の md をファイル存在で doc ページとして登録する。
+# front matter の since/until でページ自体をバージョンで出し分けられることを
+# 確認する（ライブラリ側と同じ意味論）。
+class TestCopyDocMd < Test::Unit::TestCase
+  def docs_for(version)
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, 'manual', 'api'))
+      FileUtils.mkdir_p(File.join(dir, 'manual', 'doc', 'spec'))
+      File.write(File.join(dir, 'manual', 'doc', 'spec', 'gated.md'),
+                 "---\nuntil: \"3.2\"\n---\n# ゲート付きページ\n\n本文。\n")
+      File.write(File.join(dir, 'manual', 'doc', 'spec', 'since.md'),
+                 "---\nsince: \"3.3\"\n---\n# 新機能ページ\n\n本文。\n")
+      File.write(File.join(dir, 'manual', 'doc', 'spec', 'normal.md'),
+                 "# 通常ページ\n\n本文。\n")
+
+      prefix = File.join(dir, 'db')
+      db = BitClust::MethodDatabase.new(prefix)
+      db.init
+      db.transaction do
+        db.propset('version', version)
+        db.propset('encoding', 'utf-8')
+      end
+      db.transaction do
+        db.instance_variable_set(:@md_root, File.join(dir, 'manual', 'api'))
+        db.__send__(:copy_doc_md)
+      end
+      db2 = BitClust::MethodDatabase.new(prefix)
+      return db2.docs.each_with_object({}) { |d, h| h[d.id] = d.title }
+    end
+  end
+
+  def test_until_gate_before_threshold
+    docs = docs_for('3.0')
+    assert_equal 'ゲート付きページ', docs['spec.gated']   # until: 3.2 → 3.0 は表示
+    assert_nil docs['spec.since']                         # since: 3.3 → 3.0 は非表示
+    assert_equal '通常ページ', docs['spec.normal']
+  end
+
+  def test_until_gate_after_threshold
+    docs = docs_for('3.4')
+    assert_nil docs['spec.gated']                         # until: 3.2 → 3.4 は非表示
+    assert_equal '新機能ページ', docs['spec.since']       # since: 3.3 → 3.4 は表示
+    assert_equal '通常ページ', docs['spec.normal']
+  end
+end


### PR DESCRIPTION
`manual/doc` 配下の doc ページは、これまで front matter に `since:`/`until:` を書いてもバージョンに関係なく生成されていました(`copy_doc_md` はファイル存在で無条件に登録していました)。ライブラリ側(`update_by_markdowntree`)は front matter の since/until を `md_version_covers?` で解釈しているのに、doc ページ側だけ未対応だった格好です。

doc ページでも front matter の since/until を読み、その版で有効なページだけを登録するようにします。

これにより doc ページ自体をバージョンで出し分けできます。例えば `doc/spec/safelevel.md` の先頭に `until: "3.2"` を書けば、taint 系メソッドが存在する 3.1 まではページを出し、それらが削除された 3.2 以降は出さない、という制御ができます(doctree 側の対応 PR)。

- front matter は `split_doc` が本文抽出時に読み飛ばすため、描画には影響しません(タイトル・本文は従来どおり)。
- since/until を持たない doc ページ(既存の全ページ)は従来どおり全バージョンで生成されます。

テスト(`test/test_copy_doc_md.rb`)を追加し、`until: "3.2"` のページが 3.0 で登録され 3.4 で登録されないこと、`since: "3.3"` はその逆、front matter の無いページは両方で登録されることを確認しています。全テスト green・`steep check` 型エラーなしです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
