### PR TITLE
MARKUP_SPEC §7.1 に定数・特殊変数のリンク記法を追記

### DIFF
--- a/doc/markdown-samples/MARKUP_SPEC.md
+++ b/doc/markdown-samples/MARKUP_SPEC.md
@@ -577,6 +577,8 @@ RRD の `[[type:target]]` から角括弧を1段減らし `[type:target]` とす
 | メソッド | `[m:Class#method]` | `[m:Array#each]` |
 | クラスメソッド | `[m:Class.method]` | `[m:CGI.accept_charset]` |
 | モジュール関数 | `[m:Class?.method]` | `[m:Kernel?.open]` |
+| 定数 | `[m:Class::CONST]` | `[m:Math::PI]` |
+| 特殊変数 | `[m:$name]` | `[m:$~]` |
 | ライブラリ | `[lib:name]` | `[lib:json]` |
 | C 関数 | `[f:name]` | `[f:rb_str_new]` |
 | ドキュメント | `[d:path]` | `[d:spec/m17n]` |
@@ -587,6 +589,10 @@ RRD の `[[type:target]]` から角括弧を1段減らし `[type:target]` とす
 | bugs.ruby-lang.org | `[feature:number]` | `[feature:12345]` |
 
 モジュール関数の `?.` は RRD の `.#` typemark に対応する（`?` は RBS の `self?` に由来）。
+
+定数はクラスの仲間ではなくメソッドエントリの一種として扱われるため、
+`[c:Math::PI]` ではなく `[m:Math::PI]` と書く（`[c:]` はクラス/モジュール/
+オブジェクトのページ専用。ネストしたクラス `[c:File::Stat]` とは区別すること）。
 
 ### 7.2 メソッド名のエスケープ
 


### PR DESCRIPTION
## 概要

MARKUP_SPEC §7.1「記法一覧」に**定数へのリンク記法**(`[m:Math::PI]`)を追記します。ご指摘のとおり、定数はクラスの仲間に見えるため `[c:Math::PI]` と書き間違えやすいですが、bitclust では定数はメソッドエントリの一種(typechar `c`・typemark `::`)なので `m:` が正しい形です。

あわせて、同じく一覧から漏れていた**特殊変数**(`[m:$~]`。manual/ で実際に使われている記法)も追加し、`[c:]` はクラス/モジュール/オブジェクトのページ専用である旨と、ネストしたクラス(`[c:File::Stat]`)との区別の注意書きを付けました。

fix rurema/doctree#3315

🤖 Generated with [Claude Code](https://claude.com/claude-code)
