### PR TITLE
参照リンク切れを検出する checklink サブコマンドを追加

### DIFF
--- a/lib/bitclust/link_checker.rb
+++ b/lib/bitclust/link_checker.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+#
+# bitclust/link_checker.rb
+#
+# DB 全体を走査して [[c:]]/[[m:]]/[[lib:]]/[[d:]]/[[f:]] 参照の
+# リンク切れを検出する。bitclust の参照リンクは描画時に存在検証されない
+# (URL を文字列変換で組むだけ)ため、壊れた参照は静かにリンク切れになる。
+#
+# 参照の抽出は正規表現の自前スキャンではなく、実際のコンパイル経路
+# (RDCompiler#bracket_link に仕込んだフック @option[:link_checker])で
+# 行う。これにより「描画時に本当にリンクになるものだけ」が対象になり、
+# コードスパン・コードフェンス内の参照風テキストは自然に除外される。
+
+require 'bitclust/compat'
+require 'bitclust/nameutils'
+require 'bitclust/methodid'
+require 'bitclust/exception'
+
+module BitClust
+
+  class LinkChecker
+
+    Finding = Struct.new(:location, :ref, :message)
+
+    # bracket_link が扱う型のうち、DB 外を指すので検証対象外のもの
+    EXTERNAL_TYPES = %w[url man rfc RFC ruby-list ruby-dev ruby-ext
+                        ruby-talk ruby-core feature bug misc].freeze
+
+    def initialize(db, function_database: nil)
+      @db = db
+      @fdb = function_database
+      @findings = [] #: Array[Finding]
+      @current_location = nil #: String?
+      @skipped_function_refs = 0
+    end
+
+    attr_reader :findings
+    attr_reader :skipped_function_refs
+    attr_accessor :current_location
+
+    def broken_count
+      @findings.size
+    end
+
+    # DB 中の全ソース(ライブラリ・クラス・メソッド・doc ページ)を
+    # コンパイルして findings を収集する
+    def check_all
+      @db.libraries.sort_by(&:id).each do |lib|
+        check_source(lib.source_location || "library #{lib.name}") {|c| c.compile(lib.source.to_s) }
+      end
+      @db.classes.sort_by(&:id).each do |klass|
+        check_source(klass.source_location || "class #{klass.name}") {|c| c.compile(klass.source.to_s) }
+        klass.entries.sort_by(&:id).each do |m|
+          check_source(m.source_location || "#{klass.name} #{m.name}") {|c| c.compile_method(m) }
+        end
+      end
+      @db.docs.sort_by(&:id).each do |doc|
+        check_source(doc.source_location || "doc #{doc.name}") {|c| c.compile(doc.source.to_s) }
+      end
+      @findings
+    end
+
+    # RDCompiler#bracket_link から呼ばれるフック。描画には影響しない
+    def note_ref(type, arg)
+      case type
+      when 'c'   then check_class(arg)
+      when 'm'   then check_method(arg)
+      when 'lib' then check_library(arg)
+      when 'd'   then check_doc(arg)
+      when 'f'   then check_function(arg)
+      when 'ref' then check_ref(arg)
+      else
+        unless EXTERNAL_TYPES.include?(type)
+          # 未知の型は bracket_link がリテラル [[...]] のまま出力する。
+          # ほぼ確実に型名の書き間違いなので報告する
+          record(type, arg, 'unknown link type')
+        end
+      end
+      nil
+    end
+
+    private
+
+    def check_source(location)
+      # Location#to_s は行番号不明のとき "path:" になるので末尾の : を落とす
+      @current_location = location.to_s.sub(/:\z/, '')
+      compiler = new_compiler
+      begin
+        yield compiler
+      rescue => err
+        # コンパイル自体の失敗はリンク切れとは別問題(構文エラー等)。
+        # チェックを止めず、報告だけして続行する
+        record('compile', location.to_s, "compile failed: #{err.class}: #{err.message}")
+      end
+    ensure
+      @current_location = nil
+    end
+
+    def new_compiler
+      mapper_conf = Hash.new {|_h, _k| '' } #: untyped
+      urlmapper = URLMapper.new(mapper_conf)
+      opt = { :database => @db, :link_checker => self } #: RDCompiler::option
+      if @db.properties['source_format'] == 'markdown'
+        require 'bitclust/mdcompiler'
+        gfm_opt = opt.merge(:gfm => true) #: RDCompiler::option
+        MDCompiler.new(urlmapper, 1, gfm_opt)
+      else
+        require 'bitclust/rdcompiler'
+        RDCompiler.new(urlmapper, 1, opt)
+      end
+    end
+
+    def check_class(name)
+      @db.fetch_class(name)
+    rescue NotFoundError, InvalidKey
+      record('c', name, 'class not found')
+    end
+
+    def check_method(spec_str)
+      # rdcompiler の complete_spec と同じ補完($~ 等は Kernel の特殊変数)
+      str = spec_str.start_with?('$') ? "Kernel#{spec_str}" : spec_str
+      begin
+        spec = MethodSpec.parse(str)
+      rescue => _err
+        record('m', spec_str, 'malformed method spec')
+        return
+      end
+      # fetch_methods は不在時に空配列(truthy)を返してしまい raise しない
+      # ため、単数形の fetch_method(不在で MethodNotFound)を使う
+      @db.fetch_method(spec)
+    rescue NotFoundError, InvalidKey
+      record('m', spec_str, 'method not found')
+    end
+
+    def check_library(name)
+      return if name == '/' || name == '_index'
+      @db.fetch_library(name)
+    rescue NotFoundError, InvalidKey
+      record('lib', name, 'library not found')
+    end
+
+    def check_doc(name)
+      @db.fetch_doc(name)
+    rescue NotFoundError, InvalidKey
+      record('d', name, 'doc not found')
+    end
+
+    def check_function(name)
+      return if name == '/' || name == '_index' || name.empty?
+      fdb = @fdb
+      unless fdb
+        @skipped_function_refs += 1
+        return
+      end
+      fdb.fetch_function(name)
+    rescue NotFoundError, InvalidKey
+      record('f', name, 'function not found')
+    end
+
+    # [[ref:type:name#frag]] 形式のみ検証する(参照先本体の存在チェック)。
+    # エントリローカルの [[ref:frag]] 形式は対象外(entry 文脈が必要で、
+    # アンカー未定義でも描画は劣化表示に留まるため)
+    def check_ref(arg)
+      if /\A(\w+):(.*)\#[-\w]+\z/ =~ arg
+        type, name = $1, $2
+        case type
+        when 'c'   then check_class(name || raise)
+        when 'm'   then check_method(name || raise)
+        when 'lib' then check_library(name || raise)
+        when 'd'   then check_doc(name || raise)
+        end
+      end
+    end
+
+    def record(type, arg, message)
+      @findings.push Finding.new(@current_location, "#{type}:#{arg}", message)
+    end
+  end
+end

