### PR TITLE
methodsince サブコマンドでバージョンラダーから since/until を算出する

### DIFF
--- a/lib/bitclust/entry.rb
+++ b/lib/bitclust/entry.rb
@@ -113,7 +113,7 @@ module BitClust
         when 'LibraryEntry'   then "restore_library(h['#{@name}'])"
         when 'ClassEntry'     then "restore_class(h['#{@name}'])"
         when 'MethodEntry'    then "restore_method(h['#{@name}'])"
-        when '[String]'       then "h['#{@name}'].split(/,(?=.)/)"
+        when '[String]'       then "(h['#{@name}'] || '').split(/,(?=.)/)"
         when '[LibraryEntry]' then "restore_libraries(h['#{@name}'])"
         when '[ClassEntry]'   then "restore_classes(h['#{@name}'])"
         when '[MethodEntry]'  then "restore_methods(h['#{@name}'])"

--- a/lib/bitclust/method_since_calculator.rb
+++ b/lib/bitclust/method_since_calculator.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+#
+# bitclust/method_since_calculator.rb
+#
+
+require 'bitclust/exception'
+
+module BitClust
+
+  # 複数バージョンの DB(バージョンラダー)からメソッド名別の初出/削除
+  # バージョンを算出し、対象 DB のメソッドエントリへ書き込む(bitclust#132 P2)。
+  #
+  # ライブラリは意図的に無視する: 同じメソッドが版によって別ライブラリの
+  # 下でドキュメント化されていても、同一メソッドとして union で扱う。
+  #
+  # 算出値は「著者が明示した値(将来 P4 で {: since ...} 等から記録される
+  # 想定)」より優先度が低い。#apply は MethodEntry#fill_since/fill_until を
+  # 使うため、既に値がある名前は上書きしない。
+  class MethodSinceCalculator
+
+    def initialize(dbs)
+      versions = dbs.map {|db| db.propget('version') }
+      versions.each do |v|
+        if v.nil? || v.empty?
+          raise UserError, "database has no version property"
+        end
+      end
+      dup = versions.tally.select {|_, n| n > 1 }.keys
+      unless dup.empty?
+        raise UserError, "duplicate version(s) in ladder: #{dup.join(', ')}"
+      end
+      sorted = dbs.sort_by {|db| Gem::Version.new(db.propget('version') || raise) }
+      @versions = sorted.map {|db| db.propget('version') || raise }
+      @ladder = sorted
+      @first = {} #: Hash[key, String]
+      @last  = {} #: Hash[key, String]
+    end
+
+    # ラダーの各 DB を1つずつ走査して [クラス名, typechar, 生名] ごとの
+    # 初出/最終出現バージョンを記録する。走査済みの DB への参照は
+    # メモリを膨らませないようその場で捨てる
+    def scan
+      ladder = @ladder or raise "scan was already called"
+      @ladder = nil
+      until ladder.empty?
+        db = ladder.shift
+        version = db.propget('version') || raise
+        db.classes.each do |c|
+          c.entries.each do |m|
+            next if m.kind == :undefined
+            m.names.each do |name|
+              key = [c.name, m.typechar, name] #: key
+              @first[key] ||= version
+              @last[key] = version
+            end
+          end
+        end
+      end
+      self
+    end
+
+    # key = [クラス名, typechar, 生名]。ラダー最古版から存在する(フロア)
+    # 場合は「不明」を意味するので nil を返す
+    def since_for(key)
+      first = @first[key] or return nil
+      first == (@versions.first || raise) ? nil : first
+    end
+
+    # ラダー最新版でも存在する場合は「まだ削除されていない」ので nil。
+    # そうでなければ最終出現バージョンの次のラダーバージョン(削除された版)
+    def until_for(key)
+      last = @last[key] or return nil
+      return nil if last == (@versions.last || raise)
+      idx = @versions.index(last) or raise "must not happen: #{last.inspect}"
+      @versions[idx + 1] || raise
+    end
+
+    # 対象 DB の各メソッドエントリへ算出済みの since/until を書き込む。
+    # target_db のバージョンはラダーに含まれていなければならない。
+    # 既に値がある名前は fill_since/fill_until の仕様により上書きされない
+    # (著者による明示値が算出値より優先される)。冪等: 2回目の apply は
+    # 何も変更しない(floor_skipped を除く)
+    def apply(target_db)
+      version = target_db.propget('version')
+      unless @versions.include?(version)
+        raise UserError, "#{version.inspect} is not one of the ladder versions: #{@versions.join(', ')}"
+      end
+      stats = {entries_updated: 0, since_filled: 0, until_filled: 0, floor_skipped: 0} #: stats
+      target_db.classes.each do |c|
+        c.entries.each do |m|
+          next if m.kind == :undefined
+          changed = false
+          m.names.each do |name|
+            key = [c.name, m.typechar, name] #: key
+            if since_v = since_for(key)
+              if m.fill_since(name, since_v)
+                stats[:since_filled] += 1
+                changed = true
+              end
+            else
+              stats[:floor_skipped] += 1
+            end
+            if (until_v = until_for(key)) && m.fill_until(name, until_v)
+              stats[:until_filled] += 1
+              changed = true
+            end
+          end
+          if changed
+            m.save
+            stats[:entries_updated] += 1
+          end
+        end
+      end
+      stats
+    end
+  end
+end

