### PR TITLE
関数一覧を「C API 関数一覧」に改名し冒頭に説明文を追加

### DIFF
--- a/data/bitclust/catalog/ja_JP.UTF-8
+++ b/data/bitclust/catalog/ja_JP.UTF-8
@@ -7,7 +7,7 @@ Added/Redefined Methods
 All Classes
 クラス一覧
 All Functions
-関数一覧
+C API 関数一覧
 All Libraries
 ライブラリ一覧
 Ancestor Methods
@@ -51,7 +51,7 @@ File
 FileFormat
 ファイルフォーマット
 Function Index
-関数一覧
+C API 関数一覧
 Index
 目次
 I/O
@@ -112,6 +112,8 @@ Text
 テキスト
 Thread
 スレッド
+This is a list of functions provided by the Ruby C API for developing Ruby itself and C extension libraries. These functions cannot be called directly from Ruby programs.
+Ruby の C API(C 言語 API)の関数の一覧です。Ruby 本体や拡張ライブラリの開発に使うもので、Ruby プログラムから直接呼び出す関数ではありません。
 This reference manual is for a version of Ruby that is no longer maintained.
 このマニュアルは既にメンテナンスが終了したバージョンの Ruby を対象としています。
 Undefined Methods for Explanation

--- a/data/bitclust/template.offline/function-index
+++ b/data/bitclust/template.offline/function-index
@@ -36,6 +36,7 @@
 </header>
 
 <main>
+<p><%= _('This is a list of functions provided by the Ruby C API for developing Ruby itself and C extension libraries. These functions cannot be called directly from Ruby programs.') %></p>
 <table class="entries functions">
 <%
     headline_push

--- a/data/bitclust/template/function-index
+++ b/data/bitclust/template/function-index
@@ -8,6 +8,7 @@
     headline_init
 %>
 <%= headline(_("Function Index")) %>
+<p><%= _('This is a list of functions provided by the Ruby C API for developing Ruby itself and C extension libraries. These functions cannot be called directly from Ruby programs.') %></p>
 <table class="entries functions">
 <%
     headline_push

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -979,7 +979,7 @@ HERE
 
   data("library root"    => ['[[lib:/]]',        '<a href="dummy/library/">ライブラリ一覧</a>'],
        "builtin library" => ['[[lib:_builtin]]', '<a href="dummy/library/_builtin">組み込みライブラリ</a>'],
-       "C API root"      => ['[[f:/]]',          '<a href="dummy/function/">関数一覧</a>'])
+       "C API root"      => ['[[f:/]]',          '<a href="dummy/function/">C API 関数一覧</a>'])
   def test_bracket_link_with_catalog(data)
     target, expected = data
     prefix = File.expand_path('../data/bitclust/catalog', __dir__)


### PR DESCRIPTION
rurema/doctree#3387 への対応です。検索エンジンから関数一覧ページや個々の関数ページに直接着地すると C API のものだと分かる手がかりがなく、Ruby スクリプトから呼べる関数だと誤解されうる問題を、表示側で解消します。

## 内容

- ja カタログの All Functions / Function Index の訳を「関数一覧」→「C API 関数一覧」に変更
  - 関数一覧ページのタイトル・見出し、各関数ページのパンくず、`[[f:/]]` リンクのラベル(トップページ「C API」セクション内のリンク)に効きます
- function-index テンプレート(default / offline)の冒頭に説明文を追加:
  > Ruby の C API(C 言語 API)の関数の一覧です。Ruby 本体や拡張ライブラリの開発に使うもので、Ruby プログラムから直接呼び出す関数ではありません。

## 確認

- テストスイート 17862 件すべてパス(test_rdcompiler の `[[f:/]]` ラベルの期待値も更新)
- テンプレート 2 本の ERB 構文チェック済み
- 本番 statichtml が使う offline テーマと server 用 default テーマの両方に適用(lillia テーマには function テンプレートが無いため対象外)

トップページ側は既に「C API」見出しの下に置かれているため、配置は変更していません。マージ後は次回の日次ビルドで docs.ruby-lang.org に反映されます。

closes rurema/doctree#3387

🤖 Generated with [Claude Code](https://claude.com/claude-code)
