### PR TITLE
メソッドページの title にエイリアスも列挙する

### DIFF
--- a/data/bitclust/template.epub/method
+++ b/data/bitclust/template.epub/method
@@ -1,6 +1,6 @@
 <%
     entry = @entries.sort.first
-    @title = "#{entry.type_label} #{entry.label}"
+    @title = "#{entry.type_label} #{entry.title_labels.join(', ')}"
 %>
 <p>
 <%= manual_home_link() %>

--- a/data/bitclust/template.lillia/method
+++ b/data/bitclust/template.lillia/method
@@ -1,6 +1,6 @@
 <%
     entry = @entries.sort.first
-    @title = "#{entry.type_label} #{entry.label}"
+    @title = "#{entry.type_label} #{entry.title_labels.join(', ')}"
     @description = entry.description
 %>
 <p>

--- a/data/bitclust/template.offline/method
+++ b/data/bitclust/template.offline/method
@@ -1,6 +1,6 @@
 <%
     entry = @entries.sort.first
-    @title = entry.label
+    @title = entry.title_labels.join(', ')
     @description = entry.description
     @edit_url = edit_url(entry.source_location) if @conf[:edit_base_url] && entry.source_location
 %>

--- a/data/bitclust/template/method
+++ b/data/bitclust/template/method
@@ -1,6 +1,6 @@
 <%
     entry = @entries.sort.first
-    @title = "#{entry.type_label} #{entry.label}"
+    @title = "#{entry.type_label} #{entry.title_labels.join(', ')}"
     @description = entry.description
 %>
 <p>

--- a/lib/bitclust/methodentry.rb
+++ b/lib/bitclust/methodentry.rb
@@ -138,6 +138,15 @@ module BitClust
       names().map {|name| "#{c}#{t}#{name}" }
     end
 
+    # Every name of this entry, formatted the same way as #label (i.e.
+    # without the redundant class prefix on special variables such as $!,
+    # unlike #labels). Used where all aliases of a method need to be listed
+    # together, e.g. the <title> of its page.
+    def title_labels
+      c, t, _m, _lib = methodid2specparts(@id)
+      names().map {|name| "#{t == '$' ? '' : c}#{t}#{name}" }
+    end
+
     def name?(name)
       names().include?(name)
     end

--- a/sig/bitclust/methodentry.rbs
+++ b/sig/bitclust/methodentry.rbs
@@ -58,6 +58,8 @@ module BitClust
 
     def labels: () -> Array[String]
 
+    def title_labels: () -> Array[String]
+
     def name?: (String name) -> bool
 
     def name_match?: (Regexp re) -> bool

