### PR TITLE
メソッドエントリに名前別の since/until プロパティを追加する

### DIFF
--- a/lib/bitclust/entry.rb
+++ b/lib/bitclust/entry.rb
@@ -113,7 +113,7 @@ module BitClust
         when 'LibraryEntry'   then "restore_library(h['#{@name}'])"
         when 'ClassEntry'     then "restore_class(h['#{@name}'])"
         when 'MethodEntry'    then "restore_method(h['#{@name}'])"
-        when '[String]'       then "h['#{@name}'].split(/,(?=.)/)"
+        when '[String]'       then "(h['#{@name}'] || '').split(/,(?=.)/)"
         when '[LibraryEntry]' then "restore_libraries(h['#{@name}'])"
         when '[ClassEntry]'   then "restore_classes(h['#{@name}'])"
         when '[MethodEntry]'  then "restore_methods(h['#{@name}'])"

--- a/lib/bitclust/methodentry.rb
+++ b/lib/bitclust/methodentry.rb
@@ -103,6 +103,13 @@ module BitClust
       property :kind,            'Symbol'   ## :defined | :added | :redefined | :undefined | :nomethod
       property :source,          'String'
       property :source_location, 'Location'
+      # 名前別の since/until（bitclust#132）。トークンは
+      # "#{エンコード名}=#{バージョン}" の配列（[String] 型を再利用）で、
+      # 生名の ',' '=' は encodename_url でエスケープ済みなので最後の '='
+      # がバージョンとの区切りになる（バージョン文字列には '=' も ',' も
+      # 現れない前提。fill_since/fill_until で検査する）
+      property :since_by_name,   '[String]'
+      property :until_by_name,   '[String]'
     }
 
     def inspect
@@ -150,6 +157,60 @@ module BitClust
     def name?(name)
       names().include?(name)
     end
+
+    # 名前別 since/until（bitclust#132）。名前ごとに別バージョンで
+    # 追加/削除されうる別名（例: alias）を区別して記録する
+
+    def since_of(name)
+      since_map[name]
+    end
+
+    def until_of(name)
+      until_map[name]
+    end
+
+    def since_map
+      decode_version_tokens(since_by_name)
+    end
+
+    def until_map
+      decode_version_tokens(until_by_name)
+    end
+
+    # name の since が未設定の場合のみ version を追加する。追加したら true、
+    # 既に値があって何もしなければ false を返す
+    def fill_since(name, version)
+      fill_version_token(:since_by_name, :since_of, name, version)
+    end
+
+    # fill_since の until 版
+    def fill_until(name, version)
+      fill_version_token(:until_by_name, :until_of, name, version)
+    end
+
+    private
+
+    def decode_version_tokens(tokens)
+      h = {} #: Hash[String, String]
+      tokens.each do |token|
+        i = token.rindex('=') or raise "must not happen: malformed version token #{token.inspect}"
+        raw_name = decodename_url(token[0...i] || raise)
+        h[raw_name] = token[(i + 1)..] || raise
+      end
+      h
+    end
+
+    def fill_version_token(prop, reader, name, version)
+      if version.include?('=') || version.include?(',')
+        raise ArgumentError, "version must not contain '=' or ',': #{version.inspect}"
+      end
+      return false if __send__(reader, name)
+      token = "#{encodename_url(name)}=#{version}"
+      __send__("#{prop}=", __send__(prop) + [token])
+      true
+    end
+
+    public
 
     def name_match?(re)
       names().any? {|n| re =~ n }

--- a/sig/bitclust/methodentry.rbs
+++ b/sig/bitclust/methodentry.rbs
@@ -43,6 +43,8 @@ module BitClust
     attr_accessor kind: (:defined | :added | :redefined | :undefined | :nomethod)
     attr_accessor source: String
     attr_accessor source_location: Location
+    attr_accessor since_by_name: Array[String]
+    attr_accessor until_by_name: Array[String]
 
     def inspect: () -> String
 
@@ -61,6 +63,18 @@ module BitClust
     def title_labels: () -> Array[String]
 
     def name?: (String name) -> bool
+
+    def since_of: (String name) -> String?
+
+    def until_of: (String name) -> String?
+
+    def since_map: () -> Hash[String, String]
+
+    def until_map: () -> Hash[String, String]
+
+    def fill_since: (String name, String version) -> bool
+
+    def fill_until: (String name, String version) -> bool
 
     def name_match?: (Regexp re) -> bool
 
