### PR TITLE
インラインコードスパンを CommonMark 準拠に拡張(N 連バッククォート対応)

### DIFF
--- a/lib/bitclust/markdown_to_rrd.rb
+++ b/lib/bitclust/markdown_to_rrd.rb
@@ -794,8 +794,14 @@ module BitClust
     end
 
     def convert_md_ref_to_rrd(ref)
-      # Markdown の \[ \] \\ → RD の [ ] \
-      unescaped = ref.gsub('\\[', '[').gsub('\\]', ']').gsub('\\\\', '\\')
+      # Markdown の \[ \] \` \\ → RD の [ ] ` \ 。
+      # \` の復元は convert_bare_refs のトップレベル分岐（[...] の外）と
+      # 対称: [m:$\`]（バッククォートをエスケープした参照）も
+      # [m:$`]（素のバッククォート）と同じ [[m:$`]] へ復元する
+      # （rurema/doctree#3232 レビュー、MDCompiler#extract_code_spans が
+      # コードスパンの開始候補から \` を除外するのと同じ理由で、
+      # ブラケット内の \` もコードスパンの巻き添えにならない）
+      unescaped = ref.gsub('\\[', '[').gsub('\\]', ']').gsub('\\`', '`').gsub('\\\\', '\\')
       # ? → .# (モジュール関数参照)
       unescaped = unescaped.sub(/\?\./, '.#')
       # RD で [] で終わるメソッド名のみ末尾スペースが必要 ([[m:Hash#[] ]])

--- a/lib/bitclust/mdcompiler.rb
+++ b/lib/bitclust/mdcompiler.rb
@@ -558,25 +558,101 @@ module BitClust
     end
 
     # GFM モードのテキストコンパイル:
-    # コードスパン `x` → <code>（中身は参照解決しない・HTML エスケープのみ）、
-    # 行頭 **N.** → <strong>、Markdown リンク（<url> 自動リンク・
-    # [テキスト](URL)・[テキスト](#アンカー)）→ <a>。
-    # エスケープ済み \` はリテラルのバッククォート
+    # コードスパン（CommonMark 6.1、N 連バッククォート）→ <code>（中身は
+    # 参照解決しない・HTML エスケープのみ）、行頭 **N.** → <strong>、
+    # Markdown リンク（<url> 自動リンク・[テキスト](URL)・
+    # [テキスト](#アンカー)）→ <a>。
+    # コードスパンの抽出はリンク抽出より先に行う（CommonMark のインライン
+    # 優先順位どおり。コードスパン内は他の記法を解決しない・
+    # extract_md_links 側で改めて分割する必要がない）。
+    # エスケープ済み \` はコードスパンの外だけリテラルのバッククォートに
+    # 復元される（restore_inline の convert_bare_refs が \[ \] \` の復元を
+    # 担う。コードスパン内ではバックスラッシュエスケープが無効という
+    # CommonMark のルールどおり、中身は素通しでバックスラッシュごと残す）
     def compile_gfm_text(str)