--- a/lib/bitclust/methodentry.rb
+++ b/lib/bitclust/methodentry.rb
@@ -103,6 +103,13 @@ module BitClust
       property :kind,            'Symbol'   ## :defined | :added | :redefined | :undefined | :nomethod
       property :source,          'String'
       property :source_location, 'Location'
+      # 名前別の since/until（bitclust#132）。トークンは
+      # "#{エンコード名}=#{バージョン}" の配列（[String] 型を再利用）で、
+      # 生名の ',' '=' は encodename_url でエスケープ済みなので最後の '='
+      # がバージョンとの区切りになる（バージョン文字列には '=' も ',' も
+      # 現れない前提。fill_since/fill_until で検査する）
+      property :since_by_name,   '[String]'
+      property :until_by_name,   '[String]'
     }
 
     def inspect
@@ -150,6 +157,60 @@ module BitClust
     def name?(name)
       names().include?(name)
     end
+
+    # 名前別 since/until（bitclust#132）。名前ごとに別バージョンで
+    # 追加/削除されうる別名（例: alias）を区別して記録する
+
+    def since_of(name)
+      since_map[name]
+    end
+
+    def until_of(name)
+      until_map[name]
+    end
+
+    def since_map
+      decode_version_tokens(since_by_name)
+    end
+
+    def until_map
+      decode_version_tokens(until_by_name)
+    end
+
+    # name の since が未設定の場合のみ version を追加する。追加したら true、
+    # 既に値があって何もしなければ false を返す
+    def fill_since(name, version)
+      fill_version_token(:since_by_name, :since_of, name, version)
+    end
+
+    # fill_since の until 版
+    def fill_until(name, version)
+      fill_version_token(:until_by_name, :until_of, name, version)
+    end
+
+    private
+
+    def decode_version_tokens(tokens)
+      h = {} #: Hash[String, String]
+      tokens.each do |token|
+        i = token.rindex('=') or raise "must not happen: malformed version token #{token.inspect}"
+        raw_name = decodename_url(token[0...i] || raise)
+        h[raw_name] = token[(i + 1)..] || raise
+      end
+      h
+    end
+
+    def fill_version_token(prop, reader, name, version)
+      if version.include?('=') || version.include?(',')
+        raise ArgumentError, "version must not contain '=' or ',': #{version.inspect}"
+      end
+      return false if __send__(reader, name)
+      token = "#{encodename_url(name)}=#{version}"
+      __send__("#{prop}=", __send__(prop) + [token])
+      true
+    end
+
+    public
 
     def name_match?(re)
       names().any? {|n| re =~ n }

--- a/lib/bitclust/runner.rb
+++ b/lib/bitclust/runner.rb
@@ -61,6 +61,7 @@ Subcommands(for developers):
     extract     Extract method entries from source file.
     classes     Display defined classes for all ruby.
     methods     Display defined methods for all ruby.
+    methodsince Fill per-name since/until from a version ladder of DBs.
 
 Subcommands(for packagers):
     statichtml  Generate static HTML files.
@@ -107,6 +108,7 @@ Global Options:
         'extract'     => BitClust::Subcommands::ExtractCommand.new,
         'classes'     => BitClust::Subcommands::ClassesCommand.new,
         'methods'     => BitClust::Subcommands::MethodsCommand.new,
+        'methodsince' => BitClust::Subcommands::MethodsinceCommand.new,
       }
     end
 

