### PR TITLE
フッターの CC BY ロゴの体裁を修正

### DIFF
--- a/data/bitclust/template.epub/layout
+++ b/data/bitclust/template.epub/layout
@@ -11,9 +11,7 @@
 <body>
 <%= yield %>
 <div id="footer">
-  <a rel="license" href="https://creativecommons.org/licenses/by/3.0/">
-    <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" />
-  </a>
+  <a rel="license" href="https://creativecommons.org/licenses/by/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" /></a>
 </div>
 </body>
 </html>

--- a/data/bitclust/template.lillia/layout
+++ b/data/bitclust/template.lillia/layout
@@ -14,9 +14,7 @@
 <body>
 <%= yield %>
 <div id="footer">
-  <a rel="license" href="https://creativecommons.org/licenses/by/3.0/">
-    <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" />
-  </a>
+  <a rel="license" href="https://creativecommons.org/licenses/by/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" /></a>
 </div>
 </body>
 </html>

--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -44,9 +44,7 @@
 </div>
 <%= yield %>
 <footer id="footer">
-  <a rel="license" href="https://creativecommons.org/licenses/by/3.0/">
-    <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" />
-  </a>
+  <a rel="license" href="https://creativecommons.org/licenses/by/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" /></a>
 
   <a href="https://github.com/rurema/doctree/issues/new" id="feedback-link">フィードバックを送る</a>
   <% if defined?(@edit_url) && @edit_url %>

--- a/data/bitclust/template/layout
+++ b/data/bitclust/template/layout
@@ -25,9 +25,7 @@
 <% end %>
 <%= yield %>
 <div id="footer">
-  <a rel="license" href="https://creativecommons.org/licenses/by/3.0/">
-    <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" />
-  </a>
+  <a rel="license" href="https://creativecommons.org/licenses/by/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" /></a>
 </div>
 </body>
 </html>

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -550,3 +550,17 @@ hr {
         overflow-wrap: break-word;
     }
 }
+
+/* CC BY ロゴ画像はデフォルトの vertical-align: baseline だと下に文字の
+   ディセンダ分の隙間ができ、横のリンクより浮いて見える上、リンクの
+   ホバー背景がその隙間ぶん右・下にはみ出して見える。画像を a 要素の
+   下端に揃えて解消する */
+#footer img {
+    vertical-align: bottom;
+}
+
+/* CC BY ロゴと無関係な「フィードバックを送る」リンクが近すぎるので、
+   ひと呼吸あける */
+#feedback-link {
+    margin-left: 0.5em;
+}


### PR DESCRIPTION
#265 への対応です。フッターの CC BY ロゴの体裁を修正します。

- `<img ... />` と `</a>` の間にあった改行+インデント(空白テキストノード)を除去 — ホバー時の背景がロゴの下・右にはみ出す原因でした(同じフッターを持つ 4 テンプレート全てに適用)
- CSS(theme/default)に `#footer img { vertical-align: bottom; }`(ベースライン起因の縦ずれ解消)と、「フィードバックを送る」リンクとの間隔(margin)を追加
- Retina 用の高解像度画像は、現状ロゴが creativecommons.org への外部参照でありアセットの自前ホスティングが必要になるため、issue 記載のとおり本 PR の対象外としています

実レンダリングで before/after のフッター HTML を確認済み。テスト全 green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
