### PR TITLE
インラインコードに背景色などのはっきりしたスタイルを追加

### DIFF
--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -126,6 +126,25 @@ code, pre, tt {
     font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
 }
 
+/* 地の文中のインラインコード(<code>, <tt>)に淡い背景を敷いて、地の文との
+   区別をはっきりさせる。色は pre の背景(#f2f2f2)と同系統だが、それより
+   少し薄くして地の文中では主張しすぎないようにする */
+code, tt {
+    background-color: #f5f5f5;
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+}
+
+/* pre の中の code/tt は pre 自体がブロックとして背景色を持つため、上の
+   ルールをここで打ち消して二重に背景・パディングがつかないようにする
+   (pre 内の見た目は従来どおり) */
+pre code,
+pre tt {
+    background-color: transparent;
+    padding: 0;
+    border-radius: 0;
+}
+
 /* RUN/COPY ボタンは pre の外のツールバー行(script.js が生成)にあるので、
    pre の中身は四辺とも均等に padding をとれる(上だけ 0 にして中身が
    上端に張り付く、以前のボタン内蔵ハックは不要になった) */

--- a/theme/lillia/style.css
+++ b/theme/lillia/style.css
@@ -173,8 +173,27 @@ td.library {
     border: 3px solid white;
 }
 
-code {
+code, tt {
     font-family: monospace;
+}
+
+/* 地の文中のインラインコード(<code>, <tt>)に淡い背景を敷いて、地の文との
+   区別をはっきりさせる。色は pre の背景(#eee)と同系統だが、それより少し
+   薄くして地の文中では主張しすぎないようにする */
+code, tt {
+    background-color: #f5f5f5;
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+}
+
+/* pre の中の code/tt は pre 自体がブロックとして背景色を持つため、上の
+   ルールをここで打ち消して二重に背景・パディングがつかないようにする
+   (pre 内の見た目は従来どおり) */
+pre code,
+pre tt {
+    background-color: transparent;
+    padding: 0;
+    border-radius: 0;
 }
 
 a {


### PR DESCRIPTION
#246 への対応です。地の文中のインラインコード(`code`/`tt` 要素)に、Python・Rust のドキュメント同様の淡い背景+padding+角丸を付けて、地の文との区別をはっきりさせます。

- default・lillia 両テーマに適用。背景色は各テーマの pre の背景色と同系統の薄い色(#f5f5f5)
- `pre` 内の `code`/`tt` では打ち消して従来どおり(コードブロックの見た目は不変)
- メソッドシグネチャなど見出し系に含まれる code 要素にも適用されます(インラインコードの視認性向上という issue の趣旨に含まれる想定ですが、範囲を地の文だけに絞りたい場合はセレクタを調整します)

CSS のみの変更で、テストスイートは全 green(17647 tests)です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