--- a/lib/bitclust/subcommands/methodsince_command.rb
+++ b/lib/bitclust/subcommands/methodsince_command.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+#
+# bitclust/subcommands/methodsince_command.rb
+#
+# Fills per-name since/until into method entries by scanning a version
+# ladder of databases:
+#
+#   bitclust methodsince --update=db-3.4 db-1.8.7 db-1.9.3 ... db-3.3 db-3.4
+#
+# Every positional argument and every --update path together form the
+# version ladder used to compute presence; --update paths are additionally
+# written back to (see bitclust/method_since_calculator.rb, bitclust#132 P2).
+#
+
+require 'bitclust'
+require 'bitclust/subcommand'
+require 'bitclust/method_since_calculator'
+require 'tmpdir'
+require 'fileutils'
+
+module BitClust
+  module Subcommands
+    class MethodsinceCommand < Subcommand
+      def initialize
+        super
+        @updates = []
+        @dry_run = false
+        @parser.banner = "Usage: #{File.basename($0, '.*')} methodsince [options] <dbpath>..."
+        @parser.on('--update=PATH', 'Writable target database to fill in-place (repeatable).') {|path|
+          @updates.push path
+        }
+        @parser.on('--dry-run', 'Compute and print stats without saving.') {
+          @dry_run = true
+        }
+      end
+
+      # DB パスは自前の引数(位置引数 + --update)で受けるので、
+      # グローバル --database は不要
+      def needs_database?
+        false
+      end
+
+      def exec(argv, options)
+        error("no --update given (nothing to write to)") if @updates.empty?
+
+        ladder_paths = (argv + @updates).uniq {|path| File.expand_path(path) }
+        calculator = MethodSinceCalculator.new(ladder_paths.map {|path| MethodDatabase.new(path) })
+        calculator.scan
+
+        @updates.each do |path|
+          stats, version = @dry_run ? apply_dry_run(calculator, path) : apply_and_save(calculator, path)
+          puts "#{File.basename(path)} (version #{version}): " \
+               "entries_updated=#{stats[:entries_updated]} since_filled=#{stats[:since_filled]} " \
+               "until_filled=#{stats[:until_filled]} floor_skipped=#{stats[:floor_skipped]}"
+        end
+      end
+
+      private
+
+      def apply_and_save(calculator, path)
+        target = MethodDatabase.new(path)
+        version = target.propget('version') or
+          error("#{path}: no version property (not a bitclust database?)")
+        [calculator.apply(target), version]
+      end
+
+      # --dry-run: 実際のデータベースには一切書き込まず、複製に対して
+      # apply した結果の統計だけを見せる
+      def apply_dry_run(calculator, path)
+        version = MethodDatabase.new(path).propget('version') or
+          error("#{path}: no version property (not a bitclust database?)")
+        Dir.mktmpdir do |tmp|
+          copy = File.join(tmp, 'db')
+          FileUtils.cp_r(path, copy)
+          [calculator.apply(MethodDatabase.new(copy)), version]
+        end
+      end
+    end
+  end
+end

--- a/sig/bitclust/method_since_calculator.rbs
+++ b/sig/bitclust/method_since_calculator.rbs
@@ -1,0 +1,30 @@
+module BitClust
+  class MethodSinceCalculator
+    type key = [String, NameUtils::typechar, String]
+
+    type stats = {
+      entries_updated: Integer,
+      since_filled: Integer,
+      until_filled: Integer,
+      floor_skipped: Integer,
+    }
+
+    @ladder: Array[MethodDatabase]?
+
+    @versions: Array[String]
+
+    @first: Hash[key, String]
+
+    @last: Hash[key, String]
+
+    def initialize: (Array[MethodDatabase] dbs) -> void
+
+    def scan: () -> self
+
+    def since_for: (key key) -> String?
+
+    def until_for: (key key) -> String?
+
+    def apply: (MethodDatabase target_db) -> stats
+  end
+end

--- a/sig/bitclust/methodentry.rbs
+++ b/sig/bitclust/methodentry.rbs
@@ -43,6 +43,8 @@ module BitClust
     attr_accessor kind: (:defined | :added | :redefined | :undefined | :nomethod)
     attr_accessor source: String
     attr_accessor source_location: Location
+    attr_accessor since_by_name: Array[String]
+    attr_accessor until_by_name: Array[String]
 
     def inspect: () -> String
 
@@ -61,6 +63,18 @@ module BitClust
     def title_labels: () -> Array[String]
 
     def name?: (String name) -> bool
+
+    def since_of: (String name) -> String?
+
+    def until_of: (String name) -> String?
+
+    def since_map: () -> Hash[String, String]
+
+    def until_map: () -> Hash[String, String]
+
+    def fill_since: (String name, String version) -> bool
+
+    def fill_until: (String name, String version) -> bool
 
     def name_match?: (Regexp re) -> bool
 
@@ -101,5 +115,11 @@ module BitClust
     def nomethod?: () -> bool
 
     def description: () -> String?
+
+    private
+
+    def decode_version_tokens: (Array[String] tokens) -> Hash[String, String]
+
+    def fill_version_token: (Symbol prop, Symbol reader, String name, String version) -> bool
   end
 end

--- a/sig/bitclust/subcommands/methodsince_command.rbs
+++ b/sig/bitclust/subcommands/methodsince_command.rbs
@@ -1,0 +1,23 @@
+module BitClust
+  module Subcommands
+    # 複数バージョンの DB(ラダー)からメソッド名別 since/until を算出し、
+    # --update で指定した対象 DB に書き込む(bitclust#132 P2)
+    class MethodsinceCommand < Subcommand
+      @updates: Array[String]
+
+      @dry_run: bool
+
+      def initialize: () -> void
+
+      def needs_database?: () -> bool
+
+      def exec: (Subcommand::argv argv, Subcommand::options options) -> void
+
+      private
+
+      def apply_and_save: (MethodSinceCalculator calculator, String path) -> [MethodSinceCalculator::stats, String]
+
+      def apply_dry_run: (MethodSinceCalculator calculator, String path) -> [MethodSinceCalculator::stats, String]
+    end
+  end
+end

