### PR TITLE
検索インデックスに doc ページのアンカー付き見出しを追加

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,7 @@ namespace :test do
   task :js do
     sh 'qjs', 'test/js/test_run.mjs'
     sh 'qjs', 'test/js/test_script.mjs'
+    sh 'qjs', 'test/js/test_search.mjs'
   end
 end
 

--- a/lib/bitclust/search_index_generator.rb
+++ b/lib/bitclust/search_index_generator.rb
@@ -37,6 +37,20 @@ module BitClust
       special_variable: 'variable',
     }.freeze
 
+    # Doc pages (manual/doc/**/*.md) are prose, so language keywords such as
+    # "defined?", "undef" or "alias" (see rurema/doctree#2352) are never
+    # indexed as a class/method/library. They do, however, live at their own
+    # {#id}-anchored heading within a doc page (e.g. spec/def.md's "defined?"
+    # section). Rather than hardcoding a keyword list, scan every doc page for
+    # ATX headings carrying an explicit {#id} anchor -- the same anchors
+    # [ref:d:...] cross references already rely on -- and index each one
+    # individually so a keyword search can jump straight to its section.
+    # Headings without an explicit anchor aren't linkable, so they are
+    # skipped; a "# comment" that happens to open a line inside a fenced code
+    # block is not a heading at all, so fenced regions are skipped wholesale.
+    ANCHORED_HEADING_RE = /\A(\#{1,6})[ \t]+(.*?)(?:[ \t]+\{#([\w-]+)\})?[ \t]*\z/.freeze
+    FENCE_START_RE = /\A`{3,}/.freeze
+
     def initialize(suffix: '.html', fs_casesensitive: false)
       @suffix = suffix
       @fs_casesensitive = fs_casesensitive
@@ -50,6 +64,7 @@ module BitClust
       index.concat(method_entries(db))
       index.concat(library_entries(db))
       index.concat(document_entries(db))
+      index.concat(document_heading_entries(db))
       index.concat(function_entries(fdb)) if fdb
       index
     end
@@ -154,6 +169,66 @@ module BitClust
           path:      "doc/#{encode(slug)}#{@suffix}",
         }
       end
+    end
+
+    # One entry per {#id}-anchored heading found in a doc page's body, so
+    # that e.g. "defined?" or "alias" (headings inside spec/def.md) surface
+    # directly instead of only the whole "クラス／メソッドの定義" page. See
+    # ANCHORED_HEADING_RE above for why this only looks at doc pages (prose,
+    # not method/class references) and only at explicitly anchored headings.
+    def document_heading_entries(db)
+      seen = {} #: Hash[String, bool]
+      result = [] #: Array[entry]
+      db.docs.each do |doc|
+        source = doc.source
+        next unless source
+        page_title = (doc.title && !doc.title.empty?) ? doc.title : doc.name
+        base_path = "doc/#{encode(doc.name)}#{@suffix}"
+        each_anchored_heading(source) do |label, id|
+          path = "#{base_path}##{id}"
+          next if seen[path]
+
+          seen[path] = true
+          result << {
+            name:      label,
+            full_name: "#{label} (#{page_title})",
+            type:      'heading',
+            path:      path,
+          }
+        end
+      end
+      result
+    end
+
+    # Yields [label, id] for each ATX heading in +source+ that carries an
+    # explicit {#id} anchor, skipping the contents of fenced code blocks
+    # (```lang ... ```) so an in-sample "# comment" line can never be
+    # mistaken for a heading.
+    def each_anchored_heading(source)
+      fence = nil #: Integer?
+      source.each_line do |raw|
+        line = raw.chomp
+        if fence
+          # Matches MDCompiler#code_fence's own terminator: the closing fence
+          # must be exactly as long as the opening one.
+          fence = nil if /\A`{#{fence}}[ \t]*\z/ =~ line
+          next
+        end
+        if m = FENCE_START_RE.match(line)
+          fence = (m[0] || raise).size
+          next
+        end
+        next unless m = ANCHORED_HEADING_RE.match(line)
+
+        id = m[3] or next
+        yield clean_heading_label(m[2] || raise), id
+      end
+    end
+
+    # Headings may carry inline Markdown (code spans, escaped punctuation);
+    # strip that down to plain text for the index entry.
+    def clean_heading_label(label)
+      label.gsub(/`([^`]*)`/, '\1').gsub(/\\(.)/, '\1')
     end
 
     def function_entries(fdb)

--- a/sig/bitclust/search_index_generator.rbs
+++ b/sig/bitclust/search_index_generator.rbs
@@ -9,6 +9,10 @@ module BitClust
 
     TYPENAME_TO_SEARCH_TYPE: Hash[Symbol, String]
 
+    ANCHORED_HEADING_RE: Regexp
+
+    FENCE_START_RE: Regexp
+
     type entry = Hash[Symbol, String]
 
     def initialize: (?suffix: String, ?fs_casesensitive: bool) -> void
@@ -32,6 +36,12 @@ module BitClust
     def library_entries: (MethodDatabase db) -> Array[entry]
 
     def document_entries: (MethodDatabase db) -> Array[entry]
+
+    def document_heading_entries: (MethodDatabase db) -> Array[entry]
+
+    def each_anchored_heading: (String source) { (String, String) -> void } -> void
+
+    def clean_heading_label: (String label) -> String
 
     def function_entries: (FunctionDatabase fdb) -> Array[entry]
 

--- a/test/js/test_search.mjs
+++ b/test/js/test_search.mjs
@@ -1,0 +1,148 @@
+// QuickJS-based tests for theme/default/js/search_*.js.
+// Run with: qjs test/js/test_search.mjs   (see the "test:js" rake task)
+//
+// search_ranker.js / search_navigation.js / search_controller.js are
+// vendored verbatim from RDoc's Aliki theme and are classic (non-module,
+// non-strict) scripts: evaluating them with indirect eval() attaches their
+// top-level `var`/function declarations to globalThis, exactly as a
+// `<script src="...">` tag would in a browser. search_init.js is BitClust's
+// own wiring on top of them (also a classic script); it is exercised through
+// a minimal fake DOM rather than by calling its internals directly, since
+// everything in it lives inside an IIFE.
+import * as std from 'std'
+
+let failures = 0
+function assert(cond, message) {
+  if (cond) {
+    print('ok: ' + message)
+  } else {
+    failures++
+    print('FAIL: ' + message)
+  }
+}
+
+const here = import.meta.url.replace(/^file:\/\//, '').replace(/\/[^/]*$/, '')
+const jsdir = here + '/../../theme/default/js/'
+
+// --- minimal fake DOM ---------------------------------------------------
+// Just enough for SearchController/SearchNavigation/search_init.js to run:
+// element creation, event listener registration + manual dispatch,
+// attributes, classList and a parentNode link for `this.view`.
+function makeElement(tag) {
+  const listeners = {}
+  return {
+    tagName: (tag || 'div').toUpperCase(),
+    children: [],
+    parentNode: null,
+    value: '',
+    _attrs: {},
+    _html: '',
+    classList: {
+      _set: new Set(),
+      add(c) { this._set.add(c) },
+      remove(c) { this._set.delete(c) },
+      contains(c) { return this._set.has(c) },
+    },
+    addEventListener(type, cb) { (listeners[type] ||= []).push(cb) },
+    dispatch(type, e) { (listeners[type] || []).forEach(cb => cb(e || {})) },
+    setAttribute(name, v) { this._attrs[name] = String(v) },
+    getAttribute(name) { return this._attrs[name] },
+    appendChild(child) {
+      child.parentNode = this
+      this.children.push(child)
+      return child
+    },
+    get childElementCount() { return this.children.length },
+    get firstChild() { return this.children.length > 0 ? this.children[0] : null },
+    set innerHTML(v) { this._html = v; this.children = [] },
+    get innerHTML() { return this._html },
+  }
+}
+
+function makeDocument(elementsById) {
+  const listeners = {}
+  return {
+    addEventListener(type, cb) { (listeners[type] ||= []).push(cb) },
+    dispatch(type, e) { (listeners[type] || []).forEach(cb => cb(e || {})) },
+    createElement(tag) { return makeElement(tag) },
+    querySelector(sel) { return elementsById[sel.replace(/^#/, '')] || null },
+  }
+}
+
+// --- wire up search_init.js against the fake DOM ------------------------
+// Mirrors production script order (statichtml_command.rb's SEARCH_JS_FILES).
+// search_ranker.js/search_navigation.js/search_controller.js don't touch
+// `document` at eval time, so they can load immediately; search_init.js
+// registers its DOMContentLoaded listener as soon as it is eval'd, so a fake
+// `document` must already exist before it loads.
+function loadRankerScripts() {
+  ['search_navigation.js', 'search_ranker.js', 'search_controller.js']
+    .forEach(f => (0, eval)(std.loadFile(jsdir + f)))
+}
+
+function setupSearchBox(index) {
+  const input = makeElement('input')
+  const result = makeElement('ul')
+  result.parentNode = makeElement('div') // SearchController reads result.parentNode as `view`
+  globalThis.document = makeDocument({ 'search-field': input, 'search-results': result })
+  globalThis.search_data = { index }
+  globalThis.index_rel_prefix = '../'
+  ;(0, eval)(std.loadFile(jsdir + 'search_init.js'))
+  document.dispatch('DOMContentLoaded')
+  return { input, result }
+}
+
+loadRankerScripts()
+
+// A synthetic index: one "heading" entry (the new type this change adds --
+// see rurema/doctree#2352, "defined?/undef/alias don't show up in search")
+// alongside a couple of ordinary entries, to check the new type doesn't
+// disturb ranking of the existing ones.
+const index = [
+  { name: 'defined?', full_name: 'defined? (クラス／メソッドの定義)', type: 'heading',
+    path: 'doc/spec=2fdef.html#defined' },
+  { name: 'undef', full_name: 'undef (クラス／メソッドの定義)', type: 'heading',
+    path: 'doc/spec=2fdef.html#undef' },
+  { name: 'each', full_name: 'Array#each', type: 'instance_method', path: 'method/x' },
+  { name: 'Array', full_name: 'Array', type: 'class', path: 'class/-array.html' },
+]
+
+// search_ranker.js's search(): a keyword query exactly matching a heading
+// entry's name should return that entry (core ranking logic is untouched
+// vendored code -- this checks the new entry shape doesn't fall through it).
+{
+  const results = search('defined?', index)
+  assert(results.length > 0 && results[0].name === 'defined?',
+         'search("defined?") ranks the heading entry for spec/def.md first')
+}
+{
+  const results = search('undef', index)
+  assert(results.length > 0 && results[0].name === 'undef',
+         'search("undef") ranks the heading entry for spec/def.md first')
+}
+// An unrelated query still finds the ordinary instance_method entry (the
+// new type must not shadow existing results).
+{
+  const results = search('each', index)
+  assert(results.length > 0 && results[0].name === 'each' && results[0].type === 'instance_method',
+         'search("each") still finds the ordinary method entry')
+}
+
+// End-to-end through search_init.js's DOM wiring: typing "defined?" and
+// dispatching keyup renders a result item carrying the new search-type-
+// heading badge, labeled via the formatType map added in this change.
+{
+  const { input, result } = setupSearchBox(index)
+  input.value = 'defined?'
+  input.dispatch('keyup', { key: 'd' })
+  assert(result.children.length > 0, 'typing a keyword renders at least one result')
+  const html = result.children[0].innerHTML
+  assert(html.includes('search-type-heading'), 'the result item carries the search-type-heading class')
+  assert(html.includes('>section<'), 'the heading badge is labeled "section" via the formatType map')
+  assert(html.includes('doc/spec=2fdef.html#defined'), 'the result links straight to the anchored heading')
+}
+
+if (failures > 0) {
+  throw new Error(failures + ' JS test(s) failed')
+}
+print('all JS tests passed')

--- a/test/test_search_index_generator.rb
+++ b/test/test_search_index_generator.rb
@@ -2,6 +2,7 @@
 require 'test/unit'
 require 'json'
 require 'fileutils'
+require 'tmpdir'
 require 'bitclust'
 require 'bitclust/methoddatabase'
 require 'bitclust/search_index_generator'
@@ -125,6 +126,116 @@ class TestSearchIndexGenerator < Test::Unit::TestCase
     assert_not_nil e
     assert_equal 'Ruby用語集 (glossary)', e[:full_name]
     assert_equal 'Ruby用語集 (glossary)', e[:name]
+  end
+
+  # {#id}-anchored doc headings (rurema/doctree#2352: keywords like
+  # defined?/undef/alias aren't methods, so they never show up in the
+  # class/method-derived index -- they only show up via their doc page
+  # heading). These need a native md doc tree (copy_doc_md), which is a
+  # different ingestion path than the RD @root fixture set up in #setup, so
+  # they build their own tiny db per case (mirrors test_copy_doc_md.rb).
+
+  def build_md_doc_index(files)
+    Dir.mktmpdir do |dir|
+      files.each do |relpath, content|
+        path = File.join(dir, 'manual', 'doc', relpath)
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, content)
+      end
+      FileUtils.mkdir_p(File.join(dir, 'manual', 'api'))
+
+      prefix = File.join(dir, 'db')
+      db = BitClust::MethodDatabase.new(prefix)
+      db.init
+      db.transaction do
+        db.propset('version', '3.4')
+        db.propset('encoding', 'utf-8')
+      end
+      db.transaction do
+        db.instance_variable_set(:@md_root, File.join(dir, 'manual', 'api'))
+        db.__send__(:copy_doc_md)
+      end
+      # Reopen (like test_copy_doc_md.rb) rather than reuse the writer db,
+      # so the index is built from what was actually persisted.
+      db2 = BitClust::MethodDatabase.new(prefix)
+      BitClust::SearchIndexGenerator.new.build_index(db2)
+    end
+  end
+
+  def test_document_heading_entry_for_anchored_heading
+    index = build_md_doc_index(
+      'spec/def.md' => <<~MD
+        # クラス／メソッドの定義
+
+        本文。
+
+        #### alias {#alias}
+
+        alias の説明。
+
+        #### undef {#undef}
+
+        undef の説明。
+      MD
+    )
+    e = index.find { |x| x[:type] == 'heading' && x[:name] == 'alias' }
+    assert_not_nil e
+    assert_equal 'alias (クラス／メソッドの定義)', e[:full_name]
+    assert_equal 'doc/spec=2fdef.html#alias', e[:path]
+
+    e2 = index.find { |x| x[:type] == 'heading' && x[:name] == 'undef' }
+    assert_not_nil e2
+    assert_equal 'doc/spec=2fdef.html#undef', e2[:path]
+  end
+
+  def test_heading_without_anchor_is_not_indexed
+    index = build_md_doc_index(
+      'spec/def.md' => <<~MD
+        # クラス／メソッドの定義
+
+        #### 見出し
+
+        本文。
+      MD
+    )
+    assert_nil index.find { |x| x[:type] == 'heading' }
+  end
+
+  def test_heading_inside_fenced_code_is_not_mistaken_for_a_heading
+    # A "# ..." line at column 0 inside a ```ruby sample must not be
+    # misdetected as an h1 just because it starts with "#".
+    index = build_md_doc_index(
+      'spec/control.md' => <<~MD
+        # 制御構造
+
+        #### if {#if}
+
+        ```ruby
+        # this is not a heading
+        if true
+          1
+        end
+        ```
+      MD
+    )
+    headings = index.select { |x| x[:type] == 'heading' }
+    assert_equal 1, headings.size
+    assert_equal 'if', headings[0][:name]
+  end
+
+  def test_heading_label_strips_inline_code_span_backticks
+    index = build_md_doc_index(
+      'spec/comment.md' => <<~MD
+        # コメント
+
+        ### 文字列リテラルの凍結(`frozen_string_literal`) {#frozen_string_literal}
+
+        本文。
+      MD
+    )
+    e = index.find { |x| x[:type] == 'heading' }
+    assert_not_nil e
+    assert_equal '文字列リテラルの凍結(frozen_string_literal)', e[:name]
   end
 
   def test_to_js_format

--- a/theme/default/js/search_init.js
+++ b/theme/default/js/search_init.js
@@ -59,7 +59,8 @@
       var labels = {
         'class': 'class', 'module': 'module', 'object': 'object',
         'constant': 'const', 'instance_method': 'method', 'class_method': 'method',
-        'variable': 'var', 'library': 'lib', 'document': 'doc', 'function': 'func'
+        'variable': 'var', 'library': 'lib', 'document': 'doc', 'function': 'func',
+        'heading': 'section'
       };
       return labels[type] || type;
     };

