### PR TITLE
Windows のドライブレター付き DB パスが URI 化で壊れる問題を修正

### DIFF
--- a/lib/bitclust/searcher.rb
+++ b/lib/bitclust/searcher.rb
@@ -40,8 +40,18 @@ module BitClust
         parser.banner = "Usage: #{@name} <pattern>"
         unless cmd == 'bitclust'
           parser.on('-d', '--database=URL', "Database location (default: #{dblocation_name()})") {|loc|
-            url = (/:/ =~ loc) ? loc : "file://#{File.expand_path(loc)}"
-            @dblocation = URI.parse(url)
+            @dblocation =
+              if windows_drive_path?(loc)
+                # "G:/Users/foo/.bitclust/db-2.2.0" のような Windows の
+                # ドライブレター付きパスは "/:/ =~ loc" が真になってしまい
+                # (":" がドライブレターの区切りに含まれるため)、既に URL
+                # 形式だと誤認されて file:// を付けずに URI.parse に渡って
+                # しまう。drive_path_uri で組み立てる
+                drive_path_uri(loc)
+              else
+                url = (/:/ =~ loc) ? loc : "file://#{File.expand_path(loc)}"
+                URI.parse(url)
+              end
           }
           parser.on('--server=URL', 'Spawns BitClust database server and listen URL.  Requires --database option with local path.') {|url|
             require 'bitclust/server'   # require here for speed
@@ -183,10 +193,33 @@ module BitClust
         return URI.parse(ENV.fetch(key)) if ENV[key]
       end
       if path = dbpath()
-        URI.parse("file://#{path}")
+        # Windows で "G:/Users/foo/.bitclust/db-2.2.0" のようなドライブ
+        # レター付きの絶対パスを URI.parse("file://#{path}") に渡すと、
+        # "G" が URI のホスト部分として解釈されてしまい、path からドライブ
+        # レターが失われる(URI.parse("file://G:/foo").path は "/foo" に
+        # なってしまう)。ドライブレター付きパスのときは URI 化せず、
+        # drive_path_uri でドライブレターを保持したまま file: URI を作る
+        windows_drive_path?(path) ? drive_path_uri(path) : URI.parse("file://#{path}")
       else
         nil
       end
+    end
+
+    # "G:/foo" や "C:\\foo" のような、Windows のドライブレターで始まる
+    # 絶対パスかどうかを判定する
+    def windows_drive_path?(path)
+      /\A[A-Za-z]:/.match?(path)
+    end
+
+    # ドライブレター付きの絶対パスを、ドライブレターを失わずに保持した
+    # ままの file: URI (URI::File) にする。通常の URI.parse("file://...")
+    # はホスト部分を認識してしまい先頭のドライブレターを取りこぼすため、
+    # ここでは URI::Generic#initialize の arg_check を無効にして、
+    # "先頭は / から始まる絶対パスであること" という通常の URI のパス
+    # 検証を素通りさせ、path にドライブレターを含む文字列をそのまま保持
+    # させる
+    def drive_path_uri(path)
+      URI::File.new('file', nil, '', nil, nil, path, nil, nil, nil, nil, false)
     end
 
     def dbpath

--- a/sig/bitclust/searcher.rbs
+++ b/sig/bitclust/searcher.rbs
@@ -49,6 +49,10 @@ module BitClust
 
     def find_dblocation: () -> (URI::File | URI::Generic)?
 
+    def windows_drive_path?: (String path) -> bool
+
+    def drive_path_uri: (String path) -> URI::File
+
     def dbpath: () -> String?
 
     def env_dbpath: () -> String?

--- a/test/test_searcher.rb
+++ b/test/test_searcher.rb
@@ -1,6 +1,8 @@
 require "test/unit"
 require "bitclust"
 require "bitclust/searcher"
+require "fileutils"
+require "tmpdir"
 
 class TestTerminalView < Test::Unit::TestCase
   include BitClust
@@ -17,5 +19,87 @@ class TestTerminalView < Test::Unit::TestCase
     end
     assert_equal %w[Bar Foo], out.split
     assert_empty err
+  end
+end
+
+class TestSearcherWindowsDrivePath < Test::Unit::TestCase
+  include BitClust
+
+  ENV_KEYS = %w[REFE2_SERVER BITCLUST_SERVER REFE2_DATADIR BITCLUST_DATADIR]
+
+  def setup
+    @saved_env = {}
+    ENV_KEYS.each {|key| @saved_env[key] = ENV.delete(key) }
+    @saved_dir = Dir.pwd
+    @searcher = Searcher.new
+  end
+
+  def teardown
+    Dir.chdir(@saved_dir)
+    ENV_KEYS.each do |key|
+      if @saved_env[key]
+        ENV[key] = @saved_env[key]
+      else
+        ENV.delete(key)
+      end
+    end
+  end
+
+  def test_windows_drive_path_predicate
+    assert_true @searcher.send(:windows_drive_path?, "G:/Users/foo/.bitclust/db-2.2.0")
+    assert_true @searcher.send(:windows_drive_path?, 'C:\Users\foo\.bitclust\db-2.2.0')
+    assert_false @searcher.send(:windows_drive_path?, "/home/foo/.bitclust/db-2.2.0")
+    assert_false @searcher.send(:windows_drive_path?, "druby://localhost:10001")
+  end
+
+  def test_drive_path_uri_keeps_drive_letter
+    uri = @searcher.send(:drive_path_uri, "G:/Users/foo/.bitclust/db-2.2.0")
+    assert_equal "file", uri.scheme
+    assert_equal "G:/Users/foo/.bitclust/db-2.2.0", uri.path
+  end
+
+  def test_find_dblocation_keeps_windows_drive_letter
+    with_fake_datadir("G:/Users/foo/.bitclust/db-2.2.0") do |relative_path|
+      ENV["BITCLUST_DATADIR"] = relative_path
+      location = @searcher.send(:find_dblocation)
+      assert_equal "file", location.scheme
+      assert_equal relative_path, location.path
+    end
+  end
+
+  def test_find_dblocation_keeps_unix_absolute_path
+    Dir.mktmpdir do |dir|
+      datadir = File.join(dir, ".bitclust", "db-2.2.0")
+      FileUtils.mkdir_p(datadir)
+      FileUtils.touch(File.join(datadir, "properties"))
+      ENV["BITCLUST_DATADIR"] = datadir
+      location = @searcher.send(:find_dblocation)
+      assert_equal "file", location.scheme
+      assert_equal datadir, location.path
+    end
+  end
+
+  def test_database_option_keeps_windows_drive_letter
+    @searcher.parser.parse!(["--database=G:/Users/foo/.bitclust/db-2.2.0"])
+    dblocation = @searcher.instance_variable_get(:@dblocation)
+    assert_equal "file", dblocation.scheme
+    assert_equal "G:/Users/foo/.bitclust/db-2.2.0", dblocation.path
+  end
+
+  private
+
+  # datadir/properties を tmpdir 内に作り、tmpdir へ chdir したうえで
+  # datadir までの相対パス(ドライブレターを含む)を渡す。":" は Unix の
+  # ファイル名として有効な文字なので、Linux 上でも "G:" というディレク
+  # トリを作ってドライブレター付きパスの再現ができる
+  def with_fake_datadir(relative_path)
+    Dir.mktmpdir do |dir|
+      datadir = File.join(dir, *relative_path.split("/"))
+      FileUtils.mkdir_p(datadir)
+      FileUtils.touch(File.join(datadir, "properties"))
+      Dir.chdir(dir) do
+        yield relative_path
+      end
+    end
   end
 end


### PR DESCRIPTION
#238 への対応です。Windows で bitclust をインストールしたドライブと異なるドライブから refe を実行すると DB が見つからなくなる問題を修正します。

## 原因

`lib/bitclust/searcher.rb` の `find_dblocation` が DB パスを `URI.parse("file://#{path}")` で URI 化しており、`G:/Users/foo/.bitclust/db-2.2.0` のようなドライブレター付きパスでは `G` が URI の**ホスト**として解釈され、`.path` からドライブレターが消えます(`URI.parse("file://G:/foo").path #=> "/foo"`)。Windows では `/` 始まりの絶対パスはカレントドライブのルートを指すため、カレントドライブが異なると ENOENT になります — issue のエラーメッセージ(ドライブレターの無い絶対パス)と再現条件(別ドライブからの実行)に一致します。

## 修正

- ドライブレター付き絶対パス(`/\A[A-Za-z]:/`)の場合は `URI.parse` を通さず、`URI::File` を直接組み立ててドライブレターを保持したまま `.path` に持たせるようにしました(下流の消費側は `.scheme` と `.path` しか参照しないことを確認済み)
- 同じ誤判定が `--database=URL` オプションのハンドラにもあったため(`/:/ =~ loc` のヒューリスティックに `G:/...` がマッチして URL 扱いされる)、同様に修正
- Unix パスの経路は不変です

## テスト

ドライブレター付きパスで `.path` がドライブレターを保持することのユニットテストを追加。全テスト green・`rake sig` 反映済み・`steep check` エラー 0。

Windows 実機での最終確認はできていないため、環境をお持ちの方に `refe` の動作確認をお願いできると助かります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
