### PR TITLE
静的検索の修飾付き検索を search_init 側の拡張で修理する

### DIFF
--- a/lib/bitclust/search_index_generator.rb
+++ b/lib/bitclust/search_index_generator.rb
@@ -8,6 +8,17 @@
 #
 #   { name:, full_name:, type:, path: }
 #
+# Singleton methods and module functions (full_name holding a literal "."/
+# ".#"/"?.", e.g. "File.open", "Kernel.#open", "Kernel?.open" -- see #250)
+# additionally carry a +match_name+: full_name with "?." folded to ".#" and
+# every "." turned into "::". This mirrors the "." -> "::" rewrite the
+# vendored Aliki ranker's parseQuery() applies to the *query* text (RDoc's
+# own full_names use "::" for class methods), so search_init.js/search_page.js
+# can feature-detect-wrap computeScore() to compare like-for-like without
+# ever touching the displayed full_name. See bitclust#279.
+#
+#   { name:, full_name:, type:, path:, match_name: }
+#
 # serialized as a JavaScript assignment so it can be loaded over file://
 # without tripping the browser's CORS check on JSON files:
 #
@@ -137,11 +148,22 @@ module BitClust
             # sigil is the only thing distinguishing it, so keep it in +name+
             # too (not just +full_name+) or a "$;"-style query can't match it.
             name = full_name = tmark + mname
+            result << { name: name, full_name: full_name, type: type, path: path }
           else
             name = mname
             full_name = cname + tmark + mname
+            item = { name: name, full_name: full_name, type: type, path: path } #: entry
+            if tmark.include?('.')
+              # bitclust#279: singleton methods (".") and module functions
+              # (".#"/"?.") keep a literal "." in full_name for display, but
+              # the vendored ranker's parseQuery() rewrites every "." in the
+              # *query* to "::". match_name is the same rewrite applied to
+              # this entry, so the search_init.js/search_page.js computeScore
+              # wrap can compare like-for-like. See the file header comment.
+              item[:match_name] = full_name.gsub('?.', '.#').gsub('.', '::')
+            end
+            result << item
           end
-          result << { name: name, full_name: full_name, type: type, path: path }
         end
       end
       result

