### PR TITLE
クラスページに dynamic include されたモジュールのメソッドを表示

### DIFF
--- a/data/bitclust/catalog/ja_JP.UTF-8
+++ b/data/bitclust/catalog/ja_JP.UTF-8
@@ -70,6 +70,8 @@ Math
 数学
 Method
 メソッド
+Methods Added by Dynamic Include
+動的includeで追加されるメソッド
 Modules
 モジュール
 Module Functions

--- a/data/bitclust/template.epub/class
+++ b/data/bitclust/template.epub/class
@@ -98,5 +98,24 @@
 <%
       end
     end
+%>
+
+<%
+    dyninc_groups = @entry.dynamically_included_entries.group_by(&:klass)
+    unless dyninc_groups.empty? %>
+<%=   headline(_('Methods Added by Dynamic Include')) %>
+<dl>
+<%    dyninc_groups.each do |mod, mod_entries| %>
+<dt><%= mod.name %> (by <%= mod.library.name %>)</dt>
+<dd>
+<ul>
+<%      mod_entries.each do |m| %>
+<li><%= method_link(m.spec_string, m.name) %></li>
+<%      end %>
+</ul>
+</dd>
+<%    end %>
+</dl>
+<%  end
     headline_pop
 %>

--- a/data/bitclust/template.lillia/class
+++ b/data/bitclust/template.lillia/class
@@ -83,6 +83,25 @@
 <%
       end
     end
+%>
+
+<%
+    dyninc_groups = @entry.dynamically_included_entries.group_by(&:klass)
+    unless dyninc_groups.empty? %>
+<%=   headline(_('Methods Added by Dynamic Include')) %>
+<dl class="rightlist">
+<%    dyninc_groups.each do |mod, mod_entries| %>
+<dt><%= mod.name %> (by <%= mod.library.name %>)</dt>
+<dd>
+<ul>
+<%      mod_entries.each do |m| %>
+<li><%= method_link(m.spec_string, m.name) %></li>
+<%      end %>
+</ul>
+</dd>
+<%    end %>
+</dl>
+<%  end
     headline_pop
 %>
 </div>

--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -199,6 +199,25 @@ end %>
 </dl>
 
 <%
+    dyninc_groups = @entry.dynamically_included_entries.group_by(&:klass)
+%>
+<% unless dyninc_groups.empty? %>
+  <%= headline(_("Methods Added by Dynamic Include")) %>
+<dl>
+  <% dyninc_groups.each do |mod, mod_entries| %>
+<dt><%= mod.name %> (by <%= mod.library.name %>)</dt>
+<dd>
+  <ul class="class-toc">
+    <% mod_entries.each do |m| %>
+      <li><%= method_link(m.spec_string, m.name) %></li>
+    <% end %>
+  </ul>
+</dd>
+  <% end %>
+</dl>
+<% end %>
+
+<%
     items.each do |label, entries|
       unless entries.empty? %>
 <%=     headline(label) %>

--- a/data/bitclust/template/class
+++ b/data/bitclust/template/class
@@ -182,5 +182,38 @@
 <%
       end
     end
+%>
+
+<%
+    dyninc_entries = @entry.dynamically_included_entries
+    unless dyninc_entries.empty?  %>
+<%=   headline(_('Methods Added by Dynamic Include')) %>
+<table class="entries methods">
+<tr>
+  <th><%= _('Signature') %></th>
+  <th><%= _('Description') %></th>
+  <th><%= _('Module') %></th>
+</tr>
+<%
+      headline_push
+      dyninc_entries.each do |m|
+        foreach_method_chunk(m.source) do |sigs, src| %>
+<tr>
+<td class="signature">
+  <a href="<%=h method_url(m.spec_string) %>"><code>
+  <%= sigs.map {|sig| h(sig.friendly_string) }.join("<br>") %>
+  </code></a>
+</td>
+<td class="description"><%= compile_rd(src) %></td>
+<td class="library"><%= class_link(m.klass.name) + " (by " + library_link(m.library.name) + ")" %></td>
+</tr>
+<%
+        end
+      end
+      headline_pop
+%>
+</table>
+<%
+    end
     headline_pop
 %>

--- a/lib/bitclust/classentry.rb
+++ b/lib/bitclust/classentry.rb
@@ -230,6 +230,24 @@ module BitClust
       list
     end
 
