### PR TITLE
manual/ のパースエラーに gem 更新の案内を添える

### DIFF
--- a/lib/bitclust/methoddatabase.rb
+++ b/lib/bitclust/methoddatabase.rb
@@ -202,6 +202,10 @@ module BitClust
         # lib ファイルの値へ戻す
         lib_entry.source_location = lib_location
       end
+    rescue ParseError => e
+      # manual/ には今後もより新しい bitclust を必要とする記法が入りうる。
+      # 古い gem でパースに失敗したとき原因へたどり着けるよう案内を添える
+      raise ParseError, "#{e.message} (ヒント: マニュアルがより新しい bitclust を必要とする記法を含んでいる可能性があります。bitclust の gem を更新すると解決するかもしれません)", e.backtrace
     end
 
     # since は「その版以降」、until は「その版未満」（ブリッジの

--- a/test/test_mdparser.rb
+++ b/test/test_mdparser.rb
@@ -341,6 +341,41 @@ class TestMDParser < Test::Unit::TestCase
     end
   end
 
+  def test_update_by_markdowntree_parse_error_suggests_gem_update
+    # manual/ が新しい bitclust を必要とする記法を含むとき、古い gem では
+    # パースエラーになる。原因へたどり着けるよう gem 更新の案内を添える
+    require 'tmpdir'
+    Dir.mktmpdir do |root|
+      write = ->(rel, s) {
+        path = File.join(root, rel)
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, s)
+      }
+      write.call('mylib.md', "---\ntype: library\n---\nmylib。\n")
+      write.call('mylib/Foo.md', <<~MD)
+        ---
+        library: mylib
+        ---
+        # class Foo < Object
+
+        クラス。
+
+        ## Instance Methods
+
+        ### def bar: (Integer) -> String
+
+        RBS 形式のシグネチャ(未対応)。
+      MD
+
+      db = BitClust::MethodDatabase.dummy(PARAMS)
+      error = assert_raise(BitClust::ParseError) do
+        db.update_by_markdowntree(root)
+      end
+      assert_include error.message, "unsupported method signature"
+      assert_include error.message, "bitclust の gem を更新すると解決するかもしれません"
+    end
+  end
+
   def test_copy_doc_md_keeps_relative_location
     # Windows CI 対応: doc エントリの source_location は md_root と同じ形
     # （相対で渡せば相対 manual/doc/...）で格納する。絶対パス化すると


### PR DESCRIPTION
manual/ には今後も、より新しい bitclust を必要とする記法(RBS 形式の def の対応など)が入る可能性があります。そのとき古い gem のままビルドすると「unsupported method signature」のようなエラーで失敗しますが、記法側の問題なのか gem が古いのかが利用者には分かりにくい状態でした。

`update_by_markdowntree`(manual/ 更新の入口)で ParseError を捕まえ、次のヒントを添えて投げ直すようにします。

> (ヒント: マニュアルがより新しい bitclust を必要とする記法を含んでいる可能性があります。bitclust の gem を更新すると解決するかもしれません)

doctree 側の bitclust バージョン検査(#230 の `check_bitclust_version!`)は「既知の最低要求版」を守る仕組みですが、こちらは「まだ知らない新記法」に当たったときの案内で、補完関係になります。

## 確認

- テスト追加: RBS 形式のシグネチャを含む md ツリーで、元のエラーメッセージとヒントの両方が含まれることを検証
- テストスイート全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
