### PR TITLE
meta description の module function 参照も 4.0 以降は ?. で表示する

### DIFF
--- a/lib/bitclust/entry.rb
+++ b/lib/bitclust/entry.rb
@@ -175,11 +175,17 @@ module BitClust
     def description_text(text)
       text = display_text(text)
       return text unless text
+      # module function の ".#" は表示専用なので、DB バージョンが 4.0 以降なら
+      # "?." で表示する(RDCompiler#display_spec と同じ #250/#282 の規則。
+      # ここは可視ページを通さない meta description 用の経路なので、bracket_link
+      # と同じ変換を独立に適用する必要がある。spec・URL・アンカーキーは不変)
+      version = @db&.propget('version')
       text = text.split("\n").map(&:strip).join("\n")
         .gsub(/(\P{ascii})\n(?=\P{ascii})/) { $1 || raise }
         .tr("\n", ' ')
       text.gsub(BracketLink) {|link|
-        ((link[2..-3] || raise).split(':', 2).last || raise).rstrip
+        label = ((link[2..-3] || raise).split(':', 2).last || raise).rstrip
+        label.include?('.#') ? label.sub('.#', NameUtils.display_typemark('.#', version)) : label
       }
     end
     private :description_text

--- a/test/test_methodentry.rb
+++ b/test/test_methodentry.rb
@@ -148,6 +148,39 @@ HERE
   end
 end
 
+# meta description（コンパイラを通さない表示テキスト）内の module function
+# 参照 [[m:Kernel.#mf2]] のラベルも、可視ページの bracket_link と同様に
+# DB バージョン 4.0 以降では "?." で表示する（bitclust#282/#283 の続き。
+# 従来この経路だけ ".#" のまま残っていた）
+class TestMethodEntryDescriptionQdot < Test::Unit::TestCase
+  SRC = <<HERE
+= module Kernel
+
+== Module Functions
+
+--- mf
+
+[[m:Kernel.#mf2]] を参照してください。
+
+--- mf2
+
+説明。
+HERE
+
+  def description(version)
+    _lib, db = BitClust::RRDParser.parse(SRC, 'testlib', {'version' => version})
+    db.get_method(BitClust::MethodSpec.parse('Kernel.#mf')).description
+  end
+
+  def test_meta_description_keeps_dot_hash_before_4_0
+    assert_equal('Kernel.#mf2 を参照してください。', description('3.4'))
+  end
+
+  def test_meta_description_uses_question_dot_at_4_0
+    assert_equal('Kernel?.mf2 を参照してください。', description('4.0'))
+  end
+end
+
 # メソッド名別の since/until (bitclust#132 P1)。
 #
 # テストリスト:


### PR DESCRIPTION
## 概要

`Entry#description_text`(meta description など、コンパイラを通さない表示テキスト)は、`[[m:Kernel.#mf]]` のような module function 参照からラベルを取り出すときに `.#` をそのまま出力していました。

可視ページ側の参照は #282 / #283 で「DB バージョンが 4.0 以降なら `.#` を `?.` で表示する」ようになりましたが、**この meta description 用の経路だけ `.#` のまま残っていました**(rurema/doctree で 4.0 のページの `<meta name="description">` に `ObjectSpace.#_id2ref` のような表記が出ていました)。

## 変更内容

`Entry#description_text` のラベル取り出しで、`RDCompiler#display_spec` と同じく `NameUtils.display_typemark` を使い、バージョン 4.0 以降は `.#` を `?.` に畳んで表示します。

- 表示専用の変換で、spec・URL・アンカーキーなどの識別子は一切変えません(#250/#282 と同じ方針)。
- バージョンは `@db.propget('version')`。不明な場合は従来どおり `.#` のままです。
- `Entry` は `NameUtils` を include していますが、`MethodEntry#display_typemark`(0 引数)が同名で隠すため、`RDCompiler` と同様に `NameUtils.display_typemark(...)` と明示して呼んでいます。

## テスト

`test/test_methodentry.rb` に、description に `[[m:Kernel.#mf2]]` を含むエントリで、3.4 では `Kernel.#mf2`、4.0 では `Kernel?.mf2` になることを確認するテストを追加しました。

- `ruby test/run_test.rb`: 17807 tests, 0 failures, 0 errors
- `bundle exec steep check`: No type error detected
- `bundle exec rake sig`: 差分なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