+    # Public instance methods contributed by modules that are dynamically
+    # included into this class (via `# reopen` + `include:`/`include`).
+    #
+    # Unlike +included+, +dynamically_included+ does not affect +ancestors+
+    # or the method resolution order, so these methods are never returned by
+    # +entries+/+partitioned_entries+. This method exists so that screens and
+    # templates can list them separately, attributed to the module (and its
+    # library) that defines them, without disturbing the MRO.
+    #
+    # Only each module's own public instance methods are returned (i.e. its
+    # +entries(0)+ filtered like +public_instance_methods+); methods that the
+    # dynamically included module itself inherits are not followed. If no
+    # module has been dynamically included, this returns an empty array, so
+    # output for classes without dynamic include is unaffected.
+    def dynamically_included_entries
+      dynamically_included().flat_map {|m| m.public_instance_methods(0) }
+    end
+
     def extended_modules
       ancestors().select(&:class?).map(&:extended).flatten
     end

--- a/sig/bitclust/classentry.rbs
+++ b/sig/bitclust/classentry.rbs
@@ -82,6 +82,8 @@ module BitClust
 
     def extended_modules: () -> Array[ClassEntry]
 
+    def dynamically_included_entries: () -> Array[MethodEntry]
+
     def entries: (?Integer level) -> Array[MethodEntry]
     alias methods entries
 

--- a/test/test_class_screen.rb
+++ b/test/test_class_screen.rb
@@ -103,4 +103,60 @@ HERE
     assert_include(@html, '再定義されたメソッド')
     assert_include(@html, 'redefined_instance_method')
   end
+
+  def test_class_without_dynamic_include_does_not_show_dynamic_include_section
+    # Regression guard: classes that never use dynamic include must render
+    # exactly as before (no new headline, no leftover markers).
+    assert_not_include(@html, '動的includeで追加されるメソッド')
+  end
+end
+
+class TestClassScreenDynamicInclude < Test::Unit::TestCase
+  SRC = <<'HERE'
+= module JsonMixin
+json mixin module
+== Instance Methods
+--- to_json
+to json
+== Private Instance Methods
+--- hidden_json_helper
+hidden json helper
+= class Host < Object
+host class
+== Instance Methods
+--- host_method
+host method
+= reopen Host
+include JsonMixin
+HERE
+
+  def setup
+    @lib, = BitClust::RRDParser.parse(SRC, 'jsonlib')
+    datadir = File.expand_path('../data/bitclust', __dir__)
+    manager = BitClust::ScreenManager.new(
+      :templatedir => "#{datadir}/template.offline",
+      :catalogdir => "#{datadir}/catalog",
+      :encoding => 'utf-8',
+      :default_encoding => 'utf-8',
+      :base_url => '',
+      :target_version => '3.4'
+    )
+    db = BitClust::MethodDatabase.dummy('version' => '3.4')
+    @html = manager.class_screen(@lib.fetch_class('Host'), :database => db).body
+  end
+
+  def test_dynamically_included_method_is_listed_with_attribution
+    assert_include(@html, '動的includeで追加されるメソッド')
+    assert_include(@html, 'to_json')
+    assert_include(@html, 'JsonMixin')
+    assert_include(@html, '(by jsonlib)')
+  end
+
+  def test_ancestors_are_not_affected_by_dynamic_include
+    assert_not_include(@lib.fetch_class('Host').ancestors.map(&:name), 'JsonMixin')
+  end
+
+  def test_private_instance_method_of_dynamically_included_module_is_hidden
+    assert_not_include(@html, 'hidden_json_helper')
+  end
 end

--- a/test/test_entry.rb
+++ b/test/test_entry.rb
@@ -206,3 +206,66 @@ HERE
     assert_equal('', method.description)
   end
 end