@@ -101,5 +115,11 @@ module BitClust
     def nomethod?: () -> bool
 
     def description: () -> String?
+
+    private
+
+    def decode_version_tokens: (Array[String] tokens) -> Hash[String, String]
+
+    def fill_version_token: (Symbol prop, Symbol reader, String name, String version) -> bool
   end
 end

--- a/test/test_methodentry.rb
+++ b/test/test_methodentry.rb
@@ -1,5 +1,8 @@
 require 'test/unit'
 require 'bitclust'
+require 'bitclust/methoddatabase'
+require 'tmpdir'
+require 'fileutils'
 
 class TestMethodEntryTitleLabels < Test::Unit::TestCase
   def test_title_labels_matches_label_when_no_alias
@@ -63,5 +66,151 @@ HERE
     m = db.get_method(BitClust::MethodSpec.parse('Kernel$stdout'))
     assert_equal(['$stdout'], m.title_labels)
     assert_equal(m.label, m.title_labels.join(', '))
+  end
+end
+
+# メソッド名別の since/until (bitclust#132 P1)。
+#
+# テストリスト:
+# [x] 新規エントリの since_map/until_map は空、since_of/until_of は nil
+# [x] fill_since は初回のみ追加して true を返す。既に値があれば false で上書きしない
+# [x] fill_until も同様
+# [x] fill_since/fill_until は version に '=' や ',' を含むと ArgumentError
+# [x] 実ディスク DB への保存→別インスタンスで再読込しても since_of/until_of が一致
+# [x] 名前に '=' を含む（"==", "foo="）・',' を含む（"," ）・"-@" が
+#     エンコード/デコードを経て正しく往復する
+# [x] since_by_name/until_by_name のキー自体がプロパティファイルに無い
+#     （旧DB）場合も落ちずに空配列として読める（Entry の '[String]' デシリアライザの
+#     nil 安全化）
+class TestMethodEntrySinceUntil < Test::Unit::TestCase
+  def setup
+    @dir = Dir.mktmpdir
+    @db = BitClust::MethodDatabase.new(@dir)
+    @db.init
+    @db.transaction do
+      @db.propset('version', '2.0')
+      @db.propset('encoding', 'utf-8')
+    end
+  end
+
+  def teardown
+    FileUtils.rm_rf(@dir)
+  end
+
+  def test_defaults_are_empty
+    m = build_entry('marker')
+    assert_equal({}, m.since_map)
+    assert_equal({}, m.until_map)
+    assert_nil m.since_of('marker')
+    assert_nil m.until_of('marker')
+  end
+
+  def test_fill_since_adds_once
+    m = build_entry('marker')
+    assert_equal(true, m.fill_since('marker', '2.0'))
+    assert_equal('2.0', m.since_of('marker'))
+    # 既に値があるので上書きされず false
+    assert_equal(false, m.fill_since('marker', '3.0'))
+    assert_equal('2.0', m.since_of('marker'))
+  end
+
+  def test_fill_until_adds_once
+    m = build_entry('marker')
+    assert_equal(true, m.fill_until('marker', '3.0'))
+    assert_equal('3.0', m.until_of('marker'))
+    assert_equal(false, m.fill_until('marker', '4.0'))
+    assert_equal('3.0', m.until_of('marker'))
+  end
+
+  def test_fill_since_rejects_version_with_equal_or_comma
+    m = build_entry('marker')
+    assert_raise(ArgumentError) { m.fill_since('marker', '2.0=1') }
+    assert_raise(ArgumentError) { m.fill_since('marker', '2.0,1') }
+  end
+
+  def test_fill_until_rejects_version_with_equal_or_comma
+    m = build_entry('marker')
+    assert_raise(ArgumentError) { m.fill_until('marker', '2.0=1') }
+    assert_raise(ArgumentError) { m.fill_until('marker', '2.0,1') }
+  end
+
+  def test_roundtrip_through_disk
+    m = build_entry('marker')
+    m.fill_since('marker', '2.0')
+    m.fill_until('marker', '3.0')
+    m.save
+
+    reloaded = reload_entry(m.id)
+    assert_equal('2.0', reloaded.since_of('marker'))
+    assert_equal('3.0', reloaded.until_of('marker'))
+    assert_equal({'marker' => '2.0'}, reloaded.since_map)
+    assert_equal({'marker' => '3.0'}, reloaded.until_map)
+  end
+
+  def test_roundtrip_names_with_special_characters
+    [ '==', 'foo=', '-@', ',' ].each do |name|
+      m = build_entry(name)
+      m.fill_since(name, '2.0')
+      m.save
+
+      reloaded = reload_entry(m.id)
+      assert_equal('2.0', reloaded.since_of(name),
+                   "since_of(#{name.inspect}) should round-trip")
+    end
+  end
+
+  def test_multiple_names_share_one_entry
+    m = build_entry_with_names(['-@', 'dedup'])
+    m.fill_since('-@', '2.0')
+    m.fill_since('dedup', '3.0')
+    m.save
+
+    reloaded = reload_entry(m.id)
+    assert_equal('2.0', reloaded.since_of('-@'))
+    assert_equal('3.0', reloaded.since_of('dedup'))
+    assert_equal({'-@' => '2.0', 'dedup' => '3.0'}, reloaded.since_map)
+  end
+
+  def test_missing_since_by_name_key_is_backward_compatible
+    m = build_entry('old_method')
+    m.save
+    strip_property_line(m.id, 'since_by_name')
+    strip_property_line(m.id, 'until_by_name')
+
+    reloaded = reload_entry(m.id)
+    assert_equal([], reloaded.since_by_name)
+    assert_equal([], reloaded.until_by_name)
+    assert_nil reloaded.since_of('old_method')
+  end
+
+  private
+
+  def build_entry(name)
+    build_entry_with_names([name])
+  end
+
+  def build_entry_with_names(names)
+    id = BitClust::NameUtils.build_method_id('_builtin', 'Foo', :instance_method, names.first)
+    m = BitClust::MethodEntry.new(@db, id)
+    m.names = names
+    m.visibility = :public
+    m.kind = :defined
+    m.source = "説明\n"
+    m
+  end
+
+  def reload_entry(id)
+    fresh_db = BitClust::MethodDatabase.new(@dir)
+    BitClust::MethodEntry.new(fresh_db, id)
+  end
+
+  def property_file_path(id)
+    File.join(@dir, BitClust::NameUtils.encodeid("method/#{id}"))
+  end
+
+  def strip_property_line(id, key)
+    path = property_file_path(id)
+    lines = File.readlines(path).reject {|l| l.start_with?("#{key}=") }
+    File.write(path, lines.join)
   end
 end