--- a/test/test_method_screen.rb
+++ b/test/test_method_screen.rb
@@ -1,0 +1,90 @@
+require 'test/unit'
+require 'bitclust'
+require 'bitclust/screen'
+
+# Covers data/bitclust/template.offline, used by `bitclust statichtml` (the
+# production docs.ruby-lang.org build) and `bitclust chm`.
+#
+# NOTE: only one templatedir is exercised here on purpose. Screen#run_template
+# caches the compiled ERB template methods on the *class* (MethodScreen),
+# keyed only by method name (e.g. "method_template"), regardless of which
+# @template_repository the instance was built with. So constructing
+# MethodScreen from two different templatedirs (e.g. this one and
+# data/bitclust/template) within the same process is unreliable: whichever
+# templatedir's ERB gets compiled first "wins" for every MethodScreen built
+# afterwards, in every test file, for the rest of the run. This is a
+# pre-existing quirk of Screen, not something introduced here.
+#
+# data/bitclust/template, data/bitclust/template.lillia and
+# data/bitclust/template.epub were hand-verified (each in its own process,
+# not committed as an automated test here) to build @title the same way as
+# template.offline below, just keeping their pre-existing
+# "#{entry.type_label} #{entry.label}" prefix -- i.e. the fix is
+# entry.label -> entry.title_labels.join(', ') in all four `method`
+# templates, so the CHM (template) and EPUB (template.epub) screens get the
+# same alias listing.
+class TestMethodScreenTitle < Test::Unit::TestCase
+  SRC = <<'HERE'
+= class Enumerable2 < Object
+enumerable class
+== Instance Methods
+--- collect -> Array
+--- map -> Array
+
+説明のためのエントリ
+
+--- select -> Array
+
+説明2
+HERE
+
+  def setup
+    @lib, @db = BitClust::RRDParser.parse(SRC, 'testlib')
+    datadir = File.expand_path('../data/bitclust', __dir__)
+    @manager = BitClust::ScreenManager.new(
+      :templatedir => "#{datadir}/template.offline",
+      :catalogdir => "#{datadir}/catalog",
+      :encoding => 'utf-8',
+      :default_encoding => 'utf-8',
+      :base_url => '',
+      :target_version => '3.4'
+    )
+  end
+
+  def method_html(spec)
+    entry = @db.get_method(BitClust::MethodSpec.parse(spec))
+    @manager.method_screen([entry], :database => @db).body
+  end
+
+  def title_of(html)
+    html[/<title>(.*?) \(Ruby/, 1]
+  end
+
+  # template.offline's <title> has never included the "instance method"
+  # type_label prefix (only entry.label); the alias fix must keep that
+  # pre-existing convention and just expand the single name to every alias.
+  def test_title_lists_every_alias
+    assert_equal('Enumerable2#collect, Enumerable2#map',
+                 title_of(method_html('Enumerable2#collect')))
+  end
+
+  # Both aliases are the very same entry, so they share one page/title
+  # regardless of which alias URL was requested.
+  def test_title_is_the_same_regardless_of_which_alias_was_requested
+    assert_equal(method_html('Enumerable2#collect'), method_html('Enumerable2#map'))
+  end
+
+  # A method without any alias renders exactly as before: only its own name.
+  def test_title_is_unchanged_for_a_method_without_aliases
+    html = method_html('Enumerable2#select')
+    assert_equal('Enumerable2#select', title_of(html))
+  end
+
+  # Only the <title> tag changes; the on-page h1 headline keeps showing only
+  # the entry's own (alphabetically-first) name, as before.
+  def test_h1_headline_is_not_affected
+    html = method_html('Enumerable2#collect')
+    assert_match(%r{<h1>instance method Enumerable2\#collect</h1>}, html)
+    assert_not_match(/<h1>[^<]*Enumerable2#map/, html)
+  end
+end

--- a/test/test_methodentry.rb
+++ b/test/test_methodentry.rb
@@ -1,0 +1,67 @@
+require 'test/unit'
+require 'bitclust'
+
+class TestMethodEntryTitleLabels < Test::Unit::TestCase
+  def test_title_labels_matches_label_when_no_alias
+    lib, db = BitClust::RRDParser.parse(<<HERE, 'dummy')
+= class Enumerable2
+== Instance Methods
+--- select -> Array
+
+説明のためのエントリ
+HERE
+    _ = lib
+    m = db.get_method(BitClust::MethodSpec.parse('Enumerable2#select'))
+    assert_equal(['Enumerable2#select'], m.title_labels)
+    assert_equal(m.label, m.title_labels.join(', '))
+  end
+
+  def test_title_labels_lists_every_alias
+    lib, db = BitClust::RRDParser.parse(<<HERE, 'dummy')
+= class Enumerable2
+== Instance Methods
+--- collect -> Array
+--- map -> Array
+
+説明のためのエントリ
+HERE
+    _ = lib
+    m = db.get_method(BitClust::MethodSpec.parse('Enumerable2#collect'))
+    assert_equal(['Enumerable2#collect', 'Enumerable2#map'], m.title_labels)
+  end
+
+  # #label omits the class prefix for special variables (e.g. "$;", not
+  # "Kernel$;"); #title_labels must keep that convention for every alias,
+  # unlike #labels which always includes the prefix.
+  def test_title_labels_omits_class_prefix_for_special_variables
+    lib, db = BitClust::RRDParser.parse(<<HERE, 'dummy')
+= module Kernel
+description
+== Special Variables
+--- $;
+--- $FIELD_SEPARATOR
+
+区切り文字。
+HERE
+    _ = lib
+    m = db.get_method(BitClust::MethodSpec.parse('Kernel$;'))
+    assert_equal('$;', m.label)
+    assert_equal(['$;', '$FIELD_SEPARATOR'], m.title_labels)
+    assert_equal(['Kernel$;', 'Kernel$FIELD_SEPARATOR'], m.labels)
+  end
+
+  def test_title_labels_matches_label_for_single_special_variable
+    lib, db = BitClust::RRDParser.parse(<<HERE, 'dummy')
+= module Kernel
+description
+== Special Variables
+--- $stdout -> IO
+
+標準出力。
+HERE
+    _ = lib
+    m = db.get_method(BitClust::MethodSpec.parse('Kernel$stdout'))
+    assert_equal(['$stdout'], m.title_labels)
+    assert_equal(m.label, m.title_labels.join(', '))
+  end
+end


### PR DESCRIPTION
rurema/doctree#2748 への対応です。メソッドページの HTML `<title>` に別名(エイリアス)もすべて含め、検索結果などで「collect のページに map も載っている」ことが分かるようにします。

fix rurema/doctree#2748

## 内容

- `<title>` を全名の列挙にします。例: `Enumerable#collect, Enumerable#map (Ruby 3.4 リファレンスマニュアル)`。エイリアスの無いメソッドでは従来とバイト同一
- ページ内の `<h1>` 見出しは従来どおり変更しません(主要名のみ)
- 4 テンプレート系統(template / template.offline / template.lillia / template.epub)すべてに適用
- 実装は `MethodEntry#title_labels` を新設。既存の `#labels` は特殊変数で `#label` と異なる形式(`Kernel$;` のようにクラス接頭辞が付く)を返すため、そのまま流用すると**エイリアスの無い特殊変数ページの title が変わってしまう**ことが分かり、`#label` の表記規則(特殊変数は `$name`)に合わせた別メソッドにしました(`#labels` は refsdatabase 等でも使われており出力形式の変更はリスクがあるため不変更)

## テスト

エイリアス有り/無しの title を検証するテストを追加(template.offline)。他 3 テンプレートは別プロセスで手動検証済み(同一プロセス内で複数 templatedir を検証できない Screen のテンプレートキャッシュの制約があるため。この制約自体は既存挙動で本 PR のスコープ外)。全テスト green・`rake sig` 反映済み・`steep check` エラー 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