+
+class TestClassEntryDynamicallyIncludedEntries < Test::Unit::TestCase
+  SRC = <<'HERE'
+= module DynMod
+dyn module
+== Instance Methods
+--- dyn_method
+dyn method
+== Private Instance Methods
+--- hidden_dyn_method
+hidden dyn method
+= class Host < Object
+host class
+== Instance Methods
+--- host_method
+host method
+= reopen Host
+include DynMod
+HERE
+
+  def setup
+    @lib, = BitClust::RRDParser.parse(SRC, 'dynlib')
+    @host = @lib.fetch_class('Host')
+  end
+
+  def test_returns_public_instance_methods_of_dynamically_included_modules
+    assert_equal(['dyn_method'], @host.dynamically_included_entries.map(&:name))
+  end
+
+  def test_excludes_private_instance_methods_of_the_dynamically_included_module
+    names = @host.dynamically_included_entries.map(&:name)
+    assert_not_include(names, 'hidden_dyn_method')
+  end
+
+  def test_entries_keep_their_originating_module_and_library
+    entry = @host.dynamically_included_entries.first
+    assert_equal('DynMod', entry.klass.name)
+    assert_equal('dynlib', entry.library.name)
+  end
+
+  def test_does_not_affect_ancestors
+    # dynamic include must not change the MRO/ancestors chain.
+    assert_equal(['Host', 'Object'], @host.ancestors.map(&:name))
+  end
+
+  def test_does_not_affect_entries_or_partitioned_entries
+    assert_not_include(@host.entries.map(&:name), 'dyn_method')
+    parts = @host.partitioned_entries
+    assert_not_include(parts.instance_methods.map(&:name), 'dyn_method')
+    assert_not_include(parts.added.map(&:name), 'dyn_method')
+  end
+
+  def test_is_empty_when_class_has_no_dynamic_include
+    plain, = BitClust::RRDParser.parse(<<'PLAIN', 'dynlib')
+= class Plain < Object
+plain class
+== Instance Methods
+--- plain_method
+plain method
+PLAIN
+    assert_equal([], plain.fetch_class('Plain').dynamically_included_entries)
+  end
+end


### PR DESCRIPTION
fix #248(rurema/doctree#2338 の原因対応)。

`# reopen Klass` + front matter `include:` で記述された dynamic include のモジュールのメソッドが、クラスページのメソッド一覧に一切表示されない問題を解消します(doctree では json の to_json・open-uri の OpenURI::OpenRead#open/read・rake の RakeFileUtils が該当)。

## 実装

- **ClassEntry#dynamically_included_entries** を追加: dynamic include された各モジュールの public instance methods(`public_instance_methods(0)`=モジュール自身の分のみ・可視性/ソートは既存の流儀)を返す。**ancestors/MRO・entries/partitioned_entries には一切影響しない**(dynamic include が無ければ空配列=出力不変)。
- **4テンプレート**(template/template.offline/template.lillia/template.epub の `class`)に「動的includeで追加されるメソッド」セクションを追加。既存の1行注記(`dynamic include: ... (by ...)`)はそのまま残し、純追加。
  - template(サーバ)は既存の Added Methods と同じ signature/description テーブル+Module 列(`(by ライブラリ)` リンク付き)。
  - template.offline(本番 statichtml)は同ファイルの Ancestor Methods と同じ `<dt>/<dd><ul class="class-toc">` 形式でモジュールごとにグループ化。lillia/epub も各自の既存構造に合わせた `<dl>` 形式。
- カタログに msgid「Methods Added by Dynamic Include」=「動的includeで追加されるメソッド」を追加。RBS(sig/bitclust/classentry.rbs)にも1行追加。

## テスト・検証

- test/test_entry.rb に `dynamically_included_entries` のユニットテスト(public のみ・帰属・ancestors/entries 非影響・空ケース)、test/test_class_screen.rb に ClassScreen での描画テスト(見出し・メソッド名・`(by lib)`・private 非表示・dynamic include 無しクラスは新見出しが出ない回帰テスト)を追加。
- **全テストスイート 17632 tests / 18052 assertions / 0 failures 0 errors**。
- doctree 実データ(3.4 markdowntree)で検証: Array/Hash/String/Integer/Float/NilClass/TrueClass/FalseClass/Object に to_json、URI::HTTP/URI::FTP に OpenURI::OpenRead#open/read、Kernel に RakeFileUtils の各メソッドが帰属付きで表示されること、Comparable/Enumerable 等(dynamic include 無し)の出力が完全に不変であることを4テンプレートで確認。

## 補足(スコープ外・気づいた点)

- template.offline/template.epub は従来から `ents.added`(reopen 本文直書きのメソッド)自体を表示していません(本 PR とは別の既存ギャップ)。
- 対称の `dynamic_extend`(特異メソッド側)は従来どおり1行注記のみ(現状 doctree に必要なケースなし。必要になれば同じ形で追加可能)。
- マージ後、doctree 側 Gemfile.lock のバンプで本番に反映されれば rurema/doctree#2338 をクローズできます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