--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -486,6 +486,9 @@ module BitClust
     def bracket_link(link, label = nil, frag = nil)
       type, _arg = link.split(':', 2)
       arg = _arg&.rstrip or raise
+      # link_checker(bitclust/link_checker.rb)が指定されているときは
+      # 参照を検証用に記録する。描画には影響しない
+      @option[:link_checker]&.note_ref(type || raise, arg)
       case type
       when 'lib'
         protect(link) {

--- a/lib/bitclust/runner.rb
+++ b/lib/bitclust/runner.rb
@@ -62,6 +62,7 @@ Subcommands(for developers):
     classes     Display defined classes for all ruby.
     methods     Display defined methods for all ruby.
     methodsince Fill per-name since/until from a version ladder of DBs.
+    checklink   Report broken [[c:]]/[[m:]]/[[lib:]]/[[d:]]/[[f:]] links.
 
 Subcommands(for packagers):
     statichtml  Generate static HTML files.
@@ -109,6 +110,7 @@ Global Options:
         'classes'     => BitClust::Subcommands::ClassesCommand.new,
         'methods'     => BitClust::Subcommands::MethodsCommand.new,
         'methodsince' => BitClust::Subcommands::MethodsinceCommand.new,
+        'checklink'   => BitClust::Subcommands::ChecklinkCommand.new,
       }
     end
 

