### PR TITLE
statichtml に --sitemap-baseurl オプションで sitemap.xml 生成を追加

### DIFF
--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -123,6 +123,8 @@ module BitClust
         @stop_on_syntax_error = true
         @eol_warning = false
         @run_ruby_wasm = nil
+        @sitemap_baseurl = nil
+        @sitemap_paths = []
         @parser.banner = "Usage: #{File.basename($0, '.*')} statichtml [options]"
         @parser.on('-o', '--outputdir=PATH', 'Output directory') do |path|
           begin
@@ -165,6 +167,9 @@ module BitClust
         @parser.on('--run-ruby-wasm=WASM_URL', 'Add a RUN button to Ruby sample code, executing it in-browser with the given ruby.wasm') do |url|
           @run_ruby_wasm = url
         end
+        @parser.on('--sitemap-baseurl=URL', 'Generate sitemap.xml under the output directory, with <loc> built from this base URL (e.g. https://docs.ruby-lang.org/ja/3.4/). Omit to skip sitemap.xml generation (default)') do |url|
+          @sitemap_baseurl = url
+        end
         @parser.on('--no-stop-on-syntax-error', 'Do not stop on syntax error') do |boolean|
           @stop_on_syntax_error = boolean
         end
@@ -202,17 +207,26 @@ module BitClust
         end
 
         @urlmapper.bitclust_html_base = '..'