--- a/test/test_method_since_calculator.rb
+++ b/test/test_method_since_calculator.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'bitclust'
+require 'bitclust/methoddatabase'
+require 'bitclust/method_since_calculator'
+require 'tmpdir'
+require 'fileutils'
+
+# メソッド名別 since/until の算出(bitclust#132 P2)。
+#
+# テストリスト:
+# [x] フロア(ラダー最古版から存在)のメソッドは since も until も付かない
+# [x] #@since ゲート付きメソッドは、追加された版以降の対象すべてで
+#     since が付く
+# [x] 別名グループ: シグネチャごとに異なるゲートを持てば名前ごとに
+#     別の since になる(-@ は 2.0.0、dedup は 3.0)。ゲートが効いて
+#     いない版の対象ではその別名自体が存在しない
+# [x] #@until ゲート付きメソッドは、消える1つ前の版の対象で until が付き、
+#     消えた後の対象にはエントリ自体が存在しない
+# [x] インスタンスメソッドとシンゲルトンメソッドは同名でも別キー
+# [x] kind=:undefined のエントリは走査で無視される: {: undef} → 実メソッド化
+#     したものは実メソッド化した版が since になり、逆に undef 化は削除扱いで
+#     前の版の対象に until が付く
+# [x] kind=:undefined のエントリには適用でも書き込まない
+# [x] ラダーに同じバージョンが重複していれば .new で UserError
+# [x] apply は冪等: 2回目は floor_skipped 以外すべて0
+# [x] 既に値がある名前は上書きしない(著者値が算出値より優先)
+# [x] 対象DBのバージョンがラダーに無ければ apply は UserError
+class TestMethodSinceCalculator < Test::Unit::TestCase
+  RD = <<~'RD'
+    description
+
+    = class MSCTest
+    == Instance Methods
+    --- old_timer
+
+    説明
+
+    #@since 2.0.0
+    --- newmeth
+
+    説明
+    #@end
+
+    #@since 2.0.0
+    --- -@
+    #@since 3.0
+    --- dedup
+    #@end
+
+    説明
+    #@end
+
+    #@until 3.0
+    --- legacy
+
+    説明
+    #@end
+
+    --- undefmeth
+    {: undef}
+
+    説明
+
+    --- undef_then_real
+    #@until 2.0.0
+    {: undef}
+    #@end
+
+    説明
+
+    #@since 2.0.0
+    --- real_then_undef
+    #@since 3.0
+    {: undef}
+    #@end
+
+    説明
+    #@end
+
+    --- marker
+
+    説明
+
+    == Singleton Methods
+    #@since 2.0.0
+    --- marker
+
+    説明
+    #@end
+  RD
+
+  LADDER_VERSIONS = %w[1.8.7 2.0.0 3.0]
+
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @paths = {}
+    LADDER_VERSIONS.each {|v| build_db(v) }
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_floor_method_has_no_since_or_until
+    run_calculator('2.0.0')
+    run_calculator('3.0')
+    assert_nil find_entry('2.0.0', 'i', 'old_timer').since_of('old_timer')
+    assert_nil find_entry('2.0.0', 'i', 'old_timer').until_of('old_timer')
+    assert_nil find_entry('3.0', 'i', 'old_timer').since_of('old_timer')
+    assert_nil find_entry('3.0', 'i', 'old_timer').until_of('old_timer')
+  end
+
+  def test_since_gated_method_gets_since_in_every_later_target
+    run_calculator('2.0.0')
+    run_calculator('3.0')
+    assert_equal '2.0.0', find_entry('2.0.0', 'i', 'newmeth').since_of('newmeth')
+    assert_equal '2.0.0', find_entry('3.0', 'i', 'newmeth').since_of('newmeth')
+  end
+
+  def test_alias_group_since_is_split_by_name
+    run_calculator('2.0.0')
+    run_calculator('3.0')
+
+    at_2_0_0 = find_entry('2.0.0', 'i', '-@')
+    assert_equal ['-@'], at_2_0_0.names
+    assert_equal '2.0.0', at_2_0_0.since_of('-@')
+
+    at_3_0 = find_entry('3.0', 'i', '-@')
+    assert_equal ['-@', 'dedup'], at_3_0.names.sort
+    assert_equal '2.0.0', at_3_0.since_of('-@')
+    assert_equal '3.0', at_3_0.since_of('dedup')
+  end
+
+  def test_until_gated_method
+    run_calculator('2.0.0')
+    assert_equal '3.0', find_entry('2.0.0', 'i', 'legacy').until_of('legacy')
+    assert_nil find_entry('3.0', 'i', 'legacy')
+  end
+
+  def test_singleton_and_instance_method_are_distinct_keys
+    run_calculator('2.0.0')
+    assert_nil find_entry('2.0.0', 'i', 'marker').since_of('marker')
+    assert_equal '2.0.0', find_entry('2.0.0', 's', 'marker').since_of('marker')
+  end
+
+  def test_undefined_entries_are_ignored_in_scan
+    run_calculator('3.0')
+    # 全版 {: undef} の undefmeth は presence ゼロ → 何も書かれない
+    e = find_entry('3.0', 'i', 'undefmeth')
+    assert_equal :undefined, e.kind
+    assert_nil e.since_of('undefmeth')
+    assert_nil e.until_of('undefmeth')
+    # 1.8.7 では {: undef}(存在しない印)なので presence に数えず、実メソッド化
+    # した 2.0.0 が since になる(scan がフィルタしなければ floor 扱いで nil)
+    assert_equal '2.0.0',
+                 find_entry('3.0', 'i', 'undef_then_real').since_of('undef_then_real')
+  end
+
+  def test_undefined_entries_are_ignored_in_apply
+    run_calculator('2.0.0')
+    run_calculator('3.0')
+    # 3.0 で undef 化 → presence は 2.0.0 のみ。2.0.0 の対象では削除扱いで
+    # until が付く
+    at_2_0_0 = find_entry('2.0.0', 'i', 'real_then_undef')
+    assert_equal '2.0.0', at_2_0_0.since_of('real_then_undef')
+    assert_equal '3.0', at_2_0_0.until_of('real_then_undef')
+    # 3.0 の :undefined エントリ自体には(算出値があっても)書き込まない
+    at_3_0 = find_entry('3.0', 'i', 'real_then_undef')
+    assert_equal :undefined, at_3_0.kind
+    assert_nil at_3_0.since_of('real_then_undef')
+    assert_nil at_3_0.until_of('real_then_undef')
+  end
+
+  def test_duplicate_version_in_ladder_raises
+    dbs = ladder_dbs + [fresh_db('2.0.0')]
+    assert_raise(BitClust::UserError) { BitClust::MethodSinceCalculator.new(dbs) }
+  end
+
+  def test_apply_is_idempotent
+    calc = BitClust::MethodSinceCalculator.new(ladder_dbs)
+    calc.scan
+    first_stats = calc.apply(fresh_db('2.0.0'))
+    second_stats = calc.apply(fresh_db('2.0.0'))
+
+    assert_operator first_stats[:since_filled], :>, 0
+    assert_equal 0, second_stats[:since_filled]
+    assert_equal 0, second_stats[:until_filled]
+    assert_equal 0, second_stats[:entries_updated]
+    assert_equal first_stats[:floor_skipped], second_stats[:floor_skipped]
+  end
+
+  def test_author_value_takes_precedence_over_computed_value
+    pre = fresh_db('3.0')
+    entry = pre.get_class('MSCTest').entries.find {|m| m.typechar == 'i' && m.name?('newmeth') } or raise
+    entry.fill_since('newmeth', '1.9.9')
+    entry.save
+
+    calc = BitClust::MethodSinceCalculator.new(ladder_dbs)
+    calc.scan
+    calc.apply(fresh_db('3.0'))
+
+    assert_equal '1.9.9', find_entry('3.0', 'i', 'newmeth').since_of('newmeth')
+  end
+
+  def test_apply_rejects_target_whose_version_is_not_in_ladder
+    build_db('4.0')
+    calc = BitClust::MethodSinceCalculator.new(ladder_dbs)
+    calc.scan
+    assert_raise(BitClust::UserError) { calc.apply(fresh_db('4.0')) }
+  end
+
+  private
+
+  def build_db(version)
+    root = "#{@tmpdir}/tree-#{version}/refm/api/src"
+    FileUtils.mkdir_p("#{root}/_builtin")
+    File.write("#{root}/LIBRARIES", "_builtin\n")
+    File.write("#{root}/_builtin.rd", RD)
+    prefix = "#{@tmpdir}/db-#{version}"
+    db = BitClust::MethodDatabase.new(prefix)
+    db.init
+    db.transaction do
+      db.propset('version', version)
+      db.propset('encoding', 'utf-8')
+    end
+    db.transaction do
+      db.update_by_stdlibtree(root)
+    end
+    @paths[version] = prefix
+    prefix
+  end
+
+  def fresh_db(version)
+    BitClust::MethodDatabase.new(@paths[version] || raise("no such db: #{version}"))
+  end
+
+  def ladder_dbs
+    LADDER_VERSIONS.map {|v| fresh_db(v) }
+  end
+
+  def run_calculator(target_version)
+    calc = BitClust::MethodSinceCalculator.new(ladder_dbs)
+    calc.scan
+    calc.apply(fresh_db(target_version))
+  end
+
+  def find_entry(version, typechar, name)
+    fresh_db(version).get_class('MSCTest').entries.find {|m|
+      m.typechar == typechar && m.name?(name)
+    }
+  end
+end

