### PR TITLE
RUN ボタンの横にヘルプページへのリンクを追加する

### DIFF
--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -23,6 +23,7 @@
 <script src="<%=h custom_js_url('js/search_init.js') %>"></script>
 <% if run_ruby_wasm_url %>
 <meta name="rurema-run-ruby-wasm" content="<%=h run_ruby_wasm_url %>">
+<meta name="rurema-run-help" content="<%=h document_url('help') %>#run">
 <script type="module" src="<%=h custom_js_url('js/run.js') %>"></script>
 <% end %>
 </head>

--- a/data/bitclust/template/layout
+++ b/data/bitclust/template/layout
@@ -13,6 +13,7 @@
   <link rel="search" type="application/opensearchdescription+xml" title="<%= _('Ruby %s Reference Manual', ruby_version()) %>" href="<%=h opensearchdescription_url() %>">
 <% if run_ruby_wasm_url %>
   <meta name="rurema-run-ruby-wasm" content="<%=h run_ruby_wasm_url %>">
+  <meta name="rurema-run-help" content="<%=h document_url('help') %>#run">
   <script type="module" src="<%=h custom_js_url('js/run.js') %>"></script>
 <% end %>
 </head>

--- a/lib/bitclust/screen.rb
+++ b/lib/bitclust/screen.rb
@@ -403,6 +403,10 @@ module BitClust
       @urlmapper.search_url
     end
 
+    def document_url(name)
+      @urlmapper.document_url(name)
+    end
+
     def library_index_url
       @urlmapper.library_index_url
     end

--- a/sig/bitclust/screen.rbs
+++ b/sig/bitclust/screen.rbs
@@ -291,6 +291,8 @@ module BitClust
 
     def search_url: () -> String
 
+    def document_url: (String name) -> String
+
     def library_index_url: () -> String
 
     def function_index_url: () -> String

--- a/theme/default/js/run.js
+++ b/theme/default/js/run.js
@@ -134,6 +134,20 @@ function setupBlock(pre, runner) {
   }
   group.prepend(button)
 
+  // RUN の使い方と制限(ruby.wasm で動かないサンプルがあること等)を
+  // 説明するヘルプページの RUN 節への動線。リンク先はページごとに相対
+  // URL が変わるため、サーバー側が layout の meta で埋め込んだ値を使う
+  const helpUrl = document.querySelector('meta[name="rurema-run-help"]')?.content
+  if (helpUrl) {
+    const help = document.createElement('a')
+    help.className = 'highlight__help-link'
+    help.href = helpUrl
+    help.textContent = '?'
+    help.title = 'RUN ボタンのヘルプ'
+    help.setAttribute('aria-label', 'RUN ボタンのヘルプ')
+    group.append(help)
+  }
+
   let output
   let outputTextNode
   const ensureOutput = () => {

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -276,11 +276,20 @@ pre.highlight.ruby[data-editing="true"] > code:focus {
 /* for ?(RUN のヘルプページへのリンク。highlight__button-group の中で
    COPY の右に入る)。ボタン(RUN・COPY)と違いページ遷移するリンクなので、
    色・ホバーはサイト共通のリンクの見た目(a のスタイル)に任せて、
-   ここでは配置とクリック領域だけ整える */
+   ここでは丸囲みの形と配置だけ整える */
 .highlight__help-link {
   display: inline-block;
+  box-sizing: border-box;
+  width: 1.5em;
+  height: 1.5em;
+  line-height: calc(1.5em - 2px);
+  text-align: center;
+  /* ただの ? だとクリックできると気付きにくいので、丸囲みはてなにして
+     ヘルプアイコンらしくする。枠は currentColor なので、リンク色にも
+     ホバーの反転(白文字+#33a 背景)にもそのまま追従する */
+  border: 1px solid currentColor;
+  border-radius: 50%;
   margin: 0 0.25em 0.25em 0.5em;
-  padding: 0.25em;
 }
 
 /* サンプルコードのキャプション。pre の上に密着したタブとして表示する

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -274,20 +274,13 @@ pre.highlight.ruby[data-editing="true"] > code:focus {
 }
 
 /* for ?(RUN のヘルプページへのリンク。highlight__button-group の中で
-   COPY の右に入る)。RUN・COPY と同じ見た目のリンク */
+   COPY の右に入る)。ボタン(RUN・COPY)と違いページ遷移するリンクなので、
+   色・ホバーはサイト共通のリンクの見た目(a のスタイル)に任せて、
+   ここでは配置とクリック領域だけ整える */
 .highlight__help-link {
   display: inline-block;
-  margin: 0 0 0.25em 0.5em;
-  padding: 0.25em 0.5em;
-  background: #fff;
-  cursor: pointer;
-  border: 1px solid #999;
-  border-radius: 4px;
-  color: inherit;
-  text-decoration: none;
-}
-.highlight__help-link:hover {
-  background: #EE8;
+  margin: 0 0.25em 0.25em 0.5em;
+  padding: 0.25em;
 }
 
 /* サンプルコードのキャプション。pre の上に密着したタブとして表示する

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -273,6 +273,23 @@ pre.highlight.ruby[data-editing="true"] > code:focus {
   left: -1000px;
 }
 
+/* for ?(RUN のヘルプページへのリンク。highlight__button-group の中で
+   COPY の右に入る)。RUN・COPY と同じ見た目のリンク */
+.highlight__help-link {
+  display: inline-block;
+  margin: 0 0 0.25em 0.5em;
+  padding: 0.25em 0.5em;
+  background: #fff;
+  cursor: pointer;
+  border: 1px solid #999;
+  border-radius: 4px;
+  color: inherit;
+  text-decoration: none;
+}
+.highlight__help-link:hover {
+  background: #EE8;
+}
+
 /* サンプルコードのキャプション。pre の上に密着したタブとして表示する
    (上だけ角丸でタブらしく)。script.js がツールバー行の左端に取り込む。
    下のコード部分と同じ背景色にして「つながったタブ」に見せる(ヘッダー


### PR DESCRIPTION
refs #311

サンプルコードの RUN ボタンには ruby.wasm 由来の制限がありますが、説明のあるヘルプページへの動線がボタン周辺にありませんでした。ボタン群(RUN・COPY)の右に「?」リンクを追加し、ヘルプページの「サンプルコードの実行(RUN ボタン)」の節へ飛べるようにします。

## 実装

- リンク先はページの階層ごとに相対 URL が変わるため、layout テンプレート(template / template.offline の両方)が `<meta name="rurema-run-help" content="...doc/help.html#run">` を `document_url('help')` で埋め込み、`js/run.js` がそれを読んでリンク要素を生成します(RUN 有効時のみ)
- `TemplateScreen` に `document_url` の delegation を追加しました(URLMapper 側には既存)
- 見た目は RUN・COPY と同じボタン風で、`title`/`aria-label` は「RUN ボタンのヘルプ」です
- 飛び先のアンカー `{#run}` はヘルプ文書側(doctree)で付与します(別 PR。アンカーが先に無い間はヘルプページの先頭にスクロールするだけで、リンク自体は壊れません)

## 検証

- テストスイート全パス+`steep check` クリーン
- ミニツリーの statichtml 実走(`--run-ruby-wasm` 指定)で、method ページ(`../../../doc/help.html#run`)と library ページ(`../doc/help.html#run`)の相対 URL が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