--- a/test/js/test_search.mjs
+++ b/test/js/test_search.mjs
@@ -94,6 +94,44 @@ function setupSearchBox(index) {
 
 loadRankerScripts()
 
+// A synthetic index mirroring what SearchIndexGenerator actually emits for
+// dot-qualified class methods/module functions (see search_index_generator.rb
+// and bitclust#279): singleton methods and module functions carry a
+// match_name alongside their literal-dot full_name; everything else doesn't.
+// Kernel.#open/Kernel?.open both appear here (same path, different spelling)
+// the way SearchIndexGenerator.merge's cross-version index can legitimately
+// hold both -- pre-4.0 runs emit ".#", 4.0+ runs emit "?." (bitclust#250),
+// and merge's dedup key includes full_name, so they don't collapse into one.
+const qualifiedIndex = [
+  { name: 'open', full_name: 'File.open', match_name: 'File::open',
+    type: 'class_method', path: 'method/-file/s/open.html' },
+  { name: 'open', full_name: 'Dir.open', match_name: 'Dir::open',
+    type: 'class_method', path: 'method/-dir/s/open.html' },
+  { name: 'open', full_name: 'Kernel.#open', match_name: 'Kernel::#open',
+    type: 'class_method', path: 'method/-kernel/m/open.html' },
+  { name: 'open', full_name: 'Kernel?.open', match_name: 'Kernel::#open',
+    type: 'class_method', path: 'method/-kernel/m/open.html' },
+  { name: 'size', full_name: 'String#size', type: 'instance_method',
+    path: 'method/-string/i/size.html' },
+  { name: 'HTTP', full_name: 'Net::HTTP', type: 'class', path: 'class/-net-2-1http.html' },
+]
+
+// Root-cause check: against the *pristine, unpatched* vendored ranker (no
+// search_init.js has been eval'd yet -- that only happens via setupSearchBox
+// below), every dot-qualified query below misses its own entry outright.
+// parseQuery() rewrites every "." in the query to "::" (RDoc's class-method
+// separator), but these full_names keep a literal "."/".#"/"?." for display,
+// so nothing matches. This is the bug bitclust#279 is about; the assertions
+// further down show it fixed once search_init.js's patch is loaded.
+{
+  assert(search('File.open', qualifiedIndex).length === 0,
+         '(pre-patch) "File.open" matches nothing against the unpatched vendored ranker -- the bug')
+  assert(search('Kernel.#open', qualifiedIndex).length === 0,
+         '(pre-patch) "Kernel.#open" matches nothing against the unpatched vendored ranker -- the bug')
+  assert(search('Kernel?.open', qualifiedIndex).length === 0,
+         '(pre-patch) "Kernel?.open" matches nothing against the unpatched vendored ranker -- the bug')
+}
+
 // A synthetic index: one "heading" entry (the new type this change adds --
 // see rurema/doctree#2352, "defined?/undef/alias don't show up in search")
 // alongside a couple of ordinary entries, to check the new type doesn't
@@ -140,6 +178,133 @@ const index = [
   assert(html.includes('search-type-heading'), 'the result item carries the search-type-heading class')
   assert(html.includes('>section<'), 'the heading badge is labeled "section" via the formatType map')
   assert(html.includes('doc/spec=2fdef.html#defined'), 'the result links straight to the anchored heading')
+}
+
+// --- bitclust#279: qualified-query fix, now that search_init.js's patch is
+// loaded (the setupSearchBox() call above already eval'd it once) ---------
+
+// parseQuery(): "?." folds to ".#" before the vendored "." -> "::" rewrite,
+// and q.original keeps the *real* original text, not the folded one.
+{
+  const q = parseQuery('Kernel?.open')
+  assert(q.normalized === 'kernel::#open', 'parseQuery folds "?." to ".#" before the "." -> "::" rewrite')
+  assert(q.original === 'Kernel?.open', 'parseQuery.original keeps the real original text, not the folded one')
+}
+
+// The three previously-dead queries now match their own entry.
+{
+  const r = search('File.open', qualifiedIndex)
+  assert(r.length === 1 && r[0].full_name === 'File.open',
+         '(post-patch) "File.open" matches File.open, and only File.open (not the Dir.open decoy)')
+}
+{
+  const r = search('Kernel.#open', qualifiedIndex)
+  assert(r.some(e => e.full_name === 'Kernel.#open'), '(post-patch) "Kernel.#open" matches the ".#"-spelled entry')
+  assert(r.some(e => e.full_name === 'Kernel?.open'),
+         '(post-patch) "Kernel.#open" also matches the "?."-spelled entry (cross-notation, bitclust#250)')
+}
+{
+  const r = search('Kernel?.open', qualifiedIndex)
+  assert(r.some(e => e.full_name === 'Kernel.#open'),
+         '(post-patch) "Kernel?.open" also matches the ".#"-spelled entry (cross-notation)')
+  assert(r.some(e => e.full_name === 'Kernel?.open'), '(post-patch) "Kernel?.open" matches the "?."-spelled entry')
+}
+
+// Display safety: the entries search() returns are the *original* qualifiedIndex
+// objects, untouched -- full_name is never rewritten to the "::" match_name form.
+{
+  const r = search('File.open', qualifiedIndex)
+  assert(r.length === 1 && r[0] === qualifiedIndex[0],
+         'the returned entry is the original object (identity), not a patched clone')
+  assert(r.length === 1 && r[0].full_name === 'File.open' && !r[0].full_name.includes('::'),
+         'the returned entry\'s full_name is unchanged ("File.open", not "File::open")')
+}
+
+// Controls: queries that were never affected by the bug keep working.
+{
+  const r = search('String#size', qualifiedIndex)
+  assert(r.length === 1 && r[0].full_name === 'String#size', '"#"-qualified instance-method queries are unaffected')
+}
+{
+  const r = search('Net::HTTP', qualifiedIndex)
+  assert(r.length === 1 && r[0].full_name === 'Net::HTTP', '"::"-qualified constant/namespace queries are unaffected')
+}
+{
+  const r = search('open', qualifiedIndex)
+  assert(r.length === 4, 'the unqualified "open" query still finds all four entries by name, as before')
+}
+
+// End-to-end through the DOM, same as the "defined?" test above: typing a
+// dot-qualified query renders a result whose *displayed* title is the
+// original "File.open" -- proving the match_name substitution never reaches
+// the page (highlightMatch degrades to no inline <em> marks for this query
+// shape, a known/documented limitation -- see the #279 report -- but the
+// text itself must still be exactly right and HTML-escaped normally).
+{
+  const { input, result } = setupSearchBox(qualifiedIndex)
+  input.value = 'File.open'
+  input.dispatch('keyup', { key: 'n' })
+  assert(result.children.length > 0, 'typing "File.open" renders a result (was 0 before the fix)')
+  const html = result.children[0].innerHTML
+  assert(html.includes('>File.open<') || html.includes('File.open</a>') || /File\.open/.test(html),
+         'the rendered result displays the literal "File.open" full_name')
+  assert(!html.includes('File::open'), 'the rendered result never shows the "::" match_name form')
+  assert(html.includes('method/-file/s/open.html'), 'the result links to the right path')
+}
+
+// --- bitclust#279: defensive fallback ------------------------------------
+// search_init.js's parseQuery/computeScore wraps are guarded by
+// `typeof X === 'function'`. Simulate a hypothetical future Aliki ranker
+// that no longer exposes them as bare globals (e.g. hidden inside a
+// closure/module) but still honors the same public SearchRanker contract
+// (new SearchRanker(index), .ready(fn), .find(query)) with its own
+// self-contained matching. Loading search_init.js against that must not
+// throw, and ordinary (unqualified) search must keep working through
+// whatever the "new" ranker provides on its own -- i.e. bitclust#279's
+// enhancement degrades to today's (pre-fix) behavior instead of crashing
+// the whole search box.
+{
+  parseQuery = undefined
+  computeScore = undefined
+  assert(typeof parseQuery !== 'function' && typeof computeScore !== 'function',
+         '(fallback setup) parseQuery/computeScore are hidden, simulating a future closure-based ranker')
+
+  // A closure-hiding stand-in ranker: same public shape as SearchRanker, but
+  // its matching logic never touches globalThis.
+  ;(function() {
+    function stubMatch(entry, normalizedQuery) {
+      return entry.name.toLowerCase().indexOf(normalizedQuery) !== -1
+    }
+    globalThis.SearchRanker = function(idx) {
+      this.index = idx
+      this.handlers = []
+    }
+    globalThis.SearchRanker.prototype.ready = function(fn) { this.handlers.push(fn) }
+    globalThis.SearchRanker.prototype.find = function(query) {
+      const nq = query.toLowerCase()
+      const results = this.index
+        .filter(e => stubMatch(e, nq))
+        .map(e => ({ title: e.full_name, path: e.path, type: e.type }))
+      this.handlers.forEach(fn => fn(results, true))
+    }
+  })()
+
+  let threw = false
+  let box = null
+  try {
+    box = setupSearchBox(qualifiedIndex)
+  } catch (e) {
+    threw = true
+    print('unexpected throw while loading search_init.js: ' + e)
+  }
+  assert(!threw, 'search_init.js does not throw when parseQuery/computeScore are absent from globalThis')
+
+  if (box) {
+    box.input.value = 'open'
+    box.input.dispatch('keyup', { key: 'n' })
+    assert(box.result.children.length > 0,
+           'unqualified search still works end-to-end through the stand-in ranker when the patch cannot attach')
+  }
 }
 
 if (failures > 0) {

--- a/test/test_search_index_generator.rb
+++ b/test/test_search_index_generator.rb
@@ -104,6 +104,98 @@ class TestSearchIndexGenerator < Test::Unit::TestCase
     FileUtils.rm_r([prefix, base], :force => true)
   end
 
+  # bitclust#279: the vendored Aliki search ranker's parseQuery() rewrites
+  # every "." in the *query* to "::" (RDoc's own full_names use "::" for
+  # class methods), but BitClust keeps a literal "."/".#"/"?." in full_name
+  # for singleton methods and module functions. match_name mirrors that same
+  # rewrite on the entry side (folding "?." to ".#" first) so a
+  # search_init.js computeScore wrap can compare like-for-like without ever
+  # touching the displayed full_name. See search_index_generator.rb's header
+  # comment and theme/default/js/search_init.js.
+
+  def test_singleton_method_gets_match_name_with_double_colon
+    index = @gen.build_index(@db)
+    e = find_entry(index, 'Foo.bar')
+    assert_not_nil e
+    assert_equal 'class_method', e[:type]
+    assert_equal 'Foo::bar', e[:match_name]
+  end
+
+  def test_module_function_gets_match_name_with_hash_folded
+    index = @gen.build_index(@db)
+    e = find_entry(index, 'Kernel.#at_exit')
+    assert_not_nil e
+    assert_equal 'Kernel::#at_exit', e[:match_name]
+  end
+
+  def test_module_function_at_4_0_gets_match_name_folding_question_dot
+    # The "?." (4.0+) and ".#" (pre-4.0) spellings of the same module
+    # function must fold to the *same* match_name, so a query typed in
+    # either notation can find an index built from either notation
+    # (bitclust#250's cross-notation case).
+    prefix = 'db_si_40_match'
+    base = 'tree_si_40_match'
+    root = "#{base}/refm/api/src"
+    FileUtils.mkdir_p("#{root}/_builtin")
+    File.write("#{root}/LIBRARIES", "_builtin\n")
+    File.write("#{root}/_builtin.rd", <<~RD)
+      description
+
+      = module Kernel
+      description
+      == Module Functions
+      --- at_exit{ ... } -> Proc
+      aaa
+    RD
+    db = BitClust::MethodDatabase.new(prefix)
+    db.init
+    db.transaction do
+      [%w[version 4.0], %w[encoding utf-8]].each { |k, v| db.propset(k, v) }
+    end
+    db.transaction { db.update_by_stdlibtree(root) }
+
+    index = BitClust::SearchIndexGenerator.new.build_index(db)
+    e = index.find { |x| x[:path] == 'method/-kernel/m/at_exit.html' }
+    assert_not_nil e
+    assert_equal 'Kernel?.at_exit', e[:full_name]
+    assert_equal 'Kernel::#at_exit', e[:match_name]
+  ensure
+    FileUtils.rm_r([prefix, base], :force => true)
+  end
+
+  def test_instance_method_entry_has_no_match_name
+    index = @gen.build_index(@db)
+    e = find_entry(index, 'Foo#foo')
+    assert_not_nil e
+    assert_nil e[:match_name]
+  end
+
+  def test_constant_entry_has_no_match_name
+    index = @gen.build_index(@db)
+    e = find_entry(index, 'Foo::AAA')
+    assert_not_nil e
+    assert_nil e[:match_name]
+  end
+
+  def test_special_variable_entry_has_no_match_name
+    # Guards against a regression of issue #194: "$." already contains a
+    # literal "." (from the sigil-less variable name), so if it picked up a
+    # match_name too, it would collide with the "$"-prefix handling
+    # search_init.js already has (which keeps "$"-queries literal and never
+    # goes through the "." -> "::" rewrite at all).
+    index = @gen.build_index(@db)
+    e = find_entry(index, '$;')
+    assert_not_nil e
+    assert_nil e[:match_name]
+  end
+
+  def test_merge_preserves_match_name
+    e = { name: 'bar', full_name: 'Foo.bar', match_name: 'Foo::bar',
+          type: 'class_method', path: 'method/-foo/s/bar.html' }
+    merged = BitClust::SearchIndexGenerator.merge([['3.4', [e]]])
+    assert_equal 'Foo::bar', merged[0][:match_name]
+  end
+
   def test_constant_entry
     index = @gen.build_index(@db)
     e = find_entry(index, 'Foo::AAA')
@@ -348,6 +440,8 @@ description
 
 = class Foo < Object
 description
+== Singleton Methods
+--- bar
 == Instance Methods
 --- foo
 == Constants

--- a/theme/default/js/search_init.js
+++ b/theme/default/js/search_init.js
@@ -22,15 +22,48 @@
   // never match. Wrap parseQuery so that any "$"-prefixed (special variable)
   // query keeps its literal text and is matched against full_name.
   // See https://github.com/rurema/bitclust/issues/194
+  //
+  // Separately (bitclust#279): BitClust keeps a literal "." in full_name for
+  // singleton methods ("File.open") and ".#"/"?." for module functions
+  // ("Kernel.#open" pre-4.0, "Kernel?.open" 4.0+ — see #250), instead of
+  // RDoc's "::" convention. The same "." -> "::" rewrite above then makes
+  // every one of those dot-qualified queries miss its own entry. Fold "?."
+  // to ".#" here so both module-function spellings collapse to the same
+  // query text before the "." -> "::" rewrite runs; the other half of the
+  // fix (matching against SearchIndexGenerator's match_name instead of
+  // full_name) is the computeScore wrap below.
   if (typeof parseQuery === 'function') {
     var alikiParseQuery = parseQuery;
     parseQuery = function(query) {
-      var q = alikiParseQuery(query);
+      var folded = query.indexOf('?.') === -1 ? query : query.replace(/\?\./g, '.#');
+      var q = alikiParseQuery(folded);
       if (query.charAt(0) === '$') {
         q.normalized = query.toLowerCase();  // undo the "." -> "::" rewrite
         q.matchesFullName = true;            // the "$" sigil lives in full_name
       }
+      q.original = query;  // keep the real original text, not the folded one
       return q;
+    };
+  }
+
+  // bitclust#279 (continued): computeScore() scores a query against
+  // entry.full_name, which — per the comment above — doesn't use "::" the
+  // way parseQuery's rewrite expects. SearchIndexGenerator adds a
+  // match_name to affected entries (full_name with "?." folded to ".#" and
+  // then every "." turned into "::", mirroring parseQuery's own rewrite —
+  // see search_index_generator.rb's header comment). When an entry carries
+  // one, score a shallow clone with full_name swapped to match_name instead
+  // — the original entry object (and its displayed full_name) is never
+  // touched, so this only affects which entries match, not what is shown.
+  // Entries without a match_name (instance methods, constants, classes,
+  // special variables, ...) are scored exactly as before.
+  if (typeof computeScore === 'function') {
+    var alikiComputeScore = computeScore;
+    computeScore = function(entry, q) {
+      if (entry && entry.match_name) {
+        return alikiComputeScore({ name: entry.name, full_name: entry.match_name, type: entry.type }, q);
+      }
+      return alikiComputeScore(entry, q);
     };
   }
 

--- a/theme/default/js/search_page.js
+++ b/theme/default/js/search_page.js
@@ -24,15 +24,36 @@
   // queries literal (no "." -> "::" rewrite) and match them against
   // full_name, where the "$" sigil lives.
   // See https://github.com/rurema/bitclust/issues/194
+  //
+  // Same bitclust#279 handling as search_init.js too: fold "?." to ".#" so
+  // both module-function spellings ("Kernel.#open" pre-4.0, "Kernel?.open"
+  // 4.0+ — see #250) normalize the same way, and score dot-qualified
+  // entries via their match_name (added by SearchIndexGenerator) instead of
+  // full_name, since BitClust keeps a literal "." there for display while
+  // parseQuery's rewrite expects "::". See search_init.js for the full
+  // rationale; SearchIndexGenerator.merge keeps match_name on merged
+  // cross-version entries same as any other field.
   if (typeof parseQuery === 'function') {
     var alikiParseQuery = parseQuery;
     parseQuery = function(query) {
-      var q = alikiParseQuery(query);
+      var folded = query.indexOf('?.') === -1 ? query : query.replace(/\?\./g, '.#');
+      var q = alikiParseQuery(folded);
       if (query.charAt(0) === '$') {
         q.normalized = query.toLowerCase();
         q.matchesFullName = true;
       }
+      q.original = query;
       return q;
+    };
+  }
+
+  if (typeof computeScore === 'function') {
+    var alikiComputeScore = computeScore;
+    computeScore = function(entry, q) {
+      if (entry && entry.match_name) {
+        return alikiComputeScore({ name: entry.name, full_name: entry.match_name, type: entry.type }, q);
+      }
+      return alikiComputeScore(entry, q);
     };
   }
 


### PR DESCRIPTION
## 概要

#279 の選択肢1(rurema 所有の初期化側のみでの対応)を実装しました(refs #279)。**vendored の search_controller.js / search_navigation.js / search_ranker.js は byte 単位で無変更**です(`git diff master` で確認済み)。

- **原因**: vendored の `parseQuery()` はクエリの全ての `.` を `::` に書き換えますが(RDoc の full_name 表記に合わせた挙動)、BitClust の `full_name` はシングルトンメソッド/モジュール関数を `.` / `.#` / `?.` のまま保持するため(#250)、`File.open` などの修飾クエリが自分自身のエントリにすら一致しませんでした
- **対応**:
  - `SearchIndexGenerator` が該当エントリ(typemark に `.` を含むもの)に `match_name`(`?.`→`.#` 畳み込み後、全 `.` を `::` 化= parseQuery の書き換えを鏡写しにした文字列)を追加
  - `search_init.js` / `search_page.js` が、**既存の #194(`$` 対応)と同じ機能検出付きグローバル差し替え**の手法で `parseQuery`(クエリの `?.`→`.#` 畳み込み+`q.original` 復元)と `computeScore`(`match_name` を持つエントリのみ、`full_name` を差し替えた**浅いクローン**を採点)をラップ
  - 元の entry オブジェクトには一切触れないため、**検索結果の表示ラベル(`full_name`)は不変**。`.#`/`?.` は同じ `match_name` に畳まれるため、版をまたいだクロス表記のマッチも成立します
  - フックが将来の上流更新で無くなっていた場合は機能検出により無変更でスキップ(クラッシュせず、従来動作への劣化のみ)

## 検証

- JS(qjs・`rake test:js`): 素の vendored ランカーでのバグ再現テスト+パッチ後の `File.open`・`Kernel.#open`↔`Kernel?.open` クロスマッチ・`String#size`/`open`/`Net::HTTP` の無影響・**返却エントリの同一性(表示安全)**・フォールバック(フック不在スタブでも無事故)まで 29 アサーション。実装前 red → green を確認
- Ruby: `match_name` の生成規則(singleton/モジュール関数のみ付与・instance/定数/特殊変数には付かない・merge 透過)のテスト追加。17794 tests / 0 failures・`rbs validate`・`steep check` クリーン

## 既知の制限

ハイライト(`<em>` 強調)は vendored の `highlightMatch` がそのまま `full_name` を参照するため、修飾クエリでヒットしたエントリは強調なしの平文表示になります(マッチ・順位・表示テキスト自体は正常)。ハイライトまで対応するには vendored 側の変更(fork か上流提案)が必要なため、本 PR では見送りです。

refs #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
