### PR TITLE
server のシグネチャ表で複数シグネチャがセルからはみ出すのを修正 (fix #286)

### DIFF
--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -369,8 +369,11 @@ td.signature {
 td.signature a {
     display: block;
     padding: 0.3em;
-    height: 100%;
     box-sizing: border-box;
+}
+
+td.signature a:only-child {
+    height: 100%;
 }
 
 td.description {

--- a/theme/lillia/style.css
+++ b/theme/lillia/style.css
@@ -160,6 +160,9 @@ td.signature a {
     display: block;
     padding: 0.3em;
     width: 95%;
+}
+
+td.signature a:only-child {
     height: 100%;
 }
 


### PR DESCRIPTION
## 概要

bitclust server のクラスページで、`Integer#pow` のように1つのセルに複数シグネチャが入る場合に2個目以降がセルからはみ出す問題を修正します(ご報告のとおり `td.signature a` の `height: 100%` が原因でした)。

## 原因と修正

`height: 100%` は「シグネチャが1つのセルでリンクをセル全面に広げてクリック領域を最大化する」(#177)ために入ったものですが、複数シグネチャは1つの `td` 内に `<a>...<br><a>...` と並ぶため、各リンクがセル高さいっぱいのブロックになり、2個目以降がはみ出していました。

`height: 100%` を `a:only-child` に限定します:

- 複数シグネチャのセルでは `<br>` **要素**が兄弟に挟まるため `:only-child` にならず、はみ出しが解消されます
- 単一シグネチャのセルでは従来どおりセル全面がクリック可能のままです(#177 の意図を維持)
- default / lillia 両テーマとも同じ修正です

## 検証

実 DB(4.1)から server 用テンプレートで Integer のクラスページを描画し、DOM 構造が前提どおりであることを確認しました:

- `pow`: `<a>self ** other ...</a><br><a>pow(other) ...</a><br><a>pow(other, modulo) ...</a>`(→ `:only-child` 不成立)
- `even?`: `<a>even? -> bool</a>` 単独(→ `:only-child` 成立・全面クリック維持)

なお公開サイト(statichtml)は `template.offline` を使いこの CSS を参照しないため、本番への影響はありません(server 専用の修正)。

fix #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)