--- a/test/test_methodentry.rb
+++ b/test/test_methodentry.rb
@@ -1,5 +1,8 @@
 require 'test/unit'
 require 'bitclust'
+require 'bitclust/methoddatabase'
+require 'tmpdir'
+require 'fileutils'
 
 class TestMethodEntryTitleLabels < Test::Unit::TestCase
   def test_title_labels_matches_label_when_no_alias
@@ -63,5 +66,151 @@ HERE
     m = db.get_method(BitClust::MethodSpec.parse('Kernel$stdout'))
     assert_equal(['$stdout'], m.title_labels)
     assert_equal(m.label, m.title_labels.join(', '))
+  end
+end
+
+# メソッド名別の since/until (bitclust#132 P1)。
+#
+# テストリスト:
+# [x] 新規エントリの since_map/until_map は空、since_of/until_of は nil
+# [x] fill_since は初回のみ追加して true を返す。既に値があれば false で上書きしない
+# [x] fill_until も同様
+# [x] fill_since/fill_until は version に '=' や ',' を含むと ArgumentError
+# [x] 実ディスク DB への保存→別インスタンスで再読込しても since_of/until_of が一致
+# [x] 名前に '=' を含む（"==", "foo="）・',' を含む（"," ）・"-@" が
+#     エンコード/デコードを経て正しく往復する
+# [x] since_by_name/until_by_name のキー自体がプロパティファイルに無い
+#     （旧DB）場合も落ちずに空配列として読める（Entry の '[String]' デシリアライザの
+#     nil 安全化）
+class TestMethodEntrySinceUntil < Test::Unit::TestCase
+  def setup
+    @dir = Dir.mktmpdir
+    @db = BitClust::MethodDatabase.new(@dir)
+    @db.init
+    @db.transaction do
+      @db.propset('version', '2.0')
+      @db.propset('encoding', 'utf-8')
+    end
+  end
+
+  def teardown
+    FileUtils.rm_rf(@dir)
+  end
+
+  def test_defaults_are_empty
+    m = build_entry('marker')
+    assert_equal({}, m.since_map)
+    assert_equal({}, m.until_map)
+    assert_nil m.since_of('marker')
+    assert_nil m.until_of('marker')
+  end
+
+  def test_fill_since_adds_once
+    m = build_entry('marker')
+    assert_equal(true, m.fill_since('marker', '2.0'))
+    assert_equal('2.0', m.since_of('marker'))
+    # 既に値があるので上書きされず false
+    assert_equal(false, m.fill_since('marker', '3.0'))
+    assert_equal('2.0', m.since_of('marker'))
+  end
+
+  def test_fill_until_adds_once
+    m = build_entry('marker')
+    assert_equal(true, m.fill_until('marker', '3.0'))
+    assert_equal('3.0', m.until_of('marker'))
+    assert_equal(false, m.fill_until('marker', '4.0'))
+    assert_equal('3.0', m.until_of('marker'))
+  end
+
+  def test_fill_since_rejects_version_with_equal_or_comma
+    m = build_entry('marker')
+    assert_raise(ArgumentError) { m.fill_since('marker', '2.0=1') }
+    assert_raise(ArgumentError) { m.fill_since('marker', '2.0,1') }
+  end
+
+  def test_fill_until_rejects_version_with_equal_or_comma
+    m = build_entry('marker')
+    assert_raise(ArgumentError) { m.fill_until('marker', '2.0=1') }
+    assert_raise(ArgumentError) { m.fill_until('marker', '2.0,1') }
+  end
+
+  def test_roundtrip_through_disk
+    m = build_entry('marker')
+    m.fill_since('marker', '2.0')
+    m.fill_until('marker', '3.0')
+    m.save
+
+    reloaded = reload_entry(m.id)
+    assert_equal('2.0', reloaded.since_of('marker'))
+    assert_equal('3.0', reloaded.until_of('marker'))
+    assert_equal({'marker' => '2.0'}, reloaded.since_map)
+    assert_equal({'marker' => '3.0'}, reloaded.until_map)
+  end
+
+  def test_roundtrip_names_with_special_characters
+    [ '==', 'foo=', '-@', ',' ].each do |name|
+      m = build_entry(name)
+      m.fill_since(name, '2.0')
+      m.save
+
+      reloaded = reload_entry(m.id)
+      assert_equal('2.0', reloaded.since_of(name),
+                   "since_of(#{name.inspect}) should round-trip")
+    end
+  end
+
+  def test_multiple_names_share_one_entry
+    m = build_entry_with_names(['-@', 'dedup'])
+    m.fill_since('-@', '2.0')
+    m.fill_since('dedup', '3.0')
+    m.save
+
+    reloaded = reload_entry(m.id)
+    assert_equal('2.0', reloaded.since_of('-@'))
+    assert_equal('3.0', reloaded.since_of('dedup'))
+    assert_equal({'-@' => '2.0', 'dedup' => '3.0'}, reloaded.since_map)
+  end
+
+  def test_missing_since_by_name_key_is_backward_compatible
+    m = build_entry('old_method')
+    m.save
+    strip_property_line(m.id, 'since_by_name')
+    strip_property_line(m.id, 'until_by_name')
+
+    reloaded = reload_entry(m.id)
+    assert_equal([], reloaded.since_by_name)
+    assert_equal([], reloaded.until_by_name)
+    assert_nil reloaded.since_of('old_method')
+  end
+
+  private
+
+  def build_entry(name)
+    build_entry_with_names([name])
+  end
+
+  def build_entry_with_names(names)
+    id = BitClust::NameUtils.build_method_id('_builtin', 'Foo', :instance_method, names.first)
+    m = BitClust::MethodEntry.new(@db, id)
+    m.names = names
+    m.visibility = :public
+    m.kind = :defined
+    m.source = "説明\n"
+    m
+  end
+
+  def reload_entry(id)
+    fresh_db = BitClust::MethodDatabase.new(@dir)
+    BitClust::MethodEntry.new(fresh_db, id)
+  end
+
+  def property_file_path(id)
+    File.join(@dir, BitClust::NameUtils.encodeid("method/#{id}"))
+  end
+
+  def strip_property_line(id, key)
+    path = property_file_path(id)
+    lines = File.readlines(path).reject {|l| l.start_with?("#{key}=") }
+    File.write(path, lines.join)
   end
 end

