### PR TITLE
Kernel のモジュール関数の rdoc リンクを method-i- にする

### DIFF
--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -620,8 +620,14 @@ module BitClust
 
     def rdoc_url(method_id, version)
       cname, tmark, mname, _libname = methodid2specparts(method_id)
-      tchar = typemark2char(tmark) == 'i' ? 'i' : 'c'
       cname = cname.split(".").first || raise
+      # rdoc は Kernel のモジュール関数(rb_define_global_function 由来)を
+      # private インスタンスメソッドとして掲載しているため i にする
+      if typemark2char(tmark) == 'i' || (cname == "Kernel" && tmark == '.#')
+        tchar = 'i'
+      else
+        tchar = 'c'
+      end
       cname = cname.gsub('::', '/')
       id = "method-#{tchar}-#{encodename_rdocurl(mname)}"
 

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -937,6 +937,16 @@ HERE
           :method_id => "ARGF.class/i.binmode.argf._builtin",
           :version   => "2.0.0",
           :expected  => "https://docs.ruby-lang.org/en/2.0.0/ARGF.html#method-i-binmode"
+       },
+       "Kernel.#trace_var" => {
+          :method_id => "Kernel/m.trace_var._builtin",
+          :version   => "2.0.0",
+          :expected  => "https://docs.ruby-lang.org/en/2.0.0/Kernel.html#method-i-trace_var"
+       },
+       "Math.#sqrt" => {
+          :method_id => "Math/m.sqrt._builtin",
+          :version   => "2.0.0",
+          :expected  => "https://docs.ruby-lang.org/en/2.0.0/Math.html#method-c-sqrt"
        })
   def test_rdoc_url(data)
     assert_equal(data[:expected], @c.rdoc_url(data[:method_id], data[:version]))


### PR DESCRIPTION
#237 対応。

メソッドページの rdoc リンクは従来「instance 以外は一律 `method-c-*`」で生成していましたが、rdoc(docs.ruby-lang.org/en)は **Kernel のモジュール関数(rb_define_global_function 由来)を private インスタンスメソッドとして掲載**しており、正しいアンカーは `method-i-*` です(issue の例: Kernel.#trace_var)。Kernel のモジュール関数の場合のみ `i` を使うようにしました。

Math.sqrt など他モジュールのモジュール関数は rdoc では特異メソッド掲載(`method-c-*`)のため従来どおりです(回帰テストに Math.#sqrt を追加して固定)。

検証: test_rdcompiler.rb にテスト2件追加(Kernel.#trace_var → `method-i-trace_var`・Math.#sqrt → `method-c-sqrt`)、全テストスイートパス、steep check エラー 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
