### PR TITLE
lookup --html をエントリ種別ごとの compile_* で描画する

### DIFF
--- a/lib/bitclust/subcommands/lookup_command.rb
+++ b/lib/bitclust/subcommands/lookup_command.rb
@@ -100,7 +100,7 @@ module BitClust
            <dt>classes</dt><dd><%= entry.classes.map {|c| c.name }.sort.join(', ') %></dd>
            <dt>methods</dt><dd><%= entry.methods.map {|m| m.name }.sort.join(', ') %></dd>
            </dl>
-           <%= compile_rd(entry.source) %>
+           <%= compile_rd(entry) %>
            End
         },
         :class   => {
@@ -123,7 +123,7 @@ module BitClust
            <dt>singleton_methods</dt><dd><%= entry.singleton_methods.map {|m| m.name }.sort.join(', ') %></dd>
            <dt>instance_methods</dt><dd><%= entry.instance_methods.map {|m| m.name }.sort.join(', ') %></dd>
            </dl>
-           <%= compile_rd(entry.source) %>
+           <%= compile_rd(entry) %>
            End
         },
         :method  => {
@@ -146,7 +146,7 @@ module BitClust
            <dt>kind</dt><dd><%= entry.kind %></dd>
            <dt>library</dt><dd><%= entry.library.name %></dd>
            </dl>
-           <%= compile_rd(entry.source) %>
+           <%= compile_rd(entry) %>
            End
         },
         :function => {
@@ -163,20 +163,30 @@ module BitClust
            <dt>header</dt><dd><%= entry.header %></dd>
            <dt>filename</dt><dd><%= entry.filename %></dd>
            </dl>
-           <%= compile_rd(entry.source) %>
+           <%= compile_rd(entry) %>
            End
         }
       }
 
-      def compile_rd(src)
+      def compile_rd(entry)
         umap = URLMapper.new(:base_url => 'http://example.com',
                              :cgi_url  => 'http://example.com/view')
         if @db.properties['source_format'] == 'markdown'
           # md ソースの DB は screen.rb と同じく MDCompiler（GFM）で描画する
           Kernel.require 'bitclust/mdcompiler'
-          MDCompiler.new(umap, 2, { :gfm => true, :database => @db }).compile(src)
+          compiler = MDCompiler.new(umap, 2, { :gfm => true, :database => @db })
         else
-          RDCompiler.new(umap, 2).compile(src)
+          compiler = RDCompiler.new(umap, 2, { :database => @db })
+        end
+        # シグネチャ行の描画（permalink の id 等）はエントリ文脈を要求する
+        # ので、compile ではなくエントリ種別ごとの compile_* を使う
+        case entry
+        when MethodEntry
+          compiler.compile_method(entry)
+        when FunctionEntry
+          compiler.compile_function(entry)
+        else
+          compiler.compile(entry.source)
         end
       end
     end

--- a/sig/bitclust/subcommands/lookup_command.rbs
+++ b/sig/bitclust/subcommands/lookup_command.rbs
@@ -21,7 +21,7 @@ module BitClust
 
       TEMPLATE: Hash[(:library | :class | :method | :function), Hash[(:text | :html), String]]
 
-      def compile_rd: (String src) -> String
+      def compile_rd: (any_entry entry) -> String
     end
   end
 end

--- a/test/test_bitclust.rb
+++ b/test/test_bitclust.rb
@@ -73,9 +73,11 @@ This is public function.
 <dt>header</dt><dd>VALUE public_func()</dd>
 <dt>filename</dt><dd>test.c</dd>
 </dl>
+<dd class="function-description">
 <p>
 This is public function.
 </p>
+</dd>
     EOS
   end
 end