--- a/lib/bitclust/subcommands/checklink_command.rb
+++ b/lib/bitclust/subcommands/checklink_command.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+#
+# bitclust/subcommands/checklink_command.rb
+#
+# DB 中の全ソースをコンパイル経路で走査し、[[c:]]/[[m:]]/[[lib:]]/[[d:]]/
+# [[f:]] 参照のリンク切れを報告する:
+#
+#   bitclust -d db-3.4 checklink
+#   bitclust -d db-3.4 checklink --capi-database=db-3.4-capi
+#
+# リンク切れが1件でもあれば exit 1(CI 組み込み用)。
+# [[f:]](C API 関数)は --capi-database 指定時のみ検証し、
+# 未指定ならスキップ数だけ報告する。
+
+require 'bitclust'
+require 'bitclust/subcommand'
+require 'bitclust/link_checker'
+
+module BitClust
+  module Subcommands
+    class ChecklinkCommand < Subcommand
+      def initialize
+        super
+        @capi_prefix = nil
+        @parser.banner = "Usage: #{File.basename($0, '.*')} --database=PATH checklink [options]"
+        @parser.on('--capi-database=PATH', 'C API (function) database for [[f:]] refs.') {|path|
+          @capi_prefix = path
+        }
+      end
+
+      def exec(argv, options)
+        super
+        db = @db
+        unless db.is_a?(MethodDatabase)
+          error 'checklink is for method databases (do not use --capi; pass --capi-database instead)'
+        end
+        capi_prefix = @capi_prefix
+        fdb = capi_prefix ? BitClust::FunctionDatabase.new(capi_prefix) : nil
+        checker = LinkChecker.new(db, function_database: fdb)
+        checker.check_all
+        # 同一エントリ内の同一参照の繰り返しは1行にまとめる
+        checker.findings.map {|f| "#{f.location}: [[#{f.ref}]] #{f.message}" }.uniq.each do |line|
+          puts line
+        end
+        if fdb.nil? && checker.skipped_function_refs > 0
+          puts "note: #{checker.skipped_function_refs} [[f:]] refs skipped (no --capi-database)"
+        end
+        version = @db.properties['version']
+        puts "#{checker.broken_count} broken link(s) in #{version ? "db (version #{version})" : 'db'}"
+        exit 1 unless checker.broken_count.zero?
+      end
+    end
+  end
+end

--- a/sig/bitclust/link_checker.rbs
+++ b/sig/bitclust/link_checker.rbs
@@ -1,0 +1,44 @@
+module BitClust
+  # DB 全体を走査して参照リンク切れを検出する(RDCompiler#bracket_link の
+  # @option[:link_checker] フック経由で抽出するため、コードスパン・
+  # フェンス内の参照風テキストは対象外になる)
+  class LinkChecker
+    class Finding < Struct[untyped]
+      attr_accessor location(): String?
+      attr_accessor ref(): String
+      attr_accessor message(): String
+
+      def self.new: (String? location, String ref, String message) -> instance
+    end
+
+    EXTERNAL_TYPES: Array[String]
+
+    @db: MethodDatabase
+    @fdb: FunctionDatabase?
+    @findings: Array[Finding]
+    @current_location: String?
+    @skipped_function_refs: Integer
+
+    def initialize: (MethodDatabase db, ?function_database: FunctionDatabase?) -> void
+
+    attr_reader findings: Array[Finding]
+    attr_reader skipped_function_refs: Integer
+    attr_accessor current_location: String?
+
+    def broken_count: () -> Integer
+    def check_all: () -> Array[Finding]
+    def note_ref: (String type, String arg) -> nil
+
+    private
+
+    def check_source: (untyped location) { (RDCompiler) -> untyped } -> void
+    def new_compiler: () -> RDCompiler
+    def check_class: (String name) -> untyped
+    def check_method: (String spec_str) -> untyped
+    def check_library: (String name) -> untyped
+    def check_doc: (String name) -> untyped
+    def check_function: (String name) -> untyped
+    def check_ref: (String arg) -> untyped
+    def record: (String type, String arg, String message) -> void
+  end
+end

--- a/sig/bitclust/rdcompiler.rbs
+++ b/sig/bitclust/rdcompiler.rbs
@@ -17,6 +17,7 @@ module BitClust
       :force => bool,
       :stop_on_syntax_error => bool,
       ?:gfm => bool,
+      ?:link_checker => LinkChecker,
     }
     # :catalog は実装上省略可（無ければ MessageCatalog.new({}, 'C') が使われる）
     type option = {
@@ -26,6 +27,7 @@ module BitClust
       ?:force => bool,
       ?:stop_on_syntax_error => bool,
       ?:gfm => bool,
+      ?:link_checker => LinkChecker,
     }
 
     @option: option_internal

