### PR TITLE
text-autospace で和欧文間を空ける

### DIFF
--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -19,6 +19,9 @@ body {
     margin-left: 2%;
     margin-right: 2%;
     line-height: 1.3;
+    /* 和文と欧文の間に自動で空きを入れる。プログレッシブエンハンスメント
+       (未対応ブラウザでは無視される) */
+    text-autospace: normal;
 }
 
 /*
@@ -124,6 +127,8 @@ span.compileerror {
 code, pre, tt {
     font-size: 90%;
     font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+    /* コード内では和欧文間の自動スペースを入れない */
+    text-autospace: no-autospace;
 }
 
 /* 地の文中のインラインコード(<code>, <tt>)に淡い背景を敷いて、地の文との

--- a/theme/lillia/style.css
+++ b/theme/lillia/style.css
@@ -11,6 +11,9 @@ body {
     margin-left: 2%;
     margin-right: 2%;
     line-height: 1.3;
+    /* 和文と欧文の間に自動で空きを入れる。プログレッシブエンハンスメント
+       (未対応ブラウザでは無視される) */
+    text-autospace: normal;
 }
 
 address {
@@ -175,6 +178,11 @@ td.library {
 
 code, tt {
     font-family: monospace;
+}
+
+/* コード内では和欧文間の自動スペースを入れない */
+code, pre, tt {
+    text-autospace: no-autospace;
 }
 
 /* 地の文中のインラインコード(<code>, <tt>)に淡い背景を敷いて、地の文との


### PR DESCRIPTION
#264 への対応です。和文と欧文の間を `text-autospace: normal` で空けます。

- default・lillia 両テーマの `body` に `text-autospace: normal;` を、コード系要素(`code, pre, tt`)に `text-autospace: no-autospace;` を明示追加
- CSS の未知プロパティは無視されるため、未対応ブラウザでは従来表示のまま(プログレッシブエンハンスメント)
- `<html lang="ja-JP">` は全テンプレートで設定済みであることを確認(変更不要)

なお `<span>` 等で DOM が分かれる箇所には効かないため、表記規約(半角文字の前後の空白)の完全な代替ではなく補助という位置づけです。テスト全 green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
