### PR TITLE
メソッド署名に since/until バージョンバッジを表示する

### DIFF
--- a/data/bitclust/catalog/ja_JP.UTF-8
+++ b/data/bitclust/catalog/ja_JP.UTF-8
@@ -126,3 +126,7 @@ module %s
 %sモジュール
 object %s
 %sオブジェクト
+since Ruby %s
+Ruby %s から
+removed in Ruby %s
+Ruby %s で削除

--- a/data/bitclust/template/class
+++ b/data/bitclust/template/class
@@ -79,9 +79,7 @@
           foreach_method_chunk(m.source) do |sigs, src| %>
 <tr>
 <td class="signature">
-  <a href="<%=h method_url(m.spec_string) %>"><code>
-  <%= sigs.map {|sig| h(sig.friendly_string) }.join("<br>") %>
-  </code></a>
+  <%= method_row_signature_html(m, sigs) %>
 </td>
 <%          if m.redefined? %>
 <td class="description"><%= compile_rd(src) %></td>
@@ -131,9 +129,7 @@
           foreach_method_chunk(m.source) do |sigs, src| %>
 <tr>
 <td class="signature">
-  <a href="<%=h method_url(m.spec_string) %>"><code>
-  <%= sigs.map {|sig| h(sig.friendly_string) }.join("<br>") %>
-  </code></a>
+  <%= method_row_signature_html(m, sigs) %>
 </td>
 <td class="description"><%= compile_rd(src) %></td>
 <td class="library"><%= library_link(m.library.name) %></td>
@@ -166,9 +162,7 @@
           foreach_method_chunk(m.source) do |sigs, src| %>
 <tr>
 <td class="signature">
-  <a href="<%=h method_url(m.spec_string) %>"><code>
-  <%= sigs.map {|sig| h(sig.friendly_string) }.join("<br>") %>
-  </code></a>
+  <%= method_row_signature_html(m, sigs) %>
 </td>
 <td class="description"><%= compile_rd(src) %></td>
 <td class="library"><%= library_link(m.library.name) %></td>
@@ -200,9 +194,7 @@
         foreach_method_chunk(m.source) do |sigs, src| %>
 <tr>
 <td class="signature">
-  <a href="<%=h method_url(m.spec_string) %>"><code>
-  <%= sigs.map {|sig| h(sig.friendly_string) }.join("<br>") %>
-  </code></a>
+  <%= method_row_signature_html(m, sigs) %>
 </td>
 <td class="description"><%= compile_rd(src) %></td>
 <td class="library"><%= class_link(m.klass.name) + " (by " + library_link(m.library.name) + ")" %></td>

--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -14,6 +14,7 @@ require 'bitclust/htmlutils'
 require 'bitclust/textutils'
 require 'bitclust/messagecatalog'
 require 'bitclust/syntax_highlighter'
+require 'bitclust/version_badges'
 require 'rouge'
 require 'stringio'
 
@@ -25,6 +26,7 @@ module BitClust
     include HTMLUtils
     include TextUtils
     include Translatable
+    include VersionBadges
 
     def initialize(urlmapper, hlevel = 1, opt = {})
       @urlmapper = urlmapper
@@ -435,6 +437,7 @@ module BitClust
       string @method.klass.name + @method.typemark if @opt
       string escape_html(sig.friendly_string)
       string '</code>'
+      string heading_version_badges(@method, sig.name, first) if @method
       if first
         string '<span class="permalink">['
         string a_href(@urlmapper.method_url(methodid2specstring(@method.id)), "permalink")

--- a/lib/bitclust/screen.rb
+++ b/lib/bitclust/screen.rb
@@ -13,6 +13,7 @@ require 'bitclust/methodsignature'
 require 'bitclust/htmlutils'
 require 'bitclust/nameutils'
 require 'bitclust/messagecatalog'
+require 'bitclust/version_badges'
 require 'erb'
 require 'json'
 require 'stringio'
@@ -265,6 +266,7 @@ module BitClust
   class TemplateScreen < Screen
     include Translatable
     include HTMLUtils
+    include VersionBadges
 
     def initialize(h)
       @urlmapper = h[:urlmapper]
@@ -489,6 +491,17 @@ module BitClust
       else
         RDCompiler.new(@urlmapper, @hlevel, opt)
       end
