### PR TITLE
ラベル付き参照の宛先 scheme に man: を追加

### DIFF
--- a/doc/markdown-samples/MARKUP_SPEC.md
+++ b/doc/markdown-samples/MARKUP_SPEC.md
@@ -597,13 +597,14 @@ RRD の `[[type:target]]` から角括弧を1段減らし `[type:target]` とす
 ### 7.1.1 ラベル付き参照(Markdown リンク記法)
 
 表示テキストを変えて参照したいときは、Markdown 標準のリンク記法の宛先に
-参照 scheme(`c:` / `m:` / `lib:` / `d:` / `f:` / `ref:`)を書く。
+参照 scheme(`c:` / `m:` / `lib:` / `d:` / `f:` / `ref:` / `man:`)を書く。
 呼び出し形を表示しながらメソッドへリンクする用途に使える:
 
 ```markdown
 [`OpenSSL::Random.egd_bytes(filename, 255)`](m:OpenSSL::Random?.egd_bytes)
 [文字列クラス](c:String)
 [多言語化の仕様](ref:d:spec/m17n#charset)
+[statx システムコール](man:statx(2linux))
 ```
 
 - ラベル全体をコードスパン(`` ` ``)で囲むと `<code>` で描画される。

--- a/lib/bitclust/mdcompiler.rb
+++ b/lib/bitclust/mdcompiler.rb
@@ -758,7 +758,7 @@ module BitClust
     # （MARKUP_SPEC §7.4/§7.5）
     # リンク宛先として受け付けるもの: 外部 URL・ページ内アンカー・
     # rurema 参照 scheme(c:/m:/lib:/d:/f:。ラベル付きで参照したいとき用)
-    MD_LINK_DEST_RE = %r{\A(?:https?://|\#|(?:c|m|lib|d|f|ref):)}
+    MD_LINK_DEST_RE = %r{\A(?:https?://|\#|(?:c|m|lib|d|f|ref|man):)}
 
     # Markdown のリンクを描画済み <a> へ退避し \x03idx\x03 プレースホルダに
     # 置き換える。後段の rd_compile_text（HTML エスケープ・参照解決）を
@@ -823,7 +823,7 @@ module BitClust
     # 解決する([`egd_bytes(filename, 255)`](m:OpenSSL::Random?.egd_bytes)
     # のように、呼び出し形をラベルにしてメソッドへリンクできる)
     def md_link(text, dest)
-      if (m = /\A(c|m|lib|d|f|ref):(.+)\z/m.match(dest))
+      if (m = /\A(c|m|lib|d|f|ref|man):(.+)\z/m.match(dest))
         return ref_md_link(m[1] || raise, m[2] || raise, text)
       end
       label = escape_html(unescape_md_brackets(text))

--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -519,7 +519,7 @@ module BitClust
       when 'url'
         direct_url(arg)
       when 'man'
-        man_link(arg)
+        man_link(arg, label)
       when 'rfc', 'RFC'
         rfc_link(arg)
       when 'ruby-list', 'ruby-dev', 'ruby-ext', 'ruby-talk', 'ruby-core'
@@ -623,10 +623,12 @@ module BitClust
       end
     end
 
-    def man_link(spec)
-      m = /([\w\.\/]+)\((\w+)\)/.match(spec) or return escape_html(spec)
-      url = man_url(m[2], escape_html(m[1] || raise)) or return escape_html(spec)
-      %Q(<a class="external" href="#{escape_html(url)}">#{escape_html("#{m[1]}(#{m[2]})")}</a>)
+    # label はラベル付き参照(MDCompiler#ref_md_link)からの表示テキスト
+    # 上書き。リンクにできない spec ではラベルをプレーン表示に使う
+    def man_link(spec, label = nil)
+      m = /([\w\.\/]+)\((\w+)\)/.match(spec) or return escape_html(label || spec)
+      url = man_url(m[2], escape_html(m[1] || raise)) or return escape_html(label || spec)
+      %Q(<a class="external" href="#{escape_html(url)}">#{escape_html(label || "#{m[1]}(#{m[2]})")}</a>)
     end
 
     BUGS_URL = "https://bugs.ruby-lang.org/issues/%s"

--- a/sig/bitclust/rdcompiler.rbs
+++ b/sig/bitclust/rdcompiler.rbs
@@ -158,7 +158,7 @@ module BitClust
 
     def man_url: (String? section, String? page) -> String?
 
-    def man_link: (String spec) -> String
+    def man_link: (String spec, ?String? label) -> String
 
     BUGS_URL: String
 

--- a/test/test_mdcompiler.rb
+++ b/test/test_mdcompiler.rb
@@ -1080,6 +1080,19 @@ class TestMDCompiler < Test::Unit::TestCase
       assert_include html, 'href="dummy/library/'
     end
 
+    def test_ref_link_man
+      html = gfm_compiler.compile("# t\n\n[statx システムコール](man:statx(2linux))\n")
+      assert_include html, 'href="http://man7.org/linux/man-pages/man2/statx.2.html"'
+      assert_include html, '>statx システムコール</a>'
+      assert_include html, 'class="external"'
+    end
+
+    def test_ref_link_man_unresolvable_section_falls_back_to_label
+      html = gfm_compiler.compile("# t\n\n[謎のマニュアル](man:foo(9zzz))\n")
+      assert_include html, '謎のマニュアル'
+      assert_not_include html, '<a '
+    end
+
     def test_unknown_scheme_stays_plain_text
       html = gfm_compiler.compile("# t\n\n[x](zzz:y)\n")
       assert_include html, '[x](zzz:y)'


### PR DESCRIPTION
rurema/doctree#3347 のレビューで `[statx システムコール](man:statx(2linux))` という書き方が提案されましたが、ラベル付きリンク(#293)の宛先は `c:/m:/lib:/d:/f:/ref:` のみ対応で `man:` は使えませんでした。宛先 scheme に `man:` を追加します。

- `man_link` にラベル上書き引数を追加(reference_link と同じ方式)。リンクにできない spec(不明なセクションなど)ではラベルをプレーン表示に使います
- 宛先中の括弧(セクション指定)は `matching_delimiter` がネスト対応済みなのでそのまま解釈できます
- MARKUP_SPEC §7.1.1 とテストを追従

マージ後に doctree 側で statx の箇所を suggestion の形に置き換える PR を出します(括弧書き別名表記の置き換えと同じ PR)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