-        create_file(@outputdir + "library/#{html_filename("index", @suffix)}",
+        library_index_path = @outputdir + "library/#{html_filename("index", @suffix)}"
+        create_file(library_index_path,
                     manager.library_index_screen(db.libraries.sort, {:database => db}).body,
                     :verbose => @verbose)
-        create_file(@outputdir + "class/#{html_filename("index", @suffix)}",
+        record_sitemap_path(library_index_path)
+        class_index_path = @outputdir + "class/#{html_filename("index", @suffix)}"
+        create_file(class_index_path,
                     manager.class_index_screen(db.classes.sort, {:database => db}).body,
                     :verbose => @verbose)
-        create_file(@outputdir + "function/#{html_filename("index", @suffix)}",
+        record_sitemap_path(class_index_path)
+        function_index_path = @outputdir + "function/#{html_filename("index", @suffix)}"
+        create_file(function_index_path,
                     manager.function_index_screen(fdb.functions.sort, { :database => fdb }).body,
                     :verbose => @verbose)
+        record_sitemap_path(function_index_path)
         create_index_html(@outputdir)
         create_search_index(@outputdir, db, fdb)
+        if baseurl = @sitemap_baseurl
+          create_sitemap(@outputdir, baseurl)
+        end
         FileUtils.cp(@manager_config[:themedir] + @manager_config[:css_url],
                      @outputdir.to_s, :verbose => @verbose, :preserve => true)
         FileUtils.cp(@manager_config[:themedir] + "syntax-highlight.css",
@@ -327,6 +341,55 @@ HERE
                      :verbose => @verbose, :preserve => true)
       end
 
+      # A single sitemap.xml file supports at most 50,000 URLs
+      # (https://www.sitemaps.org/protocol.html#index). Splitting into a
+      # sitemap index is out of scope for now (small start); if the site
+      # grows past this, only the first MAX_SITEMAP_URLS pages are listed
+      # and a warning is printed.
+      MAX_SITEMAP_URLS = 50_000
+
+      # The 5 characters that need escaping to embed arbitrary text as XML
+      # character data (used for the <loc> contents below).
+      XML_ESCAPES = {
+        '&' => '&amp;',
+        '<' => '&lt;',
+        '>' => '&gt;',
+        '"' => '&quot;',
+        "'" => '&apos;',
+      }.freeze
+
+      def escape_xml(str)
+        str.gsub(/[&<>"']/) {|c| XML_ESCAPES.fetch(c) }
+      end
+
+      # Remember +path+ (an HTML page actually written under @outputdir) so
+      # that create_sitemap can list it later. A no-op unless
+      # --sitemap-baseurl was given, so sitemap generation has no effect on
+      # the rest of the run when the option is not used.
+      def record_sitemap_path(path)
+        return unless @sitemap_baseurl
+        @sitemap_paths << path.relative_path_from(@outputdir).to_s
+      end
+
+      # Generate outputdir/sitemap.xml: a plain XML sitemap
+      # (https://www.sitemaps.org/protocol.html) listing every page
+      # recorded via record_sitemap_path, as baseurl + relative path.
+      def create_sitemap(outputdir, baseurl)
+        paths = @sitemap_paths
+        if paths.size > MAX_SITEMAP_URLS
+          $stderr.puts "warning: #{paths.size} pages found, but a single sitemap.xml supports at most #{MAX_SITEMAP_URLS} URLs; only the first #{MAX_SITEMAP_URLS} are included. Consider a sitemap index if you need the rest."
+          paths = paths.first(MAX_SITEMAP_URLS)
+        end
+        base = baseurl.end_with?('/') ? baseurl : "#{baseurl}/"
+        xml = +%(<?xml version="1.0" encoding="UTF-8"?>\n)
+        xml << %(<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n)
+        paths.each do |path|
+          xml << "<url><loc>#{escape_xml(base + path)}</loc></url>\n"
+        end
+        xml << "</urlset>\n"
+        create_file(outputdir + "sitemap.xml", xml, :verbose => @verbose)
+      end
+
       # Scripts for the RUN-button feature (statichtml --run-ruby-wasm):
       # run.js sets up the button and compiles the wasm module on the main
       # thread; run-worker.js is the module Worker it spawns per execution
@@ -387,6 +450,7 @@ HERE
         path.open('w') do |f|
           f.write(html)
         end
+        record_sitemap_path(path)
       end
 
       def create_file(path, str, options = {})

--- a/sig/bitclust/subcommands/statichtml_command.rbs
+++ b/sig/bitclust/subcommands/statichtml_command.rbs
@@ -27,6 +27,10 @@ module BitClust
 
       @run_ruby_wasm: String?
 
+      @sitemap_baseurl: String?
+
+      @sitemap_paths: Array[String]
+
       @outputdir: Pathname
 
       type manager_config = {
@@ -128,6 +132,16 @@ module BitClust
       SEARCH_JS_FILES: Array[String]
 
       def create_search_index: (Pathname outputdir, MethodDatabase db, FunctionDatabase fdb) -> void
+
+      MAX_SITEMAP_URLS: Integer
+
+      XML_ESCAPES: Hash[String, String]
+
+      def escape_xml: (String str) -> String
+
+      def record_sitemap_path: (Pathname path) -> void
+
+      def create_sitemap: (Pathname outputdir, String baseurl) -> void
 
       def create_html_file: (any_entry entry, ScreenManager manager, Pathname outputdir, Database db) -> void
 

--- a/test/test_statichtml_command.rb
+++ b/test/test_statichtml_command.rb
@@ -108,3 +108,97 @@ class TestStatichtmlRunRubyWasm < Test::Unit::TestCase
     end
   end
 end
+
+class TestStatichtmlSitemap < Test::Unit::TestCase
+  def build_command(outputdir)
+    cmd = BitClust::Subcommands::StatichtmlCommand.new
+    cmd.instance_variable_set(:@outputdir, Pathname.new(outputdir))
+    cmd.instance_variable_set(:@verbose, false)
+    cmd
+  end
+
+  def test_option_defaults_to_nil
+    cmd = BitClust::Subcommands::StatichtmlCommand.new
+    assert_nil(cmd.instance_variable_get(:@sitemap_baseurl))
+  end
+
+  def test_option_is_parsed
+    cmd = BitClust::Subcommands::StatichtmlCommand.new
+    cmd.parse(['--sitemap-baseurl=https://docs.ruby-lang.org/ja/3.4/'])
+    assert_equal('https://docs.ruby-lang.org/ja/3.4/',
+                 cmd.instance_variable_get(:@sitemap_baseurl))
+  end
+
+  def test_record_sitemap_path_is_noop_without_baseurl
+    Dir.mktmpdir do |dir|
+      cmd = build_command(dir)
+      cmd.send(:record_sitemap_path, Pathname.new(dir) + 'class' + 'String.html')
+      assert_empty(cmd.instance_variable_get(:@sitemap_paths))
+    end
+  end
+
+  def test_record_sitemap_path_keeps_relative_path
+    Dir.mktmpdir do |dir|
+      cmd = build_command(dir)
+      cmd.instance_variable_set(:@sitemap_baseurl, 'https://docs.ruby-lang.org/ja/3.4/')
+      cmd.send(:record_sitemap_path, Pathname.new(dir) + 'class' + 'String.html')
+      assert_equal(%w[class/String.html], cmd.instance_variable_get(:@sitemap_paths))
+    end
+  end
+
+  def test_create_sitemap_writes_loc_urls
+    Dir.mktmpdir do |dir|
+      cmd = build_command(dir)
+      cmd.instance_variable_set(:@sitemap_paths,
+                                 ['class/String.html', 'method/String/i/upcase.html'])
+      cmd.send(:create_sitemap, Pathname.new(dir), 'https://docs.ruby-lang.org/ja/3.4/')
+      xml = File.read(File.join(dir, 'sitemap.xml'))
+      assert_match(%r{\A<\?xml version="1\.0" encoding="UTF-8"\?>\n}, xml)
+      assert_match(%r{<urlset xmlns="http://www\.sitemaps\.org/schemas/sitemap/0\.9">}, xml)
+      assert_match(%r{<url><loc>https://docs\.ruby-lang\.org/ja/3\.4/class/String\.html</loc></url>}, xml)
+      assert_match(%r{<url><loc>https://docs\.ruby-lang\.org/ja/3\.4/method/String/i/upcase\.html</loc></url>}, xml)
+      assert_match(%r{</urlset>\n\z}, xml)
+    end
+  end
+
+  def test_create_sitemap_adds_trailing_slash_to_baseurl
+    Dir.mktmpdir do |dir|
+      cmd = build_command(dir)
+      cmd.instance_variable_set(:@sitemap_paths, ['class/String.html'])
+      cmd.send(:create_sitemap, Pathname.new(dir), 'https://docs.ruby-lang.org/ja/3.4')
+      xml = File.read(File.join(dir, 'sitemap.xml'))
+      assert_match(%r{<loc>https://docs\.ruby-lang\.org/ja/3\.4/class/String\.html</loc>}, xml)
+    end
+  end
+
+  def test_create_sitemap_escapes_special_characters
+    Dir.mktmpdir do |dir|
+      cmd = build_command(dir)
+      cmd.instance_variable_set(:@sitemap_paths, ['method/String/i/=3d=3d.html'])
+      cmd.send(:create_sitemap, Pathname.new(dir), 'https://example.com/a&b/')
+      xml = File.read(File.join(dir, 'sitemap.xml'))
+      assert_match(%r{<loc>https://example\.com/a&amp;b/method/String/i/=3d=3d\.html</loc>}, xml)
+      assert_not_match(/a&b/, xml)
+    end
+  end
+
+  def test_create_sitemap_warns_and_truncates_beyond_limit
+    Dir.mktmpdir do |dir|
+      cmd = build_command(dir)
+      limit = BitClust::Subcommands::StatichtmlCommand::MAX_SITEMAP_URLS
+      paths = (1..(limit + 1)).map {|i| "class/C#{i}.html" }
+      cmd.instance_variable_set(:@sitemap_paths, paths)
+      orig_stderr, $stderr = $stderr, StringIO.new
+      begin
+        cmd.send(:create_sitemap, Pathname.new(dir), 'https://example.com/')
+        assert_match(/warning:.*#{limit}/, $stderr.string)
+      ensure
+        $stderr = orig_stderr
+      end
+      xml = File.read(File.join(dir, 'sitemap.xml'))
+      assert_equal(limit, xml.scan('<url>').size)
+      assert_match(%r{<loc>https://example\.com/class/C1\.html</loc>}, xml)
+      assert_not_match(/C#{limit + 1}\.html/, xml)
+    end
+  end
+end


### PR DESCRIPTION
#130 への対応です。statichtml サブコマンドに sitemap.xml 生成機能を追加します(スモールスタート: オプション指定時のみ・最新版だけに使う想定)。

## 内容

- 新オプション `--sitemap-baseurl=URL`(例: `https://docs.ruby-lang.org/ja/3.4/`)。指定時のみ、出力ディレクトリ直下に sitemap.xml を生成します
- 生成した全ページ(library/class/method/function/doc+各 index)を `<loc>` に列挙するシンプルな XML sitemap([sitemaps.org](https://www.sitemaps.org/protocol.html) 形式)。ルートのリダイレクト用スタブ index.html は除外
- 1 ファイルの上限(50,000 URL)を超えた場合は警告を出して先頭 50,000 件のみ列挙(sitemap index への分割は今回のスコープ外)
- **オプション未指定時の出力はバイト単位で従来と同一**(記録処理は no-op)

## 運用イメージ

generated-documents 側で最新安定版のビルドにのみ `--sitemap-baseurl` を渡し、`https://docs.ruby-lang.org/ja/<最新版>/sitemap.xml` を提供する想定です(gd 側の変更は本 PR マージ後に別途)。全バージョン対応(sitemap index)は効果を見てから検討します。

## テスト

オプションの受理・sitemap.xml の内容(loc の URL 形式・XML エスケープ)のユニットテストを追加。全テスト green・`rake sig` 反映済み・`steep check` エラー 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