--- a/sig/bitclust/subcommands/checklink_command.rbs
+++ b/sig/bitclust/subcommands/checklink_command.rbs
@@ -1,0 +1,12 @@
+module BitClust
+  module Subcommands
+    # DB 中の全ソースの参照リンク切れを報告する。1件でもあれば exit 1
+    class ChecklinkCommand < Subcommand
+      @capi_prefix: String?
+
+      def initialize: () -> void
+
+      def exec: (Subcommand::argv argv, Subcommand::options options) -> void
+    end
+  end
+end

--- a/test/test_link_checker.rb
+++ b/test/test_link_checker.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'test/unit'
+require 'tmpdir'
+require 'fileutils'
+require 'bitclust'
+require 'bitclust/methoddatabase'
+require 'bitclust/link_checker'
+
+# bitclust#286 派生の要望: [[c:]]/[[m:]] 等の参照は描画時に存在検証されず
+# リンク切れが静かに発生するため、DB 全体を走査して壊れた参照を報告する
+# LinkChecker を提供する。抽出は実際のコンパイル経路(bracket_link)を
+# 使うので、コードスパン・フェンス内の参照風テキストは対象外になる。
+class TestLinkChecker < Test::Unit::TestCase
+  FOO_MD = <<~'MD'
+    ---
+    library: foo
+    ---
+    # class Foo < Object
+
+    正しい参照: [c:Foo] と [m:Foo#bar] と [m:Foo.baz] と [m:Foo::CONST]
+    と [lib:foo] と [d:spec/page]。
+
+    壊れた参照: [c:Nope] と [m:Foo#nope] と [m:Nope#x] と [lib:nolib]
+    と [d:spec/nope]。
+
+    コードスパン内は対象外: `[c:CodeSpan]`。
+
+    ```ruby
+    # フェンス内も対象外: [m:Fence#no]
+    ```
+
+    ## Instance Methods
+
+    ### def bar -> nil
+
+    メソッド本文からの壊れた参照: [m:Foo#missing_from_method]
+
+    ## Class Methods
+
+    ### def baz -> nil
+
+    baz です。
+
+    ## Constants
+
+    ### const CONST -> Integer
+
+    定数です。
+  MD
+
+  def build_db(dir)
+    api = File.join(dir, 'manual', 'api')
+    FileUtils.mkdir_p(File.join(api, 'foo'))
+    FileUtils.mkdir_p(File.join(dir, 'manual', 'doc', 'spec'))
+    File.write(File.join(api, 'foo.md'),
+               "---\ntype: library\n---\nライブラリ概要。壊れた参照: [c:AlsoNope]\n")
+    File.write(File.join(api, 'foo', 'Foo.md'), FOO_MD)
+    File.write(File.join(dir, 'manual', 'doc', 'spec', 'page.md'),
+               "# ページ\n\ndoc からの壊れた参照: [m:Foo#doc_missing]。正しい参照: [c:Foo]。\n")
+
+    prefix = File.join(dir, 'db')
+    db = BitClust::MethodDatabase.new(prefix)
+    db.init
+    db.transaction do
+      db.propset('version', '3.4')
+      db.propset('encoding', 'utf-8')
+    end
+    db.transaction do
+      db.update_by_markdowntree(api)
+    end
+    BitClust::MethodDatabase.new(prefix)
+  end
+
+  def test_check_all_reports_only_broken_refs
+    Dir.mktmpdir do |dir|
+      db = build_db(dir)
+      findings = BitClust::LinkChecker.new(db).check_all
+      refs = findings.map(&:ref).sort
+      assert_equal(
+        [
+          'c:AlsoNope',
+          'c:Nope',
+          'd:spec/nope',
+          'lib:nolib',
+          'm:Foo#doc_missing',
+          'm:Foo#missing_from_method',
+          'm:Foo#nope',
+          'm:Nope#x',
+        ],
+        refs
+      )
+    end
+  end
+
+  def test_findings_carry_location
+    Dir.mktmpdir do |dir|
+      db = build_db(dir)
+      findings = BitClust::LinkChecker.new(db).check_all
+      f = findings.find { |x| x.ref == 'm:Foo#nope' }
+      assert_not_nil f
+      assert_match(/Foo\.md/, f.location.to_s)
+    end
+  end
+
+  def test_exit_style_summary
+    Dir.mktmpdir do |dir|
+      db = build_db(dir)
+      checker = BitClust::LinkChecker.new(db)
+      checker.check_all
+      assert_equal 8, checker.broken_count
+    end
+  end
+end


### PR DESCRIPTION
## 概要

`[[c:]]` / `[[m:]]` 等の参照は描画時に存在検証されない(URL を文字列変換で組むだけ)ため、壊れた参照は静かにリンク切れになり、これまで PR 作成者・レビュワーが個別に目視確認するしかありませんでした。DB 全体を走査してリンク切れを報告する `checklink` サブコマンドを追加します。

```
bitclust -d db-4.1 checklink [--capi-database=db-4.1]
```

```
manual/api/rdoc/generator.md: [[c:RDoc:RDoc]] class not found
manual/api/drb/unix.md: [[m:UnixServer.new]] method not found
...
301 broken link(s) in db (version 4.1)
```

## 設計

- **抽出は実際のコンパイル経路で行います**。`RDCompiler#bracket_link` に `@option[:link_checker]` フックを1箇所追加し(描画には無影響)、checklink はライブラリ・クラス・メソッド・doc ページの全ソースをコンパイルして参照を収集します。正規表現の自前スキャンと違い「描画時に本当にリンクになるものだけ」が対象になるので、コードスパン・フェンス内の参照風テキスト(記法説明など)は自然に除外されます。
- 検証対象: `c`(クラス)/ `m`(メソッド・定数・特殊変数。`$~` は rdcompiler と同じ Kernel 補完)/ `lib` / `d`(doc)/ `f`(`--capi-database` 指定時のみ。未指定ならスキップ数を表示)/ `ref`(`type:name#frag` 形式の参照先本体)。`url` / `man` / `rfc` 等の外部参照は対象外。既知の型に該当しないものは「unknown link type」として報告します(`[[c:Foo]]` の型名打ち間違い等の検出)。
- リンク切れが1件でもあれば **exit 1**(CI 組み込み用)。
- 版ごとの DB に対して走るので、版ゲートで内容が変わる文書もその版で実際に表示される内容だけが検査されます。

## 実測

現行 manual/ の 4.1 版 DB で **301 件**(+capi 込みで 303 件)のリンク切れを検出しました(約 33 秒)。内訳は method not found 224 / class not found 69 / library not found 8。`RDoc:RDoc`(コロン1個のタイポ)や未収録クラスへの参照、news/* の Fixnum/Bignum 参照(4.0 以降の DB には存在しない)などです。棚卸しは doctree 側で別途 issue にします。

## テスト・型

- 実 DB を組み立てる統合テストを追加(壊れた参照8種をちょうど検出・コードスパン/フェンス内は非検出・location 付与)
- 全テスト 17821 / 0 failures・`steep check` クリーン(RBS 追加済み)
- 副産物メモ: `ClassEntry#fetch_methods` は不在時に空配列(truthy)を返して raise しないため、checklink では単数形 `fetch_method` を使用しています(既存挙動は不変)

doctree 側には `rake check_links` タスクを別 PR で追加します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