--- a/theme/default/js/search_page.js
+++ b/theme/default/js/search_page.js
@@ -124,7 +124,8 @@
       var labels = {
         'class': 'class', 'module': 'module', 'object': 'object',
         'constant': 'const', 'instance_method': 'method', 'class_method': 'method',
-        'variable': 'var', 'library': 'lib', 'document': 'doc', 'function': 'func'
+        'variable': 'var', 'library': 'lib', 'document': 'doc', 'function': 'func',
+        'heading': 'section'
       };
       return labels[type] || type;
     };


### PR DESCRIPTION
rurema/doctree#2352 のコメントでご要望のあった「`defined?` `undef` `alias` などメソッドでないものを右上の検索で出せるように」の実装です。

## 設計

キーワードのハードコードではなく、**doc ページ内の `{#id}` アンカー付き見出しを汎用的にインデックスへ追加**する方式にしました(`[ref:d:...]` 参照が使っているのと同じアンカー)。新しい種別 `heading`(表示バッジは `section`)として、見出しラベル+「(ページタイトル)」+アンカー付き URL をエントリ化します。

- 実データ(3.4 の manual/)で **202 エントリ**が追加され、`defined?`・`undef`・`alias` はそれぞれ spec/def の該当節に直接ジャンプできます(`if`・`BEGIN`・`END`・`return`・`super`・`yield` なども同様)。glossary や記号一覧の各項目アンカーも自動的に対象になります
- fenced code block 内の行頭 `#` コメントを見出しと誤認しないよう、MDCompiler の終端規則(開始と同じ長さ)に合わせた fence スキップを実装
- アンカーの無い見出しはリンク不能なので対象外です(例: 制御構造の rescue/ensure。doctree 側で `{#id}` を付ければ自動で検索に載るようになるため、フォローアップ候補)

## 検証

- テスト 17672 全 green(生成側4件追加)・`rake sig` 反映・`steep check` エラー 0
- **検索 JS のテストを新設**: `test/js/test_search.mjs`(qjs)で実 JS を読み込み、キーワード入力→結果描画→`section` バッジとアンカーリンクの出力まで end-to-end で検証(既存の `rake test:js` に追加)
- scratch DB で実生成し、`defined?` → `doc/spec=2fdef.html#defined` 等のエントリと、実 HTML(`<h3 id='defined'>`)の対応を突き合わせ済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