### PR DESCRIPTION
## 概要

#132(メソッド単位の「このバージョンから使える」表示)の **P1: スキーマ**です。設計と決定事項は #132 の設計コメントとその返信(決定一覧)を参照してください。

- `MethodEntry` に名前別の `since_by_name` / `until_by_name`('[String]' プロパティ)を追加
  - 決定事項「名前別 since/until マップ」に対応。別名ごとに追加/削除版が異なるケース(例: `-@` と 3.2 で追加された別名 `dedup`)を名前単位で記録できます
  - トークンは「エンコード名 `=` バージョン」。名前に `=` や `,` を含むもの(`==`、setter、特殊変数 `$,` など)は method id と同じ `NameUtils.encodename_url` でエスケープされるため、最後の `=` で安全に分割できます
- 読み取り `since_of` / `until_of` / `since_map` / `until_map`、書き込み `fill_since` / `fill_until`(**未設定の名前のみ**追加)。「算出値 < 著者の明示値」という決定済み優先順位の実装点で、P2 の算出はこの経由でのみ書き込みます
- `Entry` の '[String]' デシリアライザを nil セーフ化。旧 DB のプロパティファイルには新キー自体が無く、従来実装のままだと読み込み時に `nil.split` で例外になるため(後方互換の要)
- RBS 追記済み

値が空のときは従来と完全に同じ挙動(P3 の表示実装まではユーザー可視の変化なし)です。

## 検証

- テスト 9 件追加: 実ディスク DB での round-trip、特殊文字名(`==` / `foo=` / `-@` / `,`)、fill の上書き禁止、新キー欠落ファイルの後方互換読み込み
- フルスイート 17702 → 17711 tests / 0 failures・`rbs validate`・`steep check` エラーなし

refs #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
