### PR TITLE
statichtml/epub のクラスページに reopen で追加されたメソッドを表示

### DIFF
--- a/data/bitclust/template.epub/class
+++ b/data/bitclust/template.epub/class
@@ -59,6 +59,7 @@
      [_('Private Instance Methods'),  ents.private_instance_methods   ],
      [_('Protected Instance Methods'),ents.protected_instance_methods ],
      [_('Module Functions'),          ents.module_functions           ],
+     [_('Added Methods'),             ents.added                      ],
      [_('Redefined Methods'),         ents.redefined                  ],
      [_('Constants'),                 ents.constants                  ],
      [_('Special Variables'),         ents.special_variables          ,'$']] %>

--- a/data/bitclust/template.offline/class
+++ b/data/bitclust/template.offline/class
@@ -122,6 +122,7 @@
      [_('Private Instance Methods'),  ents.private_instance_methods   ],
      [_('Protected Instance Methods'),ents.protected_instance_methods ],
      [_('Module Functions'),          ents.module_functions           ],
+     [_('Added Methods'),             ents.added                      ],
      [_('Redefined Methods'),         ents.redefined                  ],
      [_('Undefined Methods for Explanation'), ents.nomethod           ],
      [_('Constants'),                 ents.constants                  ],

--- a/test/test_class_screen.rb
+++ b/test/test_class_screen.rb
@@ -160,3 +160,52 @@ HERE
     assert_not_include(@html, 'hidden_json_helper')
   end
 end
+
+class TestClassScreenAddedMethods < Test::Unit::TestCase
+  SRC = <<'HERE'
+= class Target < Object
+target class
+== Instance Methods
+--- own_method
+own method
+= reopen Target
+== Instance Methods
+--- added_by_reopen
+added by reopen
+HERE
+
+  def setup
+    @lib, = BitClust::RRDParser.parse(SRC, 'extlib')
+    datadir = File.expand_path('../data/bitclust', __dir__)
+    @manager = BitClust::ScreenManager.new(
+      :templatedir => "#{datadir}/template.offline",
+      :catalogdir => "#{datadir}/catalog",
+      :encoding => 'utf-8',
+      :default_encoding => 'utf-8',
+      :base_url => '',
+      :target_version => '3.4'
+    )
+    db = BitClust::MethodDatabase.dummy('version' => '3.4')
+    @html = @manager.class_screen(@lib.fetch_class('Target'), :database => db).body
+  end
+
+  # reopen 本文に直接定義されたメソッド(kind = :added)が
+  # statichtml 用テンプレートの目次に出ること
+  def test_added_methods_are_listed_in_offline_index
+    assert_include(@html, '追加されるメソッド')
+    assert_include(@html, 'added_by_reopen')
+  end
+
+  def test_class_without_added_methods_has_no_added_heading
+    plain, = BitClust::RRDParser.parse(<<'PLAIN', 'extlib')
+= class Plain < Object
+plain class
+== Instance Methods
+--- plain_method
+plain method
+PLAIN
+    db = BitClust::MethodDatabase.dummy('version' => '3.4')
+    html = @manager.class_screen(plain.fetch_class('Plain'), :database => db).body
+    assert_not_include(html, '追加されるメソッド')
+  end
+end


### PR DESCRIPTION
#249 の調査で見つかった、本番テンプレートの表示ギャップの修正です。

## 問題

`template.offline`(statichtml=docs.ruby-lang.org 用)と `template.epub` のクラスページ目次(items)には `partitioned_entries` の **added(`reopen` 本文に直接定義されたメソッド)が含まれておらず**、一覧に表示されていません。実レンダリングで確認したところ、本番相当の出力で:

- Array のページに csv の `to_csv`・shellwords の `shelljoin`・abbrev の `abbrev` が出ない
- Kernel のページに rake の `task`/`desc`/`file` などが出ない

(サーバ用 `template` と `template.lillia` は従来から Added Methods を表示しています。)

## 修正

両テンプレートの items に `Added Methods`(カタログ訳「追加されるメソッド」は既存)の行を追加。表示位置は Module Functions と Redefined Methods の間です。

## 検証

- doctree 実データ(3.4 markdowntree)で Array(to_csv/shelljoin 表示)・Kernel(task 表示)・Comparable(追加メソッドなし=出力不変)を offline/epub 両テンプレートで確認。
- test_class_screen.rb に回帰テストを追加(added が目次に出る・無いクラスには見出しが出ない)。**全テストスイートパス**。

マージ後は doctree 側の Gemfile.lock バンプ(次の doctree PR に同乗可)で本番に反映されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
