### PR TITLE
[ref:] のフラグメントにハイフンを許容する

### DIFF
--- a/lib/bitclust/markdown_to_rrd.rb
+++ b/lib/bitclust/markdown_to_rrd.rb
@@ -47,7 +47,7 @@ module BitClust
             .gsub(/^\*\*(\d+\.)\*\* /, '\1 ')
             .gsub(/^\\#/, '#')
             .gsub(/\\`/, '`')
-      ).gsub(/\x00(\w+)\x00/) { "[a:#{$1}]" }
+      ).gsub(/\x00([-\w]+)\x00/) { "[a:#{$1}]" }
        .gsub(/\x01(\d+)\x01/) { saved[$1.to_i] }
     end
 
@@ -99,7 +99,7 @@ module BitClust
     # 全文変換（convert）の対応箇所と同じ規則の表示専用ミラー
     def self.restore_display_line(l)
       case l
-      when /\A(\#{1,6}) (.*?) \{#(\w+)\}([ \t]*\n?)\z/m
+      when /\A(\#{1,6}) (.*?) \{#([-\w]+)\}([ \t]*\n?)\z/m
         # アンカーは restore_inline の裸参照復元（[a:x]→[[a:x]]）を
         # 避けるため \x00 で包み、最後に [a:x] へ戻す
         "#{'=' * ($1 || raise).length}\x00#{$3}\x00 #{$2}#{$4}"

--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -537,7 +537,7 @@ module BitClust
 
     def reference_link(arg)
       case arg
-      when /(\w+):(.*)\#(\w+)\z/
+      when /(\w+):(.*)\#([-\w]+)\z/
         # @type var type: String
         # @type var name: String
         # @type var frag: String
@@ -560,7 +560,7 @@ module BitClust
         label = @option[:database].refs[t, id, frag]
         label = title + '/' + label if label and name
         bracket_link("#{type}:#{name}", label, frag)
-      when /\A(\w+)\z/
+      when /\A([-\w]+)\z/
         e = @option[:entry]
         frag = $1 || raise
         type = e.type_id.to_s

--- a/lib/bitclust/refsdatabase.rb
+++ b/lib/bitclust/refsdatabase.rb
@@ -67,9 +67,9 @@ module BitClust
     def extract(entry)
       entry.source.each_line{|l|
         anchor, label =
-          if /\A={1,6}\[a:(\w+)\] *(.*)/ =~ l
+          if /\A={1,6}\[a:([-\w]+)\] *(.*)/ =~ l
             [$1, $2]
-          elsif /\A\#{1,6} +(.*?) *\{#(\w+)\}\s*\z/ =~ l
+          elsif /\A\#{1,6} +(.*?) *\{#([-\w]+)\}\s*\z/ =~ l
             # md ソース: 「### 見出し {#anchor}」形式（M3 ネイティブパース）。
             # ラベルは rd 表示形へ戻す（\` エスケープ解除等。pattern_matching）
             Kernel.require 'bitclust/markdown_to_rrd'

--- a/test/test_markdown_to_rrd.rb
+++ b/test/test_markdown_to_rrd.rb
@@ -281,6 +281,12 @@ class TestMarkdownToRRD < Test::Unit::TestCase
       convert("### 破壊的な変更 {#mutable}\n")
   end
 
+  def test_h3_with_hyphenated_anchor
+    # doctree/manual の glossary.md 等、用語アンカーはハイフン区切り
+    assert_equal "===[a:thread-safe] スレッドセーフ\n",
+      convert("### スレッドセーフ {#thread-safe}\n")
+  end
+
   def test_h4_heading
     assert_equal "==== 小見出し\n",
       convert("#### 小見出し\n")
@@ -682,6 +688,10 @@ class TestMarkdownToRRD < Test::Unit::TestCase
       BitClust::MarkdownToRRD.restore_description("### 記号の説明")
     assert_equal "===[a:str] 特別な文字列に対するマッチ",
       BitClust::MarkdownToRRD.restore_description("### 特別な文字列に対するマッチ {#str}")
+    # ハイフン入りアンカー（doctree/manual の glossary.md 用語アンカー等）も
+    # プレースホルダ往復（\x00...\x00 → [a:...]）を経て正しく復元される
+    assert_equal "===[a:thread-safe] スレッドセーフ",
+      BitClust::MarkdownToRRD.restore_description("### スレッドセーフ {#thread-safe}")
   end
 
   def test_restore_description_metadata

--- a/test/test_mdcompiler.rb
+++ b/test/test_mdcompiler.rb
@@ -95,6 +95,16 @@ class TestMDCompiler < Test::Unit::TestCase
     RD
   end
 
+  def test_inline_ref_with_hyphenated_fragment
+    # [ref:d:page#frag] のフラグメントはハイフンを含められる
+    # （doctree/manual の glossary.md 用語アンカー等、rd 直接/md 変換後で等価）
+    assert_equivalent_method <<~RD
+      --- index(val) -> Integer
+
+      [[ref:d:hoge/bar#thread-safe]] を参照。
+    RD
+  end
+
   def test_code_block_from_emlist
     assert_equivalent_method <<~RD
       --- index(val) -> Integer
@@ -177,6 +187,20 @@ class TestMDCompiler < Test::Unit::TestCase
       説明。
 
       ===[a:anchor] 深掘り
+
+      本文。
+    RD
+  end
+
+  def test_entry_heading_with_hyphenated_anchor
+    # ハイフン入りアンカー（doctree/manual の glossary.md 用語アンカー等）でも
+    # rd 直接コンパイルと md 変換後コンパイルが等価であること
+    assert_equivalent_method <<~RD
+      --- index(val) -> Integer
+
+      説明。
+
+      ===[a:thread-safe] スレッドセーフ
 
       本文。
     RD

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -726,16 +726,30 @@ HERE
     assert_equal(expected, compiler.send(:compile_text, target), target)
   end
 
-  data("doc"             => ['[[d:hoge/bar]]',            '<a href="dummy/hoge/bar">.*</a>'],
-       "ref doc"         => ['[[ref:d:hoge/bar#frag]]',   '<a href="dummy/hoge/bar#frag">.*</a>'],
-       "ref class"       => ['[[ref:c:Hoge#frag]]',       '<a href="dummy/class/Hoge#frag">.*</a>'],
-       "ref special var" => ['[[ref:m:$~#frag]]',         '<a href="dummy/method/Kernel/v/=7e#frag">.*</a>'],
-       "ref library"     => ['[[ref:lib:jcode#frag]]',    '<a href="dummy/library/jcode#frag">.*</a>'],
-       "ref class error" => ['[[ref:c:Hoge]]',            'compileerror'],
-       "ref ref"         => ['[[ref:ref:hoge/bar#frag]]', 'compileerror'],)
+  data("doc"                    => ['[[d:hoge/bar]]',                 '<a href="dummy/hoge/bar">.*</a>'],
+       "ref doc"                => ['[[ref:d:hoge/bar#frag]]',        '<a href="dummy/hoge/bar#frag">.*</a>'],
+       "ref doc hyphen frag"    => ['[[ref:d:hoge/bar#thread-safe]]', '<a href="dummy/hoge/bar#thread-safe">.*</a>'],
+       "ref class"              => ['[[ref:c:Hoge#frag]]',            '<a href="dummy/class/Hoge#frag">.*</a>'],
+       "ref special var"        => ['[[ref:m:$~#frag]]',              '<a href="dummy/method/Kernel/v/=7e#frag">.*</a>'],
+       "ref library"            => ['[[ref:lib:jcode#frag]]',         '<a href="dummy/library/jcode#frag">.*</a>'],
+       "ref class error"        => ['[[ref:c:Hoge]]',                 'compileerror'],
+       "ref ref"                => ['[[ref:ref:hoge/bar#frag]]',      'compileerror'],)
   def test_bracket_link_doc(data)
     target, expected = data
     assert_match(/#{expected}/, @c.send(:compile_text, target), target)
+  end
+
+  def test_reference_link_same_page_hyphen_fragment
+    # [ref:frag]（type:name 無し）は同一ページ内アンカーへのリンク。
+    # ハイフン入りフラグメント（doctree/manual の {#id} アンカーに合わせる）
+    entry = BitClust::DocEntry.new(@db, 'glossary')
+    entry.source = "### スレッドセーフ {#thread-safe}\n\n本文。\n"
+    refs = BitClust::RefsDatabase.new
+    refs.extract(entry)
+    stub(@db).refs { refs }
+    compiler = BitClust::RDCompiler.new(@u, 1, {:database => @db, :entry => entry})
+    assert_equal('<a href="#thread-safe">スレッドセーフ</a>',
+                 compiler.send(:reference_link, 'thread-safe'))
   end
 
   def test_nomethod_is_not_rendered

--- a/test/test_refsdatabase.rb
+++ b/test/test_refsdatabase.rb
@@ -81,4 +81,36 @@ HERE
       assert_equal(s.upcase, db.refs['class',  'ARGF', s])
     end
   end
+
+  # rd 形式の [a:xxx] アンカーもハイフンを含められる（doctree/bitclust#(このPR)）
+  S3 = <<HERE
+===[a:with-hyphen] With Hyphen
+HERE
+
+  def test_make_refs_rd_anchor_with_hyphen
+    _, db = BitClust::RRDParser.parse(S3, 'dummy')
+    db.make_refs
+    assert_equal('With Hyphen', db.refs['library', 'dummy', 'with-hyphen'])
+  end
+
+  # md ソースの見出しアンカー {#xxx} 収集はハイフンを許容する
+  # （doctree/manual の glossary.md 等、用語アンカーはハイフン区切り）
+  def test_extract_markdown_heading_anchor_with_hyphen
+    db = BitClust::MethodDatabase.dummy("version" => "3.4.0")
+    entry = BitClust::DocEntry.new(db, 'glossary')
+    entry.source = "### スレッドセーフ {#thread-safe}\n\n本文。\n"
+    refs = BitClust::RefsDatabase.new
+    refs.extract(entry)
+    assert_equal('スレッドセーフ', refs['doc', 'glossary', 'thread-safe'])
+  end
+
+  # 従来のアンダースコア・単語アンカーの回帰が無いことも確認する
+  def test_extract_markdown_heading_anchor_with_underscore
+    db = BitClust::MethodDatabase.dummy("version" => "3.4.0")
+    entry = BitClust::DocEntry.new(db, 'glossary')
+    entry.source = "### 見出し {#my_anchor}\n\n本文。\n"
+    refs = BitClust::RefsDatabase.new
+    refs.extract(entry)
+    assert_equal('見出し', refs['doc', 'glossary', 'my_anchor'])
+  end
 end


### PR DESCRIPTION
`[ref:]` 記法のフラグメントにハイフンを許容します。

## 背景

doctree の manual/ には `{#id}` アンカーにハイフンを含むものが 102 件あります(glossary の用語アンカーなど)が、`[ref:d:page#frag]` のフラグメントは `\w+` 限定で、これらへ ref リンクを張ると compile error になります(rurema/doctree#3216 ではやむを得ず glossary のアンカー3つを `_` に改名しました)。mdcompiler の dlist アンカー収集は既に `[\w-]+` を許容しており、不整合の解消です。

## 変更(6箇所・lib の diff 6行)

- rdcompiler の `type:name#frag` パターンと同一ページ内 `[ref:frag]` パターン
- refsdatabase の見出しアンカー収集(Markdown `{#id}` と RD `[a:id]` の両方。RD 側は表示側が無制限なのに収集側だけ `\w+` 限定という既存の非対称でした)
- markdown_to_rrd のアンカー復元(2箇所ペア。片側だけ直すとハイフン入り id がプレースホルダのまま残る実害があるため両方)

フラグメントの許容は `[-\w]+` までで、`.` や `:` は従来どおり不可です。

## 検証

- テスト追加(rdcompiler・refsdatabase・markdown_to_rrd・mdcompiler の4ファイル、ハイフン+アンダースコア回帰)。全 17676 tests green・`steep check` エラー 0
- 実データ: scratch DB(3.4)で `[ref:d:glossary#thread-safe]` が修正前は compile error、修正後は正しいアンカー付きリンクに解決されることを両コンパイラ経路で確認

## 補足(既存挙動・本 PR の範囲外)

glossary の用語アンカーは dlist 形式(`- **用語**: {#id}`)のため refs DB に label が登録されず、ref リンクのラベルはページタイトルにフォールバックします(リンク先は正しく解決)。dlist アンカーの label 収集は必要になれば別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