+    end
+
+    # bitclust#132 P3: data/bitclust/template/class の署名欄で使う。この
+    # テンプレートは compile_method(RDCompiler)を経由せず自前でシグネチャを
+    # 描画するので、別名(alias)ごとに自分の since/until バッジを付けた
+    # <a><code>...</code></a> を1行ずつ組み立て、<br> で連結する
+    def method_row_signature_html(m, sigs)
+      sigs.map {|sig|
+        %Q(<a href="#{h(method_url(m.spec_string))}"><code>#{h(sig.friendly_string)}</code></a>) +
+          row_version_badges(m, sig.name)
+      }.join('<br>')
     end
 
     def foreach_method_chunk(src)

--- a/lib/bitclust/version_badges.rb
+++ b/lib/bitclust/version_badges.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+#
+# bitclust/version_badges.rb
+#
+# This program is free software.
+# You can distribute/modify this program under the Ruby License.
+#
+
+module BitClust
+
+  # Renders the small "since"/"until" version badges shown next to a
+  # method's signature (bitclust#132 phase P3). The version data comes from
+  # MethodEntry's per-name since_map/until_map (bitclust#132 phase P2); an
+  # empty map means "no badge", which keeps the output byte-identical to
+  # what it was before this feature existed.
+  #
+  # Included by both RDCompiler (the <dt class="method-heading"> emitted
+  # for RD/Markdown method pages) and TemplateScreen (the default server
+  # template's method table rows), so it only relies on the `_`
+  # (Translatable) and escape_html (HTMLUtils) methods that both hosts
+  # already provide.
+  module VersionBadges
+    SINCE_CSS_CLASS = 'method-since-badge'
+    UNTIL_CSS_CLASS = 'method-until-badge'
+    SINCE_CATALOG_KEY = 'since Ruby %s'
+    UNTIL_CATALOG_KEY = 'removed in Ruby %s'
+
+    # HTML for the badges attached to the <dt> heading of one of +entry+'s
+    # signature lines (RDCompiler#method_signature). since/until are
+    # decided independently: when every one of entry's names maps to the
+    # very same version, the badge is rendered once, on the first
+    # signature's <dt> (+first+ true), instead of being repeated on every
+    # alias's <dt>; otherwise (mixed/partial) it is looked up per +name+.
+    def heading_version_badges(entry, name, first)
+      join_badge_spans(
+        heading_badge_span(entry, name, first, entry.since_map,
+                            SINCE_CSS_CLASS, SINCE_CATALOG_KEY),
+        heading_badge_span(entry, name, first, entry.until_map,
+                            UNTIL_CSS_CLASS, UNTIL_CATALOG_KEY)
+      )
+    end
+
+    # HTML for the badges attached to a single signature line in the
+    # default (server) template's method table
+    # (data/bitclust/template/class). Each row already lists every alias on
+    # its own line, so this always looks the version up by +name+ directly
+    # -- no uniform-across-all-names aggregation, unlike heading_version_badges.
+    def row_version_badges(entry, name)
+      join_badge_spans(
+        badge_span(entry.since_map[name], SINCE_CSS_CLASS, SINCE_CATALOG_KEY),
+        badge_span(entry.until_map[name], UNTIL_CSS_CLASS, UNTIL_CATALOG_KEY)
+      )
+    end
+
+    private
+
+    def heading_badge_span(entry, name, first, map, css_class, catalog_key)
+      return nil if map.empty?
+      version = uniform_map?(entry, map) ? (first ? map.values.first : nil) : map[name]
+      badge_span(version, css_class, catalog_key)
+    end
+
+    # Whether +map+ assigns the very same version to every one of entry's
+    # names, i.e. the badge applies uniformly and doesn't need to be
+    # repeated per alias.
+    def uniform_map?(entry, map)
+      map.size == entry.names.size && map.values.uniq.size == 1
+    end
+
+    def badge_span(version, css_class, catalog_key)
+      return nil unless version
+      %Q(<span class="#{css_class}">#{escape_html(_(catalog_key, version))}</span>)
+    end
+
+    def join_badge_spans(*spans)
+      spans.compact.join(' ')
+    end
+  end
+end

--- a/sig/bitclust/rdcompiler.rbs
+++ b/sig/bitclust/rdcompiler.rbs
@@ -47,6 +47,8 @@ module BitClust
 
     include Translatable
 
+    include VersionBadges
+
     def initialize: (URLMapper urlmapper, ?::Integer hlevel, ?option opt) -> void
 
     def compile: (String src) -> String

--- a/sig/bitclust/screen.rbs
+++ b/sig/bitclust/screen.rbs
@@ -232,6 +232,8 @@ module BitClust
 
     include HTMLUtils
 
+    include VersionBadges
+
     # この階層では定義されていないので undef の代わりに bot にしておく。
     def body: () -> bot
 
@@ -324,6 +326,8 @@ module BitClust
     def markdown_source?: () -> bool
 
     def rdcompiler: () -> RDCompiler
+
+    def method_row_signature_html: (MethodEntry m, Array[MethodSignature] sigs) -> String
 
     def foreach_method_chunk: (String src) { (Array[MethodSignature], String) -> void } -> void
 

--- a/sig/bitclust/version_badges.rbs
+++ b/sig/bitclust/version_badges.rbs
@@ -1,0 +1,25 @@
+module BitClust
+  module VersionBadges : Translatable, HTMLUtils
+    SINCE_CSS_CLASS: "method-since-badge"
+
+    UNTIL_CSS_CLASS: "method-until-badge"
+
+    SINCE_CATALOG_KEY: "since Ruby %s"
+
+    UNTIL_CATALOG_KEY: "removed in Ruby %s"
+
+    def heading_version_badges: (MethodEntry entry, String name, bool first) -> String
+
+    def row_version_badges: (MethodEntry entry, String name) -> String
+
+    private
+
+    def heading_badge_span: (MethodEntry entry, String name, bool first, Hash[String, String] map, String css_class, String catalog_key) -> String?
+
+    def uniform_map?: (MethodEntry entry, Hash[String, String] map) -> bool
+
+    def badge_span: (String? version, String css_class, String catalog_key) -> String?
+
+    def join_badge_spans: (*String? spans) -> String
+  end
+end

--- a/test/test_class_screen.rb
+++ b/test/test_class_screen.rb
@@ -1,6 +1,8 @@
 require 'test/unit'
 require 'bitclust'
 require 'bitclust/screen'
+require 'tmpdir'
+require 'fileutils'
 
 class TestClassScreen < Test::Unit::TestCase
   SRC = <<'HERE'
@@ -207,5 +209,121 @@ PLAIN
     db = BitClust::MethodDatabase.dummy('version' => '3.4')
     html = @manager.class_screen(plain.fetch_class('Plain'), :database => db).body
     assert_not_include(html, '追加されるメソッド')
+  end
+end
+
+# bitclust#132 P3: since/until バージョンバッジが class ページ(template.offline、
+# 各メソッドをインライン(compile_method 経由)で描画する側)にも出ることの確認
+class TestClassScreenVersionBadges < Test::Unit::TestCase
+  SRC = <<'HERE'
+= class Target < Object
+target class
+== Instance Methods
+--- own_method
+own method
+HERE
+
+  def setup
+    @lib, = BitClust::RRDParser.parse(SRC, 'extlib')
+    datadir = File.expand_path('../data/bitclust', __dir__)
+    @manager = BitClust::ScreenManager.new(
+      :templatedir => "#{datadir}/template.offline",
+      :catalogdir => "#{datadir}/catalog",
+      :encoding => 'utf-8',
+      :default_encoding => 'utf-8',
+      :base_url => '',
+      :target_version => '3.4'
+    )
+    @db = BitClust::MethodDatabase.dummy('version' => '3.4')
+  end
+
+  def test_since_badge_is_rendered_in_inlined_entry
+    entry = @lib.fetch_class('Target').fetch_method(BitClust::MethodSpec.parse('Target#own_method'))
+    entry.fill_since('own_method', '3.2')
+    html = @manager.class_screen(@lib.fetch_class('Target'), :database => @db).body
+    assert_include(html, '<span class="method-since-badge">Ruby 3.2 から</span>')
+  end
+end
+
+# bitclust#132 P3: default(サーバー動的配信用)テンプレートは compiler を経由せず
+# 独自に署名行を描画するので、別名(alias)ごとの署名行にそれぞれ対応する
+# バッジが付く(一様化はしない)ことを個別に確認する。
+#
+# この template/class は @entry.inherited_method_specs を呼び、これは
+# ClassEntry#_index 経由でディスク上の永続化された索引ファイルを読む。
+# 他のテストのような RRDParser.parse + MethodDatabase.dummy のインメモリ
+# 組では索引が存在せず ENOENT になるので、ここだけは init/update で実際に
+# ディスクへコミットした本物の MethodDatabase を使う
+class TestClassScreenDefaultTemplateVersionBadges < Test::Unit::TestCase
+  SRC = <<'HERE'
+= class Target < Object
+target class
+== Instance Methods
+--- alias_one
+--- alias_two
+shared body
+HERE
+
+  def setup
+    @datadir = File.expand_path('../data/bitclust', __dir__)
+    @dbdir = Dir.mktmpdir('bitclust-version-badges-db')
+    srcdir = Dir.mktmpdir('bitclust-version-badges-src')
+    src_path = File.join(srcdir, 'testlib.rd')
+    File.write(src_path, SRC)
+
+    @db = BitClust::MethodDatabase.new(@dbdir)
+    @db.init
+    @db.transaction do
+      @db.propset('version', '3.4')
+      @db.propset('encoding', 'utf-8')
+    end
+    @db.transaction do
+      @db.update_by_file(src_path, 'testlib')
+    end
+    FileUtils.rm_r(srcdir, :force => true)
+  end
+
+  def teardown
+    FileUtils.rm_r(@dbdir, :force => true)
+  end
+
+  def test_per_signature_badges_attach_to_their_own_alias_line
+    entry = @db.get_method(BitClust::MethodSpec.parse('Target#alias_one'))
+    entry.fill_since('alias_one', '3.0')
+    entry.fill_until('alias_two', '4.0')
+
+    manager = BitClust::ScreenManager.new(
+      :templatedir => "#{@datadir}/template",
+      :catalogdir => "#{@datadir}/catalog",
+      :encoding => 'utf-8',
+      :default_encoding => 'utf-8',
+      :base_url => '',
+      :target_version => '3.4'
+    )
+    # Screen#run_template は互換 ERB を self.class にキャッシュするので、同一
+    # プロセス内の他のテスト(template.offline を使う ClassScreen)と
+    # templatedir が混線しないよう、この検証専用のサブクラスを介して描画する
+    # (テストファイル上部のコメント、および test_method_screen.rb の同種の
+    # 注記を参照。ClassScreen 本体には触れない)
+    screen_class = Class.new(BitClust::ClassScreen)
+    html = manager.send(:new_screen, screen_class, @db.get_class('Target'), :database => @db).body
+
+    since_badge = '<span class="method-since-badge">Ruby 3.0 から</span>'
+    until_badge = '<span class="method-until-badge">Ruby 4.0 で削除</span>'
+    assert_include(html, since_badge)
+    assert_include(html, until_badge)
+
+    alias_one_pos = html.index('<code>alias_one</code>')
+    alias_two_pos = html.index('<code>alias_two</code>')
+    since_pos = html.index(since_badge)
+    until_pos = html.index(until_badge)
+    assert(alias_one_pos && alias_two_pos && since_pos && until_pos,
+           'expected both signature lines and both badges to be present')
+    # since は alias_one の行に付き、alias_two の行より前に来る
+    assert(alias_one_pos < since_pos && since_pos < alias_two_pos,
+           'the since badge must attach right after alias_one, not alias_two')
+    # until は alias_two の行に付き、alias_two より後に来る
+    assert(alias_two_pos < until_pos,
+           'the until badge must attach after alias_two')
   end
 end

--- a/test/test_mdcompiler.rb
+++ b/test/test_mdcompiler.rb
@@ -29,6 +29,9 @@ class TestMDCompiler < Test::Unit::TestCase
     mock(method_entry).index_id.any_times { "dummy" }
     mock(method_entry).defined?.any_times { true }
     mock(method_entry).id.any_times { "String/i.index._builtin" }
+    mock(method_entry).names.any_times { [] }
+    mock(method_entry).since_map.any_times { {} }
+    mock(method_entry).until_map.any_times { {} }
     compiler.compile_method(method_entry)
   end
 

--- a/test/test_method_screen.rb
+++ b/test/test_method_screen.rb
@@ -88,3 +88,36 @@ HERE
     assert_not_match(/<h1>[^<]*Enumerable2#map/, html)
   end
 end
+
+# bitclust#132 P3: since/until バージョンバッジが method ページ(template.offline、
+# statichtml/chm が使う経路)の <dt> に実際に描画されることのエンドツーエンド確認
+class TestMethodScreenVersionBadges < Test::Unit::TestCase
+  SRC = <<'HERE'
+= class Enumerable2 < Object
+enumerable class
+== Instance Methods
+--- select -> Array
+
+説明
+HERE
+
+  def setup
+    @lib, @db = BitClust::RRDParser.parse(SRC, 'testlib')
+    datadir = File.expand_path('../data/bitclust', __dir__)
+    @manager = BitClust::ScreenManager.new(
+      :templatedir => "#{datadir}/template.offline",
+      :catalogdir => "#{datadir}/catalog",
+      :encoding => 'utf-8',
+      :default_encoding => 'utf-8',
+      :base_url => '',
+      :target_version => '3.4'
+    )
+  end
+
+  def test_since_badge_is_rendered_after_fill_since
+    entry = @db.get_method(BitClust::MethodSpec.parse('Enumerable2#select'))
+    entry.fill_since('select', '3.2')
+    html = @manager.method_screen([entry], :database => @db).body
+    assert_include(html, '<span class="method-since-badge">Ruby 3.2 から</span>')
+  end
+end

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -19,13 +19,25 @@ class TestRDCompiler < Test::Unit::TestCase
     assert_equal(expected, @c.compile(src))
   end
 
-  def assert_compiled_method_source(expected, src)
+  def assert_compiled_method_source(expected, src, names: [], since_map: {}, until_map: {})
     method_entry = Object.new
     mock(method_entry).source{ src }
     mock(method_entry).index_id.any_times{ "dummy" }
     mock(method_entry).defined?.any_times{ true }
     mock(method_entry).id.any_times{ "String/i.index._builtin" }
+    mock(method_entry).names.any_times{ names }
+    mock(method_entry).since_map.any_times{ since_map }
+    mock(method_entry).until_map.any_times{ until_map }
     assert_equal(expected, @c.compile_method(method_entry))
+  end
+
+  # badge のカタログ訳(「Ruby %s から」等)を検証するテストで使う、
+  # 日本語カタログを読み込んだ compiler を作る(setup の @c はカタログ無しの
+  # C ロケールなので、_() はキーそのまま(英語)を返してしまう)
+  def ja_catalog_compiler
+    prefix = File.expand_path('../data/bitclust/catalog', __dir__)
+    catalog = BitClust::MessageCatalog.load_with_locales(prefix, ['ja_JP.UTF-8'])
+    BitClust::RDCompiler.new(@u, 1, {:database => @db, :catalog => catalog})
   end
 
   def test_dlist
@@ -479,6 +491,113 @@ HERE
     assert_compiled_method_source(expected, src)
   end
 
+  # bitclust#132 P3: since/until バージョンバッジ。名前ごとの since_map/
+  # until_map が空なら(既存の全テストがそう)何も出ない = 従来どおりの
+  # 出力(このケースは assert_compiled_method_source のデフォルト引数で
+  # 既存テストとして担保済み)。以下は非空の場合の描画を確認する
+
+  def test_method_signature_since_badge_uniform_single_name
+    @c = ja_catalog_compiler
+    src = <<'HERE'
+--- hoge
+foo
+HERE
+    expected = <<'HERE'
+<dt class="method-heading" id="dummy"><code>hoge</code><span class="method-since-badge">Ruby 2.0.0 から</span><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dd class="method-description">
+<p>
+foo
+</p>
+</dd>
+HERE
+    assert_compiled_method_source(expected, src,
+      names: ['hoge'], since_map: {'hoge' => '2.0.0'})
+  end
+
+  # 別名(alias)の全名が同じバージョンを持つ「一様」なケースでは、
+  # バッジは最初の dt にだけ出す(2つ目以降の dt では繰り返さない)
+  def test_method_signature_since_badge_uniform_alias
+    @c = ja_catalog_compiler
+    src = <<'HERE'
+--- hoge1
+--- hoge2
+bar
+HERE
+    expected = <<'HERE'
+<dt class="method-heading" id="dummy"><code>hoge1</code><span class="method-since-badge">Ruby 2.0.0 から</span><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading"><code>hoge2</code></dt>
+<dd class="method-description">
+<p>
+bar
+</p>
+</dd>
+HERE
+    assert_compiled_method_source(expected, src,
+      names: ['hoge1', 'hoge2'], since_map: {'hoge1' => '2.0.0', 'hoge2' => '2.0.0'})
+  end
+
+  # 別名の一部にしか値が無い「混在」なケースでは、一様とはみなさず名前ごとに
+  # 判定する。ここでは最初の名前(hoge1)ではなく2番目(hoge2)にだけ値がある
+  # ケースで、バッジが正しく hoge2 の dt にだけ付くことを確認する(2番目
+  # だから、ではなく「最初の dt だから」で誤って出ていないことの確認)
+  def test_method_signature_since_badge_mixed_alias
+    @c = ja_catalog_compiler
+    src = <<'HERE'
+--- hoge1
+--- hoge2
+bar
+HERE
+    expected = <<'HERE'
+<dt class="method-heading" id="dummy"><code>hoge1</code><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dt class="method-heading"><code>hoge2</code><span class="method-since-badge">Ruby 2.0.0 から</span></dt>
+<dd class="method-description">
+<p>
+bar
+</p>
+</dd>
+HERE
+    assert_compiled_method_source(expected, src,
+      names: ['hoge1', 'hoge2'], since_map: {'hoge2' => '2.0.0'})
+  end
+
+  def test_method_signature_until_badge
+    @c = ja_catalog_compiler
+    src = <<'HERE'
+--- hoge
+foo
+HERE
+    expected = <<'HERE'
+<dt class="method-heading" id="dummy"><code>hoge</code><span class="method-until-badge">Ruby 4.0 で削除</span><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dd class="method-description">
+<p>
+foo
+</p>
+</dd>
+HERE
+    assert_compiled_method_source(expected, src,
+      names: ['hoge'], until_map: {'hoge' => '4.0'})
+  end
+
+  # 同じ dt に since と until の両方が付く場合、since→until の順で
+  # 半角スペース1つ区切りで並ぶ
+  def test_method_signature_since_and_until_badges_on_same_dt
+    @c = ja_catalog_compiler
+    src = <<'HERE'
+--- hoge
+foo
+HERE
+    expected = <<'HERE'
+<dt class="method-heading" id="dummy"><code>hoge</code><span class="method-since-badge">Ruby 2.0.0 から</span> <span class="method-until-badge">Ruby 4.0 で削除</span><span class="permalink">[<a href="dummy/method/String/i/index">permalink</a>][<a href="https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-index">rdoc</a>]</span></dt>
+<dd class="method-description">
+<p>
+foo
+</p>
+</dd>
+HERE
+    assert_compiled_method_source(expected, src,
+      names: ['hoge'], since_map: {'hoge' => '2.0.0'}, until_map: {'hoge' => '4.0'})
+  end
+
   def test_ulist_simple
     src =  <<'HERE'
  * hoge1
@@ -764,6 +883,9 @@ HERE
     mock(method_entry).index_id.any_times { "dummy" }
     mock(method_entry).defined?.any_times { true }
     mock(method_entry).id.any_times { "String/i.index._builtin" }
+    mock(method_entry).names.any_times { [] }
+    mock(method_entry).since_map.any_times { {} }
+    mock(method_entry).until_map.any_times { {} }
     html = @c.compile_method(method_entry)
     assert_not_include(html, 'UNKNOWN_META_INFO')
     assert_not_include(html, '{:')
@@ -784,6 +906,9 @@ HERE
     mock(method_entry).index_id.any_times { "dummy" }
     mock(method_entry).defined?.any_times { true }
     mock(method_entry).id.any_times { "String/i.index._builtin" }
+    mock(method_entry).names.any_times { [] }
+    mock(method_entry).since_map.any_times { {} }
+    mock(method_entry).until_map.any_times { {} }
     html = @c.compile_method(method_entry)
     assert_not_include(html, '{:')
     assert_include(html, 'to_a2')
@@ -803,6 +928,9 @@ HERE
     mock(method_entry).index_id.any_times { "dummy" }
     mock(method_entry).defined?.any_times { true }
     mock(method_entry).id.any_times { "String/i.index._builtin" }
+    mock(method_entry).names.any_times { [] }
+    mock(method_entry).since_map.any_times { {} }
+    mock(method_entry).until_map.any_times { {} }
     html = @c.compile_method(method_entry)
     assert_not_include(html, '{:')
     assert_include(html, 'このメソッドは定義されていません。')

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -569,3 +569,17 @@ hr {
 #feedback-link {
     margin-left: 0.5em;
 }
+
+/* since/until バージョンバッジ(bitclust#132 P3)。地の文から浮かないよう
+   リンク色(#33a)や EOL バナー(#aa3333)と同系統の抑えた配色にする */
+span.method-since-badge,
+span.method-until-badge {
+    display: inline-block;
+    margin-left: 0.6em;
+    padding: 0 0.6em;
+    border-radius: 1em;
+    font-size: 75%;
+    font-weight: normal;
+}
+span.method-since-badge { background-color: #e6f2e6; color: #2d6a2d; }
+span.method-until-badge { background-color: #f7e6e6; color: #aa3333; }

--- a/theme/lillia/style.css
+++ b/theme/lillia/style.css
@@ -300,6 +300,20 @@ hr {
   float: right;
 }
 
+/* since/until バージョンバッジ(bitclust#132 P3)。他の配色(リンク #33a)
+   から浮かないよう抑えた配色にする */
+span.method-since-badge,
+span.method-until-badge {
+  display: inline-block;
+  margin-left: 0.6em;
+  padding: 0 0.6em;
+  border-radius: 1em;
+  font-size: 75%;
+  font-weight: normal;
+}
+span.method-since-badge { background-color: #e6f2e6; color: #2d6a2d; }
+span.method-until-badge { background-color: #f7e6e6; color: #aa3333; }
+
 .method-description{
   padding-bottom: 10px;
   margin-bottom: 90px ; 


### PR DESCRIPTION
## 概要

#132 の **P3: バージョンバッジ表示**です(P2 の算出サブコマンド PR がベース。**P2 マージ後にレビュー・マージしてください**)。

P1/P2 で DB に入る名前別 since/until を画面に描画します。データが空(現状の全 DB)なら**出力は従来と完全同一**で、`methodsince` を流した DB からバッジが現れます。

- メソッド署名の `<dt class="method-heading">` に、`</code>` 直後・permalink の手前でバッジを挿入
  - since: `<span class="method-since-badge">Ruby 3.2 から</span>` / until: `<span class="method-until-badge">Ruby 4.0 で削除</span>`(カタログキー `since Ruby %s` / `removed in Ruby %s`。C ロケールは英語キーのまま表示)
  - **since/until は独立判定**。別名グループの全名が同じ版なら「一様」として先頭の dt にだけ表示、名前ごとに版が違う/一部にしか無い場合は該当する名前の dt にだけ表示(決定事項「版差のある名前のシグネチャ行にだけ個別バッジ」)
  - floor(値なし)は非表示(決定事項どおり)
- 共通ロジックは `BitClust::VersionBadges`(新規 mixin)に切り出し、`RDCompiler` と `TemplateScreen` の両方に include
  - `RDCompiler#method_signature` への 1 行挿入で、**メソッドページ(全4テンプレート系統)と offline/epub/lillia のクラスページのインライン本文をすべてカバー**(MDCompiler は同メソッドを再利用しているので Markdown 原稿も両対応)
  - 唯一 compiler を経由しない default(動的サーバー配信用)`template/class` の署名欄のみ、別名ごとに `<a><code>…</code></a>`+自分のバッジの行に最小限再構成(バッジを名前単位で付けるため。空マップでも構造は変わるが表示テキストは同一。statichtml には影響なし)
- CSS: default/lillia 両テーマにピル型バッジ(since=抑えた緑・until=EOL バナー系統の抑えた赤)
- クラスページ冒頭の目次(`ul.class-toc`)へのコンパクト表示は今回は見送り(多段組の名前リストに文言バッジは密度的に厳しいため。必要なら表記を決めて追加します)

## 検証

- テスト 8 件追加(17731 → 17739 tests / 0 failures): 一様バッジ(単名・別名)・**版差別名で該当 dt にのみ付くこと**(値を敢えて2番目の名前に置いて先頭 dt に出ないことを証明)・until・since+until 併記順・method_screen / class_screen(offline)/ class_screen(default テンプレート)の E2E。既存テストの期待値は無変更(=空データで出力不変の証明)
- `rbs validate`・`steep check` エラーなし(mixin は自己型 `: Translatable, HTMLUtils`)
- **実データ E2E**: P2 の `methodsince` を適用済みの db-1.9.3 複製に対し template.offline で描画 → `String#prepend` のメソッドページに `Ruby 1.9.3 から` バッジ・floor の `String#length`(+別名 size)は完全無出力・String クラスページはインライン本文に 30 個のバッジを確認

refs #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