--- a/test/test_methodsince_command.rb
+++ b/test/test_methodsince_command.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'bitclust'
+require 'bitclust/methoddatabase'
+require 'bitclust/subcommands/methodsince_command'
+require 'stringio'
+require 'tmpdir'
+require 'fileutils'
+
+# methodsince サブコマンド(bitclust#132 P2)。
+#
+# テストリスト:
+# [x] グローバル --database 不要(needs_database? が false)
+# [x] --update が無いとエラー
+# [x] ラダー DB を走査して --update 対象に since/until が書き込まれる
+#     (フロアのメソッドには付かず、ゲート付きメソッドには付く)
+# [x] 統計行が "basename (version V): entries_updated=.. since_filled=..
+#     until_filled=.. floor_skipped=.." の形式で出力される
+# [x] --update は複数指定でき、対象ごとに統計行が出力される
+# [x] --update に無い位置引数の DB はラダーには参加するが書き込まれない
+# [x] --dry-run は統計を表示するだけで実DBファイルには一切書き込まない
+# [x] Runner に登録されている(bitclust methodsince として呼べる)
+class TestMethodsinceCommand < Test::Unit::TestCase
+  def setup
+    @tmpdir = "methodsince_test_tmp"
+    FileUtils.rm_rf(@tmpdir)
+    @db10 = build_db('1.0', <<~'RD')
+      description
+
+      = class Foo < Object
+      == Instance Methods
+      --- old
+
+      説明
+    RD
+    @db20 = build_db('2.0', <<~'RD')
+      description
+
+      = class Foo < Object
+      == Instance Methods
+      --- old
+
+      説明
+
+      #@since 2.0
+      --- newone
+
+      説明
+      #@end
+    RD
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def build_db(version, builtin_rd)
+    root = "#{@tmpdir}/tree-#{version}/refm/api/src"
+    FileUtils.mkdir_p("#{root}/_builtin")
+    File.write("#{root}/LIBRARIES", "_builtin\n")
+    File.write("#{root}/_builtin.rd", builtin_rd)
+    prefix = "#{@tmpdir}/db-#{version}"
+    db = BitClust::MethodDatabase.new(prefix)
+    db.init
+    db.transaction do
+      db.propset('version', version)
+      db.propset('encoding', 'utf-8')
+    end
+    db.transaction do
+      db.update_by_stdlibtree(root)
+    end
+    prefix
+  end
+
+  def run_command(argv)
+    cmd = BitClust::Subcommands::MethodsinceCommand.new
+    cmd.parse(argv)
+    out = StringIO.new
+    orig_stdout = $stdout
+    $stdout = out
+    begin
+      cmd.exec(argv, { prefix: nil, capi: false })
+    ensure
+      $stdout = orig_stdout
+    end
+    out.string
+  end
+
+  def find_entry(prefix, name)
+    db = BitClust::MethodDatabase.new(prefix)
+    db.get_class('Foo').entries.find {|m| m.name?(name) }
+  end
+
+  def test_needs_no_global_database_option
+    cmd = BitClust::Subcommands::MethodsinceCommand.new
+    assert_false cmd.needs_database?
+  end
+
+  def test_no_update_is_an_error
+    cmd = BitClust::Subcommands::MethodsinceCommand.new
+    argv = [@db10, @db20]
+    cmd.parse(argv)
+    assert_raise(SystemExit) do
+      capture_stderr { cmd.exec(argv, { prefix: nil, capi: false }) }
+    end
+  end
+
+  def test_fills_since_into_update_target
+    run_command([@db10, "--update=#{@db20}"])
+    assert_nil find_entry(@db20, 'old').since_of('old')
+    assert_equal '2.0', find_entry(@db20, 'newone').since_of('newone')
+  end
+
+  def test_prints_one_stats_line_per_target
+    out = run_command([@db10, "--update=#{@db20}"])
+    assert_match(
+      /\Adb-2\.0 \(version 2\.0\): entries_updated=\d+ since_filled=\d+ until_filled=\d+ floor_skipped=\d+\n\z/,
+      out)
+  end
+
+  def test_multiple_update_targets_each_get_a_stats_line
+    out = run_command(["--update=#{@db10}", "--update=#{@db20}"])
+    lines = out.lines
+    assert_equal 2, lines.size
+    assert_match(/\Adb-1\.0 /, lines[0])
+    assert_match(/\Adb-2\.0 /, lines[1])
+  end
+
+  def test_positional_ladder_db_is_not_written_to
+    before = File.read(property_file_path(@db10, 'old'))
+    run_command([@db10, "--update=#{@db20}"])
+    after = File.read(property_file_path(@db10, 'old'))
+    assert_equal before, after
+  end
+
+  def test_dry_run_leaves_real_database_untouched
+    run_command([@db10, "--update=#{@db20}", '--dry-run'])
+    assert_nil find_entry(@db20, 'newone').since_of('newone')
+  end
+
+  def test_dry_run_still_prints_computed_stats
+    out = run_command([@db10, "--update=#{@db20}", '--dry-run'])
+    assert_match(/since_filled=1\b/, out)
+  end
+
+  def test_registered_in_runner
+    require 'bitclust/runner'
+    runner = BitClust::Runner.new
+    runner.prepare
+    subcommands = runner.instance_variable_get(:@subcommands)
+    assert_kind_of(BitClust::Subcommands::MethodsinceCommand, subcommands['methodsince'])
+  end
+
+  private
+
+  def property_file_path(prefix, name)
+    id = BitClust::NameUtils.build_method_id('_builtin', 'Foo', :instance_method, name)
+    File.join(prefix, BitClust::NameUtils.encodeid("method/#{id}"))
+  end
+
+  def capture_stderr
+    orig = $stderr
+    $stderr = StringIO.new
+    yield
+  ensure
+    $stderr = orig
+  end
+end