-      hidden = str.gsub(/\\`/, "\x00")
-      hidden.split(/(`[^`\n]+`)/, -1).map { |seg|
-        if seg =~ /\A`([^`\n]+)`\z/
-          "<code>#{escape_html(($1 || raise).gsub("\x00", '`'))}</code>"
-        else
-          links = [] #: Array[String]
-          seg = extract_md_links(seg, links)
-          seg = seg.gsub(/^\*\*(\d+\.)\*\* /, "\x01\\1\x02 ")
-          rd_compile_text(MarkdownToRRD.restore_inline(seg))
-            .gsub("\x01", '<strong>').gsub("\x02", '</strong>')
-            .gsub("\x00", '`')
-            .gsub(/\x03(\d+)\x03/) { links[($1 || raise).to_i] || raise }
+      code_spans = [] #: Array[String]
+      str = extract_code_spans(str, code_spans)
+      links = [] #: Array[String]
+      str = extract_md_links(str, links)
+      str = str.gsub(/^\*\*(\d+\.)\*\* /, "\x01\\1\x02 ")
+      rd_compile_text(MarkdownToRRD.restore_inline(str))
+        .gsub("\x01", '<strong>').gsub("\x02", '</strong>')
+        .gsub(/\x03(\d+)\x03/) { links[($1 || raise).to_i] || raise }
+        .gsub(/\x04(\d+)\x04/) { code_spans[($1 || raise).to_i] || raise }
+    end
+
+    # CommonMark 6.1 のインラインコードスパンを描画済み <code> へ退避し
+    # \x04idx\x04 プレースホルダに置き換える（extract_md_links と同じ流儀）。
+    # 開始と同じ長さのバッククォート列で閉じる（最長一致ではなく同長
+    # ペアリング）。閉じる相手が見つからない開始列はコードスパンにせず、
+    # そのまま次の候補から探索を続ける（非対称の開始列＝リテラル）。
+    # 改行はまたがない（テキストノードの行区切りを保持する既存の制約を
+    # 維持する）。
+    # \` は開始候補にしない（CommonMark: バックスラッシュエスケープされた
+    # バッククォートはコードスパンを開始しない。2.4 の \`not code\` 例）。
+    # 閉じ側の探索はエスケープを見ない（コードスパン内ではバックスラッシュ
+    # エスケープが無効なため、開いた後は同じ長さのバッククォート列が
+    # 来れば必ず閉じる。`foo\`bar` → <code>foo\</code>bar` という
+    # GitHub の実描画と同じ）
+    def extract_code_spans(str, saved)
+      result = +''
+      i = 0
+      len = str.length
+      while i < len
+        c = str[i] or raise
+        if c == '`' && (i.zero? || str[i - 1] != '\\')
+          run_len = 1
+          run_len += 1 while str[i + run_len] == '`'
+          close = find_code_span_close(str, i + run_len, run_len)
+          if close
+            content = str[(i + run_len)...close] || raise
+            saved << "<code>#{escape_html(normalize_code_span(content))}</code>"
+            result << "\x04#{saved.size - 1}\x04"
+            i = close + run_len
+            next
+          else
+            result << ('`' * run_len)
+            i += run_len
+            next
+          end
         end