--- a/test/test_lookup_command.rb
+++ b/test/test_lookup_command.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'tmpdir'
+require 'fileutils'
+require 'stringio'
+require 'bitclust'
+require 'bitclust/methoddatabase'
+require 'bitclust/subcommands/lookup_command'
+
+# lookup サブコマンド(bitclust#294)。
+#
+# テストリスト:
+# [x] --method --html が Markdown ソースの DB で HTML を返す
+#     (シグネチャ dt に index_id の id 属性と permalink が付く)
+# [x] --method --html が RD ソースの DB でも HTML を返す
+# [x] --method(text)は従来どおりソースをそのまま出力する
+# [x] --class --html は従来どおり動く
+class TestLookupCommand < Test::Unit::TestCase
+  FOO_MD = <<~'MD'
+    ---
+    library: foo
+    ---
+    # class Foo < Object
+
+    クラスの説明。
+
+    ## Instance Methods
+
+    ### def bar -> nil
+
+    bar の説明。
+  MD
+
+  FOO_RD = <<~'RD'
+    description
+
+    = class Foo < Object
+
+    クラスの説明。
+
+    == Instance Methods
+
+    --- bar -> nil
+
+    bar の説明。
+  RD
+
+  def build_markdown_db(dir)
+    api = File.join(dir, 'manual', 'api')
+    FileUtils.mkdir_p(File.join(api, 'foo'))
+    File.write(File.join(api, 'foo.md'), "---\ntype: library\n---\nfoo ライブラリ。\n")
+    File.write(File.join(api, 'foo', 'Foo.md'), FOO_MD)
+    prefix = File.join(dir, 'db')
+    db = BitClust::MethodDatabase.new(prefix)
+    db.init
+    db.transaction do
+      db.propset('version', '3.4')
+      db.propset('encoding', 'utf-8')
+    end
+    db.transaction do
+      db.update_by_markdowntree(api)
+    end
+    prefix
+  end
+
+  def build_rd_db(dir)
+    root = File.join(dir, 'refm', 'api', 'src')
+    FileUtils.mkdir_p(root)
+    File.write(File.join(root, 'LIBRARIES'), "foo\n")
+    File.write(File.join(root, 'foo.rd'), FOO_RD)
+    prefix = File.join(dir, 'db')
+    db = BitClust::MethodDatabase.new(prefix)
+    db.init
+    db.transaction do
+      db.propset('version', '3.4')
+      db.propset('encoding', 'utf-8')
+    end
+    db.transaction do
+      db.update_by_stdlibtree(root)
+    end
+    prefix
+  end
+
+  def run_lookup(prefix, argv)
+    cmd = BitClust::Subcommands::LookupCommand.new
+    cmd.parse(argv)
+    out = StringIO.new
+    orig_stdout = $stdout
+    $stdout = out
+    begin
+      cmd.exec([], { prefix: prefix, capi: false })
+    ensure
+      $stdout = orig_stdout
+    end
+    out.string
+  end
+
+  def test_method_html_on_markdown_db
+    Dir.mktmpdir do |dir|
+      prefix = build_markdown_db(dir)
+      html = run_lookup(prefix, ['--method', 'Foo#bar', '--html'])
+      assert_match(/<dt class="method-heading" id="[^"]+"><code>bar/, html)
+      assert_match(/permalink/, html)
+      assert_match(/bar の説明。/, html)
+    end
+  end
+
+  def test_method_html_on_rd_db
+    Dir.mktmpdir do |dir|
+      prefix = build_rd_db(dir)
+      html = run_lookup(prefix, ['--method', 'Foo#bar', '--html'])
+      assert_match(/<dt class="method-heading" id="[^"]+"><code>bar/, html)
+      assert_match(/permalink/, html)
+      assert_match(/bar の説明。/, html)
+    end
+  end
+
+  def test_method_text
+    Dir.mktmpdir do |dir|
+      prefix = build_markdown_db(dir)
+      text = run_lookup(prefix, ['--method', 'Foo#bar'])
+      assert_match(/\Atype: instance_method$/, text)
+      assert_match(/^### def bar -> nil$/, text)
+    end
+  end
+
+  def test_class_html
+    Dir.mktmpdir do |dir|
+      prefix = build_markdown_db(dir)
+      html = run_lookup(prefix, ['--class', 'Foo', '--html'])
+      assert_match(%r{<dt>name</dt><dd>Foo</dd>}, html)
+      assert_match(/クラスの説明。/, html)
+    end
+  end
+end


### PR DESCRIPTION
fix #294

`lookup --html` の HTML テンプレートはエントリのソースをライブラリページ用の `compile` で描画していたため、シグネチャ行を含むメソッドエントリでは `@method` などのエントリ文脈が無く、permalink 用 id の描画(`@method.index_id`)で NoMethodError になっていました。Markdown ソースの DB だけでなく、RD ソースの DB でも同様に再現します(テストで両方確認)。

## 変更内容

- テンプレートにはソース文字列ではなくエントリ自体を渡し、メソッドエントリは `compile_method`、関数エントリは `compile_function` で描画するようにしました
- RD 側のコンパイラにも `:database` オプションを渡すようにしました(permalink 横の rdoc リンクが DB の `version` プロパティを参照するため)
- テスト追加(`test/test_lookup_command.rb`): md ソース DB・RD ソース DB それぞれの `--method --html`、回帰確認として text 形式と `--class --html`

## 動作の変化(副次的)

`lookup --function --html` の本文が、関数ページの画面描画と同じく `<dd class="function-description">` で包まれるようになります(`test/test_bitclust.rb` の期待値を更新)。`@param`/`@see` などの関数ドキュメント記法もこの経路で処理されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