### PR DESCRIPTION
## 概要

#132 の **P2: 算出サブコマンド**です(P1 のスキーマ PR がベース。**P1 マージ後にレビュー・マージしてください**)。

- `BitClust::MethodSinceCalculator`: バージョンラダー(複数版の DB 群)を横断して presence を集計し、名前ごとの初出版(since)と削除版(until)を算出します
  - 単位は [クラス名, typechar, 生名]。**ライブラリは意図的に無視**(版によって所属ライブラリが変わっても同一メソッドとして union)
  - ラダー最古版から存在する(floor)ものは since を付けない=「不明」(決定事項「floor はバッジ非表示、必要なら `{: since}` で明示」に対応)
  - ラダー最新版にも存在するものは until を付けない。それ以外は最終出現版の**次の**ラダー版を until とする(front matter と同じ半開区間)
  - kind=:undefined(`{: undef}`)のエントリは「存在しない印」として走査・適用の両方で除外。undef 化は削除扱いになり、前の版の対象に until が付きます
  - 書き込みは `fill_since` / `fill_until` 経由なので**既存値(将来 P4 で記録される著者の明示値)を上書きしません**。冪等で、2回目の適用は何も変更しません
- `bitclust methodsince [--update=PATH ...] [--dry-run] <dbpath>...`
  - 位置引数と `--update` のパス全体がラダーを構成し、書き込むのは `--update` の DB だけ(凍結 DB は読み取りのみ=generated-documents#157 の運用と整合)
  - `--dry-run` は一時ディレクトリへの複製に適用して統計だけ表示します
  - 対象ごとに統計1行を出力: `db-3.4 (version 3.4): entries_updated=.. since_filled=.. until_filled=.. floor_skipped=..`
- 想定運用(P5): generated-documents の日次 workflow で全版 DB 生成後・statichtml 前に、db/ の全 17 版をラダーとして現行版(3.0〜4.1)を `--update` に指定して実行

## 検証

- テスト 20 件追加(calculator 11 + サブコマンド 9): floor・`#@since` ゲート・**別名グループの名前別 since**(`-@`=2.0.0 / `dedup`=3.0 に分かれること)・`#@until` の until 付与・singleton/instance の別キー・undef の scan/apply 両側スキップ(フィルタを外すと失敗することをミューテーションで確認済み)・冪等性・著者値優先・重複バージョン検出・dry-run が実ファイル無変更・位置引数 DB がバイト単位で無変更・Runner 登録
- フルスイート 17731 tests / 0 failures・`rbs validate`・`steep check` エラーなし
- 実データスモークテスト: ローカルの凍結 DB 7 版(1.8.7〜2.3.0 + 2.7.0)をラダーに db-2.7.0 の複製へ適用(約1分・3544 エントリ更新)。`String#prepend` → since 1.9.3、`String#length` → floor で付与なし、`String#delete_prefix` → 2.7.0(ローカルに 2.4〜2.6 の DB が無いための想定どおりの過大評価。リモートの全 17 版フルラダーでは 2.5 になります)

refs #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