-      }.join
+        result << c
+        i += 1
+      end
+      result
+    end
+
+    # from 位置以降で、run_len と同じ長さのバッククォート列（開始位置）を
+    # 探す。改行をまたいだら諦める（見つからないのと同じ扱い）
+    def find_code_span_close(str, from, run_len)
+      i = from
+      len = str.length
+      while i < len
+        c = str[i] or raise
+        case c
+        when "\n"
+          return nil
+        when '`'
+          j = i
+          j += 1 while str[j] == '`'
+          return i if j - i == run_len
+          i = j
+        else
+          i += 1
+        end
+      end
+      nil
+    end
+
+    # CommonMark 6.1: 前後が両方スペースで、かつ内容が全部スペースでは
+    # ない場合に前後を1個ずつ剥ぐ（`` `a` `` の内容を `a` として書ける
+    # ようにするための規則）
+    def normalize_code_span(content)
+      if content.start_with?(' ') && content.end_with?(' ') && content.match?(/[^ ]/)
+        content[1..-2] || ''
+      else
+        content
+      end
     end
 
     AUTOLINK_RE = %r{<(https?://[^<>\s]+)>}
@@ -645,7 +721,7 @@ module BitClust
     # （リンク内リンクは HTML として成立しないため）。外部 URL は rd の
     # [[url:]] と同じ external クラス、#アンカーはページ内リンク
     def md_link(text, dest)
-      label = escape_html(unescape_md_brackets(text).gsub("\x00", '`'))
+      label = escape_html(unescape_md_brackets(text))
       href = escape_html(unescape_md_brackets(dest))
       if dest.start_with?('#')
         %Q(<a href="#{href}">#{label}</a>)

--- a/sig/bitclust/mdcompiler.rbs
+++ b/sig/bitclust/mdcompiler.rbs
@@ -121,6 +121,16 @@ module BitClust
     # GFM モードのテキストコンパイル
     def compile_gfm_text: (String str) -> String
 
+    # CommonMark 6.1 のインラインコードスパンを描画済み <code> へ退避し
+    # プレースホルダに置き換える
+    def extract_code_spans: (String str, Array[String] saved) -> String
+
+    # run_len と同じ長さのバッククォート列（開始位置）を探す
+    def find_code_span_close: (String str, Integer from, Integer run_len) -> Integer?
+
+    # 前後が両方スペースで、かつ全部スペースではない場合に前後を1個ずつ剥ぐ
+    def normalize_code_span: (String content) -> String
+
     AUTOLINK_RE: ::Regexp
 
     # インラインリンクの宛先として受ける形（URL と #フラグメントのみ）

--- a/test/test_markdown_to_rrd.rb
+++ b/test/test_markdown_to_rrd.rb
@@ -654,6 +654,14 @@ class TestMarkdownToRRD < Test::Unit::TestCase
     assert_equal "[[m:Array#each]] を参照。\n", convert("[m:Array#each] を参照。\n")
   end
 
+  def test_escaped_backtick_bare_ref_resolves_same_as_unescaped
+    # znz さん提示の書き方(doctree#3232): [m:$\`]（バッククォートを
+    # エスケープした参照）は [m:$`]（素のバッククォート、既存の後方互換）
+    # と同じ [[m:$`]] へ復元される
+    assert_equal "[[m:$`]] を参照。\n", convert("[m:$\\`] を参照。\n")
+    assert_equal "[[m:$`]] を参照。\n", convert("[m:$`] を参照。\n")
+  end
+
   def test_escaped_leading_hash_is_unescaped
     assert_equal "# : 2002-08-01 IO#read\n#    本文。\n",
       convert("\\# : 2002-08-01 IO#read\n\\#    本文。\n")

--- a/test/test_mdcompiler.rb
+++ b/test/test_mdcompiler.rb
@@ -548,6 +548,74 @@ class TestMDCompiler < Test::Unit::TestCase
     assert_include html, "<code>a&lt;b&gt;</code> です。"
   end
 
+  # ---- CommonMark 6.1: N 連バッククォートのコードスパン(doctree#3232) ----
+
+  def test_gfm_double_backtick_span_contains_single_backtick
+    # 開始と同じ長さ(2連)のバッククォート列で閉じ、前後の空白を1個ずつ剥ぐ
+    html = gfm_compiler.compile("# T\n\n`` foo ` bar `` です。\n")
+    assert_include html, "<code>foo ` bar</code> です。"
+  end
+
+  def test_gfm_triple_backtick_span
+    # 行頭 ``` はブロックレベルのフェンスと解釈されるため、文中に置く
+    html = gfm_compiler.compile("# T\n\n見よ ``` code ``` です。\n")
+    assert_include html, "<code>code</code> です。"
+  end
+
+  def test_gfm_unbalanced_backtick_run_stays_literal
+    # 閉じる相手のいない開始列はコードスパンにせずリテラルのまま
+    html = gfm_compiler.compile("# T\n\n``foo` です。\n")
+    assert_include html, "``foo` です。"
+    assert_not_include html, "<code>"
+  end
+
+  def test_gfm_escaped_backtick_inside_span_keeps_backslash
+    # コードスパン内ではバックスラッシュエスケープが無効(CommonMark 6.1)。
+    # \` はバックスラッシュごとリテラルに残る(GitHub の実描画と同一)
+    html = gfm_compiler.compile("# T\n\n`` \\` `` は変換されません。\n")
+    assert_include html, "<code>\\`</code> は変換されません。"
+  end
+
+  def test_gfm_bare_backtick_in_bracket_ref_still_resolves
+    # 既存の [m:$`](素のバッククォート)の後方互換
+    html = gfm_compiler.compile("# T\n\n[m:$`] を参照。\n")
+    assert_include html, ">$`</a>"
+    assert_not_include html, "[[m:$"
+  end
+
+  def test_gfm_escaped_backtick_in_bracket_ref_resolves
+    # znz さん提示の書き方(doctree#3232 レビュー): [m:$\`] は
+    # [m:$`](素のバッククォート)と同じ参照へ解決される
+    escaped = gfm_compiler.compile("# T\n\n[m:$\\`] を参照。\n")
+    bare = gfm_compiler.compile("# T\n\n[m:$`] を参照。\n")
+    assert_equal bare, escaped
+    assert_include escaped, ">$`</a>"
+    assert_not_include escaped, "[[m:$"
+    assert_not_include escaped, "\\`"
+  end
+
+  def test_gfm_znz_gsub_paragraph_golden
+    # doctree PR #3232 レビューで znz さんが提示した段落そのもの
+    # (String#gsub の説明)。GitHub 上の実描画(gh api -X POST /markdown で
+    # 確認済み)と同等の構造 — \`・\'・\+ がコードスパンに、
+    # 3つの参照がすべて解決されること — をまとめて確認する
+    md = <<~MD
+      # T
+
+      置換文字列内では `` \\` ``、`\\'`、`\\+` も使えます。
+      これらは [m:$\\`]、[m:$']、[m:$+] に対応します。
+    MD
+    html = gfm_compiler.compile(md)
+    assert_include html, "<code>\\`</code>"
+    assert_include html, "<code>\\'</code>"
+    assert_include html, "<code>\\+</code>"
+    assert_include html, ">$`</a>"
+    assert_include html, ">$'</a>"
+    assert_include html, ">$+</a>"
+    assert_not_include html, "[[m:$"
+    assert_not_include html, "[m:$"
+  end
+
   def test_gfm_ref_and_span_coexist
     html = gfm_compiler.compile("# タイトル\n\n[c:String] と `x` を参照。\n")
     assert_include html, "</a> と <code>x</code> を参照。"


### PR DESCRIPTION
rurema/doctree#3232 のレビュー指摘(バックスラッシュ表記の書き方を CommonMark に合わせる)の前提となる、インラインコードスパンの CommonMark 準拠化です。

## 変更

- **N 連バッククォートのコードスパン**(CommonMark 6.1)に対応: 同じ長さのバッククォート列でペアリングし、``` `` \` `` ``` のような「バッククォートを含むコード」を書けるようにしました(両端スペースの単一剥ぎ規則も実装)
- 処理順を CommonMark の実際の優先順位に合わせ、コードスパン抽出を最初に実行。**コードスパン内ではエスケープ無効**(`` \` `` はバックスラッシュ+バッククォートのまま)、スパン外の `` \` `` はリテラルバッククォートに解決
- ブラケット参照内のバッククォートエスケープに対応: ``[m:$\`]`` が既存の ``[m:$`]`` と同一の HTML(`` $` `` へのリンク)になります(後方互換維持)

## 検証

- TDD(全ケース先に失敗を確認)・テスト 17688 全 green・steep エラー 0
- **GitHub の実描画をゴールデンに**: `gh api -X POST /markdown` の出力と、レビューで提示された gsub の段落全体の構造が一致することを確認
- **manual/ 全体の回帰比較**: 全 13,593 生成ファイルの statichtml を新旧で比較し、差分は help/symref の 2 ファイルのみ(単一バッククォートスパン内の `` \` `` の解釈が GitHub と同一になる方向の変化。compile 経路の直接比較では新旧同一の出力になることも確認済みで、原稿側の修正は不要でした)

マージ後、doctree 側で gsub 系原稿をレビュー提示の形に修正する PR(準備済み)を取り込めます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
