### PR TITLE
refe: module function の表示と検索を 4.0 以降の ?. に対応

### DIFF
--- a/lib/bitclust/completion.rb
+++ b/lib/bitclust/completion.rb
@@ -514,7 +514,8 @@ $cm_comb_m += 1
       end
 
       def names
-        @specs.map {|spec| spec.display_name }
+        version = @db && @db.properties["version"]
+        @specs.map {|spec| spec.display_name(version) }
       end
 
       def class_name

--- a/lib/bitclust/methodid.rb
+++ b/lib/bitclust/methodid.rb
@@ -90,8 +90,13 @@ module BitClust
       "#{@klass}#{@type}#{@method}"
     end
 
-    def display_name
-      @type == '$' ? "$#{@method}" : to_s()
+    # version はドキュメント対象の Ruby バージョン(DB の version プロパティ)。
+    # 指定すると module function の typemark を表示用に畳む
+    # (4.0 以降は "?."。NameUtils#display_typemark と同じ規則)
+    def display_name(version = nil)
+      return "$#{@method}" if @type == '$'
+      return "#{@klass}#{NameUtils.display_typemark(_ = @type, version)}#{@method}" if version
+      to_s()
     end
 
     def ==(other)

--- a/lib/bitclust/searcher.rb
+++ b/lib/bitclust/searcher.rb
@@ -352,10 +352,12 @@ module BitClust
       find_method db, cnames.join('::'), '::', name
     end
 
+    # 区切りは反転文字列上で探す。"?." は 4.0 以降の module function の
+    # 表示形式(反転すると ".?")で、内部表記の ".#" に正規化する
     def parse_method_spec_pattern(pat)
-      _m, _t, _c = pat.reverse.split(/([\#,]\.|\.[\#,]|[\#\.\,])/, 2)
+      _m, _t, _c = pat.reverse.split(/([\#,]\.|\.[\#,]|\.\?|[\#\.\,])/, 2)
       c = (_c || raise).reverse
-      t = (_t || raise).tr(',', '#').sub(/\#\./, '.#')
+      t = (_t || raise).tr(',', '#').sub(/\#\.|\.\?/, '.#')
       m = (_m || raise).reverse
       return c, t, m
     end

--- a/sig/bitclust/methodid.rbs
+++ b/sig/bitclust/methodid.rbs
@@ -49,7 +49,7 @@ module BitClust
 
     def to_s: () -> ::String
 
-    def display_name: () -> ::String
+    def display_name: (?::String? version) -> ::String
 
     def ==: (untyped other) -> bool
 

--- a/test/test_searcher.rb
+++ b/test/test_searcher.rb
@@ -103,3 +103,51 @@ class TestSearcherWindowsDrivePath < Test::Unit::TestCase
     end
   end
 end
+
+# refe の module_function 表示(bitclust#297)。
+# HTML 側(#282)と同じく、DB のバージョンが 4.0 以降なら
+# "Foo.#baz" ではなく "Foo?.baz" と表示する。
+class TestSearcherModuleFunctionDisplay < Test::Unit::TestCase
+  include BitClust
+
+  def record_for(version)
+    db = MethodDatabase.dummy("version" => version)
+    spec = MethodSpec.parse("Foo.#baz")
+    SearchResult::Record.new(db, spec, spec)
+  end
+
+  def test_names_folds_module_function_typemark_for_40
+    assert_equal ["Foo?.baz"], record_for("4.0").names
+  end
+
+  def test_names_keeps_typemark_before_40
+    assert_equal ["Foo.#baz"], record_for("3.4").names
+  end
+
+  def test_names_without_db_version_keeps_typemark
+    spec = MethodSpec.parse("Foo.#baz")
+    assert_equal ["Foo.#baz"], SearchResult::Record.new(nil, spec, spec).names
+  end
+end
+
+# refe のクエリ側も 4.0 以降の表示形式 "Foo?.baz" を受け付ける(bitclust#297)
+class TestSearcherModuleFunctionQuery < Test::Unit::TestCase
+  include BitClust
+
+  def parse(pat)
+    Searcher.new.send(:parse_method_spec_pattern, pat)
+  end
+
+  def test_question_dot_pattern
+    assert_equal ["Foo", ".#", "baz"], parse("Foo?.baz")
+  end
+
+  def test_dot_hash_pattern_still_works
+    assert_equal ["Foo", ".#", "baz"], parse("Foo.#baz")
+  end
+
+  def test_predicate_method_names_unaffected
+    assert_equal ["Foo", "#", "empty?"], parse("Foo#empty?")
+    assert_equal ["Foo", ".", "b?"], parse("Foo.b?")
+  end
+end


### PR DESCRIPTION
refs #297

refe の Markdown(manual/)対応確認の中で見つかった、module function の表示・検索の残作業です(#282 の `?.` 化が HTML 描画側のみで、refe には効いていませんでした)。

- **表示**: `MethodSpec#display_name` にバージョン引数を追加し、`SearchResult::Record#names` が DB の version プロパティで畳みます(`NameUtils#display_typemark` と同じ規則。4.0 以降のみ `?.`、それ未満と version 不明時は従来どおり `.#`)
- **検索**: 表示が `?.` になるのに合わせて、クエリ側(`parse_method_spec_pattern`)も `Foo?.baz` 形式を受け付けて内部表記 `.#` に正規化します。`Foo#empty?` や `Foo.b?` のような述語メソッド名の解釈は変えていません(テストで担保)

## 検証

- md ツリーから作った version=3.4 / 4.0 の DB に対する実測: 4.0 で `Foo?.baz` 表示+`refe Foo?.baz` がヒット、3.4 は従来どおり `Foo.#baz`
- `refe Foo?.baz` の挙動は `refe Foo.#baz` と同一(候補一覧の出方も含めて)
- 全テスト+steep green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
