### PR TITLE
検索クエリで ?. 記法のモジュール関数指定を受け付ける

### DIFF
--- a/lib/bitclust/simplesearcher.rb
+++ b/lib/bitclust/simplesearcher.rb
@@ -73,10 +73,18 @@ module BitClust
       end
       return pat, nil, nil if /\A[A-Z]\w*\z/ =~ pat
       return nil, '$', $1  if /\$(\S*)/ =~ pat
-      _m, _t, _c = pat.reverse.split(/(::|[\#,]\.|\.[\#,]|[\#\.\,])/, 2)
+      # bitclust#250: "?." is an alternate spelling of the module-function
+      # separator ".#" (Ruby >=4.0 docs display it that way since #277; see
+      # NameUtils.display_typemark). Accept it here regardless of which
+      # Ruby version the query is about -- this is query *input*, not
+      # display, so both notations are always accepted. "?" is added to the
+      # same reversed-pattern alternative that already matches "#." and ",."
+      # (a marker character immediately followed by ".", read in the
+      # reversed pattern), so "?." matches the same way "#." already does.
+      _m, _t, _c = pat.reverse.split(/(::|[\#,]\.|\.[\#,\?]|[\#\.\,])/, 2)
       _m || raise
       c = _c.reverse if _c
-      t = _t.tr(',', '#').sub(/\#\./, '.#') if _t
+      t = _t.tr(',?', '##').sub(/\#\./, '.#') if _t
       m = _m.reverse
       return c, t, m
     end

--- a/test/test_simplesearcher.rb
+++ b/test/test_simplesearcher.rb
@@ -15,6 +15,12 @@ class TestSearcher <  Test::Unit::TestCase
 == Class Methods
 --- bar
 = reopen Kernel
+== Module Functions
+--- open
+
+== Instance Methods
+--- puts
+
 == Special Variables
 --- $spespe
 
@@ -44,5 +50,27 @@ HERE
     }
     assert_equal([], search_pattern(@db, " "), 'space')
     assert_equal([], search_pattern(@db, ""), 'blank')
+  end
+
+  # bitclust#250 follow-up: the dynamic server's /search accepts free-text
+  # queries, and a module function may be typed in either notation --
+  # "Kernel.#open" (bitclust's own internal spec-string form, still what
+  # docs for Ruby < 4.0 display) or "Kernel?.open" (what docs for Ruby >=
+  # 4.0 display since #277). Both must resolve to the same method,
+  # regardless of which notation the *query* uses -- the query parser has
+  # no idea (and shouldn't need to know) which doc version the user is
+  # thinking of.
+  def test_module_function_query_notation
+    [['Kernel?.open', 'open'],  # new (>=4.0 display) notation
+     ['Kernel.#open', 'open'],  # existing (bitclust-internal) notation: regression check
+     ['?.open',       'open'],  # bare module-function marker, no class name
+     ['Kernel#puts',  'puts'],  # instance method: unaffected by the "?." change
+    ].each{|q, expected|
+      ret = search_pattern(@db, q)
+      assert_not_equal([], ret, q)
+      assert_equal(expected, ret[0].name, q)
+    }
+    # Singleton-method dot notation ('Hoge.h' => 'hoge' in test_simple_search
+    # above) is also unaffected; kept there rather than duplicated here.
   end
 end


### PR DESCRIPTION
## 概要

#250 のフォローアップ(rurema/bitclust#277 の PR body に記録した件): **動的 `/search`(SimpleSearcher)**で `?.` 記法のモジュール関数指定を受け付けます(refs #250)。クエリ入力は表示と違い版に紐付かないため、`.#` / `?.` の**両記法を常に受理**する方針です。

- `parse_method_spec_pattern` の逆転文字列正規表現に `?` が無く、`Kernel?.open` は `?` がクラス名側に付いて 0 件でした。`#.`/`,.` と同じ選択肢に `?` を追加し、従来どおり正準形 `.#` へ正規化します
- 回帰確認: `Kernel.#open`・`Kernel#open`・`Kernel.open`・`Kernel::open`・裸の `?.open` は挙動不変

## 静的検索(search_ranker.js)を触らない理由

`search_ranker.js` は Aliki テーマからの **verbatim vendor 方針**のため、本 PR では変更しません。なお調査の過程で、静的検索では**修飾付き検索(`File.open` や `Kernel.#open` など。モジュール関数に限らない)が従来から 0 件**になること(クエリの一律 `.`→`::` 書き換えとインデックスの `full_name` 形式の不一致)が判明したため、vendored 方針下での対応方針も含めて別 issue として起票します。

## 検証

- テスト+1(両記法・裸 `?.`・インスタンスメソッド無影響)= 17788 tests / 0 failures・`rbs validate`・`steep check` クリーン・`rake test:js`(vendored 挙動のベースライン)も green
- スモーク: version=3.4 / 4.0 の各 mini-DB で `Dummy?.mf` / `Dummy.#mf` とも同一ヒット

refs #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)
