### PR TITLE
statichtml に Markdown 出力オプションを追加

### DIFF
--- a/lib/bitclust/markdown_exporter.rb
+++ b/lib/bitclust/markdown_exporter.rb
@@ -1,0 +1,311 @@
+# frozen_string_literal: true
+
+require 'bitclust/nameutils'
+
+module BitClust
+
+  # statichtml の --markdown-output 用に、HTML の各ページと対になる Markdown を
+  # エントリの前処理済みソース(Markdown ツリー由来の md)から組み立てる。
+  # 参照記法(単一ブラケットの [m:...] 等と、参照 scheme を宛先にした
+  # ラベル付きリンク)は相対 .md リンクへ解決する。解決できない参照
+  # (未対応の種別・不正な指定)はそのまま残し、エラーにしない。
+  # コードスパンとコードフェンスの中は変換しない。
+  class MarkdownExporter
+
+    # クラスページの メソッド種別 → セクション見出し(doctree の md と同じ名称)
+    CLASS_SECTIONS = [
+      ["Class Methods",              :public,    :singleton_method],
+      ["Instance Methods",           :public,    :instance_method],
+      ["Private Class Methods",      :private,   :singleton_method],
+      ["Private Instance Methods",   :private,   :instance_method],
+      ["Protected Instance Methods", :protected, :instance_method],
+      ["Module Functions",           :public,    :module_function],
+      ["Constants",                  :public,    :constant],
+      ["Special Variables",          :public,    :special_variable],
+    ].freeze
+
+    def initialize(urlmapper, html_suffix)
+      @urlmapper = urlmapper
+      @html_suffix = html_suffix
+    end
+
+    def library_page(entry)
+      page("# library #{entry.name}", entry.source)
+    end
+
+    # クラスページは HTML と同じく本文+メソッドリンク一覧(本文は載せない)
+    def class_page(entry)
+      out = +""
+      CLASS_SECTIONS.each do |section, visibility, type|
+        methods = entry.entries.select { |m|
+          !m.undefined? && m.type == type && m.visibility == visibility
+        }
+        next if methods.empty?
+        out << "\n## #{section}\n\n"
+        methods.each do |m|
+          m.names.each do |name|
+            spec = m.klass.name + m.typemark + name
+            url = ref_url('m', spec)
+            out << (url ? "- [#{escape_label(name)}](#{url})\n" : "- #{escape_label(name)}\n")
+          end
+        end
+      end
+      page(class_heading(entry), entry.source, out)
+    end
+
+    def method_page(method_name, entries)
+      out = +"# #{method_name.sub('.#', '?.')}\n"
+      entries.each do |m|
+        body = m.source.strip
+        out << "\n" << convert_text(body) << "\n" unless body.empty?
+      end
+      out
+    end
+
+    def doc_page(entry)
+      page("# #{entry.title}", entry.source)
+    end
+
+    def function_page(entry)
+      page("# #{entry.name}", "### #{entry.header}\n#{entry.source}")
+    end
+
+    # 本文中の参照をコードスパン・コードフェンスを避けて相対 .md リンクへ
+    # 変換する
+    def convert_text(str)
+      out = +''
+      fence = nil
+      str.each_line do |line|
+        if fence
+          out << line
+          stripped = line.strip
+          fence = nil if stripped.match?(/\A`+\z/) && stripped.length >= (fence || 0)
+        elsif (m = /\A {0,3}(`{3,})/.match(line))
+          fence = (m[1] || raise).length
+          out << line
+        else
+          out << convert_line(line)
+        end
+      end
+      out
+    end
+
+    private
+
+    def page(heading, source, trailer = "")
+      out = +"#{heading}\n"
+      body = source.strip
+      out << "\n" << convert_text(body) << "\n" unless body.empty?
+      out << trailer
+      out
+    end
+
+    def class_heading(entry)
+      case entry.type
+      when :class
+        sc = entry.superclass
+        sc ? "# class #{entry.name} < #{sc.name}" : "# class #{entry.name}"
+      when :module
+        "# module #{entry.name}"
+      when :object
+        "# object #{entry.name}"
+      else
+        "# #{entry.name}"
+      end
+    end
+
+    def convert_line(line)
+      spans = [] #: Array[String]
+      converted = convert_refs(extract_code_spans(line, spans))
+      converted.gsub(/\x00(\d+)\x00/) { spans[($1 || raise).to_i] || raise }
+    end
+
+    # インラインコードスパン(CommonMark 6.1、N 連バッククォートの同長
+    # ペアリング)を書かれたままプレースホルダへ退避する
+    def extract_code_spans(str, saved)
+      result = +''
+      i = 0
+      len = str.length
+      while i < len
+        c = str[i] or raise
+        if c == '\\' && i + 1 < len
+          result << (str[i, 2] || raise)
+          i += 2
+          next
+        end
+        if c == '`'
+          run = 1
+          run += 1 while str[i + run] == '`'
+          close = find_code_span_close(str, i + run, run)
+          if close
+            saved << (str[i...(close + run)] || raise)
+            result << "\x00#{saved.size - 1}\x00"
+            i = close + run
+            next
+          end
+          result << ('`' * run)
+          i += run
+          next
+        end
+        result << c
+        i += 1
+      end
+      result
+    end
+
+    def find_code_span_close(str, from, run_len)
+      i = from
+      len = str.length
+      while i < len
+        case str[i]
+        when "\n"
+          return nil
+        when '`'
+          j = i
+          j += 1 while str[j] == '`'
+          return i if j - i == run_len
+          i = j
+        else
+          i += 1
+        end
+      end
+      nil
+    end
+
+    REF_SCHEME_RE = /\A([a-zA-Z][a-zA-Z-]*):(.*)\z/m
+
+    def convert_refs(str)
+      result = +''
+      i = 0
+      while i < str.length
+        if str[i] == '\\' && i + 1 < str.length
+          result << (str[i, 2] || raise)
+          i += 2
+          next
+        end
+        if str[i] == '['
+          close = matching_delimiter(str, i, '[', ']')
+          if close
+            if str[close + 1] == '(' &&
+               (dest_end = matching_delimiter(str, close + 1, '(', ')', space_ends: true)) &&
+               (dest = str[(close + 2)...dest_end])
+              # ラベル付きリンク [text](dest)
+              if (m = REF_SCHEME_RE.match(dest)) && (url = ref_url(m[1] || raise, m[2] || raise))
+                result << "[#{str[(i + 1)...close]}](#{url})"
+                i = dest_end + 1
+                next
+              end
+              if dest.start_with?('#') || dest.match?(%r{\Ahttps?://})
+                # 通常の Markdown リンクはそのまま(ラベル内は再解釈しない)
+                result << (str[i..dest_end] || raise)
+                i = dest_end + 1
+                next
+              end
+            end
+            # 単一ブラケット参照 [type:target]([[ は除外)
+            inner = str[(i + 1)...close] || raise
+            if str[i + 1] != '[' && (m = REF_SCHEME_RE.match(inner)) &&
+               (converted = bare_ref(m[1] || raise, m[2] || raise, inner))
+              result << converted
+              i = close + 1
+              next
+            end
+          end
+        end
+        result << (str[i] || raise)
+        i += 1
+      end
+      result
+    end
+
+    # open 位置の括弧に対応する閉じ括弧の位置(\ エスケープ対応・ネスト可)。
+    # space_ends: リンク宛先用。空白が現れたらリンクではない(nil)
+    def matching_delimiter(str, open, open_char, close_char, space_ends: false)
+      depth = 0
+      i = open
+      while i < str.length
+        c = str[i]
+        if c == '\\'
+          i += 1
+        elsif space_ends && c =~ /\s/
+          return nil
+        elsif c == open_char
+          depth += 1
+        elsif c == close_char
+          depth -= 1
+          return i if depth == 0
+        end
+        i += 1
+      end
+      nil
+    end
+
+    # 単一ブラケット参照 1 個を Markdown リンクにする。ラベルは書かれた
+    # ままの形(エスケープ込み)から type: を落としたもの
+    def bare_ref(type, arg, written)
+      label =
+        case type
+        when 'm', 'c', 'lib', 'd', 'f'
+          written.split(':', 2)[1]
+        when 'url'
+          arg
+        when 'ref'
+          case arg
+          when /\A(\w+):(.*)\#([-\w]+)\z/
+            "#{$2}##{$3}"
+          when /\A[-\w]+\z/
+            arg
+          end
+        end
+      return nil unless label
+      url = ref_url(type, arg)
+      return nil unless url
+      "[#{label}](#{url})"
+    end
+
+    # 参照 scheme の宛先 URL(.md への相対リンク)。解決できなければ nil
+    def ref_url(type, arg)
+      arg = unescape_md_brackets(arg)
+      case type
+      when 'm'
+        # md 表記の module function ?. は内部表記 .# に正規化して引く
+        md_suffix(@urlmapper.method_url(arg.sub('?.', '.#')))
+      when 'c'
+        md_suffix(@urlmapper.class_url(arg))
+      when 'lib'
+        md_suffix(@urlmapper.library_url(arg))
+      when 'd'
+        md_suffix(@urlmapper.document_url(arg))
+      when 'f'
+        md_suffix(@urlmapper.function_url(arg))
+      when 'url'
+        arg
+      when 'ref'
+        case arg
+        when /\A(\w+):(.*)\#([-\w]+)\z/
+          url = ref_url($1 || raise, $2 || raise)
+          url ? "#{url}##{$3}" : nil
+        when /\A[-\w]+\z/
+          "##{arg}"
+        end
+      end
+    rescue StandardError
+      nil
+    end
+
+    def md_suffix(html_url)
+      return html_url unless html_url.end_with?(@html_suffix)
+      "#{html_url[0, html_url.length - @html_suffix.length]}.md"
+    end
+
+    def unescape_md_brackets(str)
+      str.gsub(/\\([\[\]\\])/, '\1')
+    end
+
+    def escape_label(text)
+      text.gsub(/[\\\[\]]/) { "\\#{$&}" }
+    end
+
+  end
+
+end

--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -13,6 +13,7 @@ require 'bitclust/subcommand'
 require 'bitclust/progress_bar'
 require 'bitclust/silent_progress_bar'
 require 'bitclust/search_index_generator'
+require 'bitclust/markdown_exporter'
 
 module BitClust
   module Subcommands
@@ -125,6 +126,7 @@ module BitClust
         @run_ruby_wasm = nil
         @sitemap_baseurl = nil
         @sitemap_paths = []
+        @markdown_output = false
         @parser.banner = "Usage: #{File.basename($0, '.*')} statichtml [options]"
         @parser.on('-o', '--outputdir=PATH', 'Output directory') do |path|
           begin
@@ -170,6 +172,9 @@ module BitClust
         @parser.on('--sitemap-baseurl=URL', 'Generate sitemap.xml under the output directory, with <loc> built from this base URL (e.g. https://docs.ruby-lang.org/ja/3.4/). Omit to skip sitemap.xml generation (default)') do |url|
           @sitemap_baseurl = url
         end
+        @parser.on('--markdown-output', 'Also write each page as Markdown (.md next to the .html), assembled from the preprocessed Markdown sources. Ignored for databases not created from a Markdown tree') do
+          @markdown_output = true
+        end
         @parser.on('--no-stop-on-syntax-error', 'Do not stop on syntax error') do |boolean|
           @stop_on_syntax_error = boolean
         end
@@ -185,8 +190,10 @@ module BitClust
         db = MethodDatabase.new(prefix.to_s)
         fdb = FunctionDatabase.new(prefix.to_s)
         manager = ScreenManager.new(@manager_config)
+        @markdown_exporter = MarkdownExporter.new(@urlmapper, @suffix) if @markdown_output
 
         db.transaction do
+          warn_markdown_output_skipped(db, "the method database")
           methods = {} #: Hash[String, Array[MethodEntry]]
           db.methods.each_with_index do |entry, i|
             next if entry.undefined?
@@ -203,6 +210,7 @@ module BitClust
         end
 
         fdb.transaction do
+          warn_markdown_output_skipped(fdb, "the function database")
           create_html_entries("capi", fdb.functions, manager, fdb)
         end
 
@@ -419,6 +427,7 @@ HERE
           @urlmapper.bitclust_html_base = '..'
           path = outputdir + e.type_id.to_s + html_filename(encodename_package(e.name), @suffix)
           create_html_file_p(entry, manager, path, db)
+          create_markdown_file_p(e, path, db)
         when :function
           create_html_function_file(entry, manager, outputdir, db)
         else
@@ -435,6 +444,11 @@ HERE
         path = outputdir + e.type_id.to_s + encodename_package(e.klass.name) +
           e.typechar + html_filename(encodename_package(name), @suffix)
         create_html_file_p(entries, manager, path, db)
+        if markdown_export?(db)
+          create_file(markdown_path(path),
+                      @markdown_exporter.method_page(method_name, entries.sort),
+                      :verbose => @verbose)
+        end
       end
 
       def create_html_function_file(entry, manager, outputdir, db)
@@ -442,6 +456,7 @@ HERE
         @urlmapper.bitclust_html_base = '..'
         path = outputdir + entry.type_id.to_s + html_filename(entry.name, @suffix)
         create_html_file_p(entry, manager, path, db)
+        create_markdown_file_p(entry, path, db)
       end
 
       def create_html_file_p(entry, manager, path, db)
@@ -451,6 +466,36 @@ HERE
           f.write(html)
         end
         record_sitemap_path(path)
+      end
+
+      # --markdown-output は Markdown ツリー由来の DB でのみ有効。
+      # ソースが md でない(凍結版 RD など)DB では何も出力しない
+      def markdown_export?(db)
+        @markdown_output && db.properties['source_format'] == 'markdown'
+      end
+
+      def warn_markdown_output_skipped(db, label)
+        return if !@markdown_output || db.properties['source_format'] == 'markdown'
+        $stderr.puts "warning: --markdown-output is ignored for #{label}: it was not created from a Markdown tree"
+      end
+
+      def create_markdown_file_p(entry, html_path, db)
+        return unless markdown_export?(db)
+        content =
+          case entry.type_id
+          when :library then @markdown_exporter.library_page(_ = entry)
+          when :class then @markdown_exporter.class_page(_ = entry)
+          when :doc then @markdown_exporter.doc_page(_ = entry)
+          when :function then @markdown_exporter.function_page(_ = entry)
+          else return
+          end
+        create_file(markdown_path(html_path), content, :verbose => @verbose)
+      end
+
+      def markdown_path(html_path)
+        s = html_path.to_s
+        s = s.end_with?(@suffix) ? s[0, s.length - @suffix.length].to_s : s
+        Pathname.new("#{s}.md")
       end
 
       def create_file(path, str, options = {})

--- a/sig/bitclust/markdown_exporter.rbs
+++ b/sig/bitclust/markdown_exporter.rbs
@@ -1,0 +1,53 @@
+module BitClust
+  # statichtml の --markdown-output 用に、HTML の各ページと対になる Markdown を
+  # エントリの前処理済みソース(Markdown ツリー由来の md)から組み立てる
+  class MarkdownExporter
+    CLASS_SECTIONS: Array[[String, Symbol, Symbol]]
+
+    REF_SCHEME_RE: Regexp
+
+    @urlmapper: Subcommands::StatichtmlCommand::URLMapperEx
+
+    @html_suffix: String
+
+    def initialize: (Subcommands::StatichtmlCommand::URLMapperEx urlmapper, String html_suffix) -> void
+
+    def library_page: (LibraryEntry entry) -> String
+
+    def class_page: (ClassEntry entry) -> String
+
+    def method_page: (String method_name, Array[MethodEntry] entries) -> String
+
+    def doc_page: (DocEntry entry) -> String
+
+    def function_page: (FunctionEntry entry) -> String
+
+    def convert_text: (String str) -> String
+
+    private
+
+    def page: (String heading, String source, ?String trailer) -> String
+
+    def class_heading: (ClassEntry entry) -> String
+
+    def convert_line: (String line) -> String
+
+    def extract_code_spans: (String str, Array[String] saved) -> String
+
+    def find_code_span_close: (String str, Integer from, Integer run_len) -> Integer?
+
+    def convert_refs: (String str) -> String
+
+    def matching_delimiter: (String str, Integer open, String open_char, String close_char, ?space_ends: bool) -> Integer?
+
+    def bare_ref: (String type, String arg, String written) -> String?
+
+    def ref_url: (String type, String arg) -> String?
+
+    def md_suffix: (String html_url) -> String
+
+    def unescape_md_brackets: (String str) -> String
+
+    def escape_label: (String text) -> String
+  end
+end

--- a/sig/bitclust/subcommands/statichtml_command.rbs
+++ b/sig/bitclust/subcommands/statichtml_command.rbs
@@ -31,6 +31,10 @@ module BitClust
 
       @sitemap_paths: Array[String]
 
+      @markdown_output: bool
+
+      @markdown_exporter: MarkdownExporter
+
       @outputdir: Pathname
 
       type manager_config = {
@@ -142,6 +146,14 @@ module BitClust
       def record_sitemap_path: (Pathname path) -> void
 
       def create_sitemap: (Pathname outputdir, String baseurl) -> void
+
+      def markdown_export?: (Database db) -> bool
+
+      def warn_markdown_output_skipped: (Database db, String label) -> void
+
+      def create_markdown_file_p: (any_entry entry, Pathname html_path, Database db) -> void
+
+      def markdown_path: (Pathname html_path) -> Pathname
 
       def create_html_file: (any_entry entry, ScreenManager manager, Pathname outputdir, Database db) -> void
 

--- a/test/test_markdown_exporter.rb
+++ b/test/test_markdown_exporter.rb
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+require 'test/unit'
+require 'stringio'
+require 'bitclust'
+require 'bitclust/markdown_exporter'
+require 'bitclust/mdparser'
+require 'bitclust/methoddatabase'
+require 'bitclust/functiondatabase'
+require 'bitclust/subcommands/statichtml_command'
+
+# MarkdownExporter: statichtml --markdown-output 用に、HTML の各ページと
+# 対になる Markdown を前処理済みソースから組み立てる。
+class TestMarkdownExporter < Test::Unit::TestCase
+  PARAMS = { "version" => "3.4" }
+
+  def setup
+    @urlmapper = BitClust::Subcommands::StatichtmlCommand::URLMapperEx.new(
+      :suffix => '.html',
+      :fs_casesensitive => true
+    )
+    @urlmapper.bitclust_html_base = '..'
+    @exporter = BitClust::MarkdownExporter.new(@urlmapper, '.html')
+  end
+
+  def parse_md(md, libname = "_builtin")
+    db = BitClust::MethodDatabase.dummy(PARAMS)
+    lib = BitClust::MDParser.new(db).parse(StringIO.new(md), libname, PARAMS)
+    [db, lib]
+  end
+
+  sub_test_case("convert_text") do
+    def test_bare_method_ref
+      assert_equal "[Array#index](../method/Array/i/index.md) を参照",
+                   @exporter.convert_text("[m:Array#index] を参照")
+    end
+
+    def test_bare_class_ref
+      assert_equal "[String](../class/String.md)",
+                   @exporter.convert_text("[c:String]")
+    end
+
+    def test_bare_library_ref
+      assert_equal "[csv](../library/csv.md)",
+                   @exporter.convert_text("[lib:csv]")
+    end
+
+    def test_bare_doc_ref
+      assert_equal "[spec/literal](../doc/spec=2fliteral.md)",
+                   @exporter.convert_text("[d:spec/literal]")
+    end
+
+    def test_bare_function_ref
+      assert_equal "[rb_ary_new](../function/rb_ary_new.md)",
+                   @exporter.convert_text("[f:rb_ary_new]")
+    end
+
+    def test_module_function_ref
+      # md 表記の ?. は内部表記 .# に正規化して URL を引く(ラベルは書かれたまま)
+      assert_equal "[Kernel?.puts](../method/Kernel/m/puts.md)",
+                   @exporter.convert_text("[m:Kernel?.puts]")
+    end
+
+    def test_method_ref_with_escaped_brackets
+      # [m:Array#\[\]] のようにエスケープされた参照。URL はエスケープを解いた
+      # メソッド名から引き、ラベルは書かれたまま(md として正しい形)を保つ
+      assert_equal "[Array#\\[\\]](../method/Array/i/=5b=5d.md)",
+                   @exporter.convert_text("[m:Array#\\[\\]]")
+    end
+
+    def test_labeled_ref
+      assert_equal "[個数](../method/Array/i/size.md)",
+                   @exporter.convert_text("[個数](m:Array#size)")
+    end
+
+    def test_labeled_ref_with_code_span_label
+      assert_equal "[`Array#size`](../method/Array/i/size.md)",
+                   @exporter.convert_text("[`Array#size`](m:Array#size)")
+    end
+
+    def test_markdown_link_kept
+      assert_equal "[Ruby](https://www.ruby-lang.org/)",
+                   @exporter.convert_text("[Ruby](https://www.ruby-lang.org/)")
+    end
+
+    def test_anchor_link_kept
+      assert_equal "[前述の例](#example)",
+                   @exporter.convert_text("[前述の例](#example)")
+    end
+
+    def test_url_ref
+      assert_equal "[https://www.ruby-lang.org/](https://www.ruby-lang.org/)",
+                   @exporter.convert_text("[url:https://www.ruby-lang.org/]")
+    end
+
+    def test_ref_in_page
+      assert_equal "[overview](#overview)",
+                   @exporter.convert_text("[ref:overview]")
+    end
+
+    def test_ref_cross_page
+      assert_equal "[spec/literal#num](../doc/spec=2fliteral.md#num)",
+                   @exporter.convert_text("[ref:d:spec/literal#num]")
+    end
+
+    def test_code_span_is_not_converted
+      assert_equal "`[m:Array#index]`",
+                   @exporter.convert_text("`[m:Array#index]`")
+    end
+
+    def test_code_fence_is_not_converted
+      src = "```ruby\n# [m:Array#index]\n```\n[m:Array#index]\n"
+      expected = "```ruby\n# [m:Array#index]\n```\n[Array#index](../method/Array/i/index.md)\n"
+      assert_equal expected, @exporter.convert_text(src)
+    end
+
+    def test_unknown_ref_type_is_kept
+      assert_equal "[man:printf(3)]", @exporter.convert_text("[man:printf(3)]")
+    end
+
+    def test_unresolvable_method_spec_is_kept
+      # クラス名とメソッド名に分割できない指定はそのまま残す
+      assert_equal "[m:broken spec]", @exporter.convert_text("[m:broken spec]")
+    end
+
+    def test_escaped_bracket_is_kept
+      assert_equal "\\[m:Array#index]", @exporter.convert_text("\\[m:Array#index]")
+    end
+  end
+
+  sub_test_case("pages") do
+    CLASS_MD = <<~MD
+      ---
+      library: _builtin
+      ---
+      # class Array < Object
+
+      配列クラス。[c:Enumerable] も参照。
+
+      ## Class Methods
+
+      ### def self.new(size) -> Array
+
+      生成。
+
+      ## Instance Methods
+
+      ### def index(val) -> Integer
+      ### def find_index(val) -> Integer
+
+      位置を返します。
+    MD
+
+    def test_class_page
+      _, lib = parse_md(CLASS_MD)
+      md = @exporter.class_page(lib.classes.first)
+      assert_equal <<~MD, md
+        # class Array < Object
+
+        配列クラス。[Enumerable](../class/Enumerable.md) も参照。
+
+        ## Class Methods
+
+        - [new](../method/Array/s/new.md)
+
+        ## Instance Methods
+
+        - [find_index](../method/Array/i/find_index.md)
+        - [index](../method/Array/i/index.md)
+      MD
+    end
+
+    def test_module_page_heading
+      md = <<~MD
+        ---
+        library: _builtin
+        ---
+        # module Comparable
+
+        比較。
+      MD
+      _, lib = parse_md(md)
+      page = @exporter.class_page(lib.classes.first)
+      assert page.start_with?("# module Comparable\n"), page
+    end
+
+    def test_method_page
+      _, lib = parse_md(CLASS_MD)
+      entry = lib.classes.first.entries.find { |e| e.names.include?("index") }
+      @urlmapper.bitclust_html_base = '../../..'
+      md = @exporter.method_page("Array#index", [entry])
+      assert_equal <<~MD, md
+        # Array#index
+
+        ### def index(val) -> Integer
+        ### def find_index(val) -> Integer
+
+        位置を返します。
+      MD
+    end
+
+    def test_method_page_normalizes_module_function_name
+      _, lib = parse_md(CLASS_MD)
+      entry = lib.classes.first.entries.first
+      md = @exporter.method_page("Kernel.#puts", [entry])
+      assert md.start_with?("# Kernel?.puts\n"), md
+    end
+
+    def test_library_page
+      md = <<~MD
+        ---
+        type: library
+        category: FileFormat
+        ---
+        CSV を扱うライブラリです。
+      MD
+      _, lib = parse_md(md, "csv")
+      page = @exporter.library_page(lib)
+      assert_equal <<~MD, page
+        # library csv
+
+        CSV を扱うライブラリです。
+      MD
+    end
+
+    def test_doc_page
+      db = BitClust::MethodDatabase.dummy(PARAMS)
+      entry = BitClust::DocEntry.new(db, "help")
+      entry.title = "ヘルプ"
+      entry.source = "\n[c:String] を参照。\n"
+      page = @exporter.doc_page(entry)
+      assert_equal <<~MD, page
+        # ヘルプ
+
+        [String](../class/String.md) を参照。
+      MD
+    end
+
+    def test_function_page
+      require 'bitclust/functiondatabase'
+      md = <<~MD
+        ### VALUE rb_ary_new()
+
+        空の配列を返します。
+      MD
+      db = BitClust::FunctionDatabase.dummy(PARAMS)
+      io = StringIO.new(md)
+      def io.path = "array.c.md"
+      BitClust::MDFunctionParser.new(db).parse(io, "array.c", PARAMS)
+      page = @exporter.function_page(db.functions.first)
+      assert_equal <<~MD, page
+        # rb_ary_new
+
+        ### VALUE rb_ary_new()
+
+        空の配列を返します。
+      MD
+    end
+  end
+end

--- a/test/test_statichtml_command.rb
+++ b/test/test_statichtml_command.rb
@@ -202,3 +202,98 @@ class TestStatichtmlSitemap < Test::Unit::TestCase
     end
   end
 end
+
+class TestStatichtmlMarkdownOutput < Test::Unit::TestCase
+  def build_command(markdown_output: true)
+    cmd = BitClust::Subcommands::StatichtmlCommand.new
+    argv = ["--fs-casesensitive"]
+    argv.unshift("--markdown-output") if markdown_output
+    cmd.parse(argv)
+    cmd.instance_variable_set(:@verbose, false)
+    cmd.send(:create_manager_config)
+    urlmapper = cmd.instance_variable_get(:@urlmapper)
+    urlmapper.bitclust_html_base = '..'
+    cmd.instance_variable_set(:@markdown_exporter,
+                              BitClust::MarkdownExporter.new(urlmapper, '.html'))
+    cmd
+  end
+
+  def markdown_db
+    db = BitClust::MethodDatabase.dummy({ "version" => "3.4" })
+    def db.properties = { 'source_format' => 'markdown' }
+    db
+  end
+
+  def test_option_defaults_to_false
+    cmd = BitClust::Subcommands::StatichtmlCommand.new
+    assert_false(cmd.instance_variable_get(:@markdown_output))
+  end
+
+  def test_option_is_parsed
+    cmd = BitClust::Subcommands::StatichtmlCommand.new
+    cmd.parse(["--markdown-output"])
+    assert_true(cmd.instance_variable_get(:@markdown_output))
+  end
+
+  def test_markdown_path_replaces_html_suffix
+    cmd = BitClust::Subcommands::StatichtmlCommand.new
+    assert_equal("out/class/ARGF.class.md",
+                 cmd.send(:markdown_path, Pathname.new("out/class/ARGF.class.html")).to_s)
+  end
+
+  def test_writes_md_next_to_html_for_markdown_db
+    Dir.mktmpdir do |dir|
+      cmd = build_command
+      db = markdown_db
+      entry = BitClust::DocEntry.new(db, "help")
+      entry.title = "ヘルプ"
+      entry.source = "\n[c:String] を参照。\n"
+      path = Pathname.new(dir) + "doc/help.html"
+      FileUtils.mkdir_p(path.dirname)
+      cmd.send(:create_markdown_file_p, entry, path, db)
+      md = File.read(File.join(dir, "doc", "help.md"))
+      assert_equal("# ヘルプ\n\n[String](../class/String.md) を参照。\n", md)
+    end
+  end
+
+  def test_skips_md_for_non_markdown_db
+    Dir.mktmpdir do |dir|
+      cmd = build_command
+      db = BitClust::MethodDatabase.dummy({ "version" => "3.4" })
+      def db.properties = {}
+      entry = BitClust::DocEntry.new(db, "help")
+      entry.title = "ヘルプ"
+      entry.source = "\n本文\n"
+      path = Pathname.new(dir) + "doc/help.html"
+      FileUtils.mkdir_p(path.dirname)
+      cmd.send(:create_markdown_file_p, entry, path, db)
+      assert_false(File.exist?(File.join(dir, "doc", "help.md")))
+    end
+  end
+
+  def test_warns_when_db_is_not_markdown
+    cmd = build_command
+    db = BitClust::MethodDatabase.dummy({ "version" => "3.4" })
+    def db.properties = {}
+    orig_stderr, $stderr = $stderr, StringIO.new
+    begin
+      cmd.send(:warn_markdown_output_skipped, db, "the method database")
+      assert_match(/--markdown-output is ignored/, $stderr.string)
+    ensure
+      $stderr = orig_stderr
+    end
+  end
+
+  def test_no_warning_without_option
+    cmd = build_command(markdown_output: false)
+    db = BitClust::MethodDatabase.dummy({ "version" => "3.4" })
+    def db.properties = {}
+    orig_stderr, $stderr = $stderr, StringIO.new
+    begin
+      cmd.send(:warn_markdown_output_skipped, db, "the method database")
+      assert_equal("", $stderr.string)
+    ensure
+      $stderr = orig_stderr
+    end
+  end
+end


### PR DESCRIPTION
## 概要

statichtml に `--markdown-output` オプションを追加します(#316 の段階 1)。
指定すると、各ページの `.html` と並べて同名の `.md` を出力します。AI エージェント等が
HTML を剥がさずに本文を取り込めるようにするためのものです。

## 仕様

- 内容は Markdown ツリー由来の前処理済みソース(版ゲート適用後)から組み立てます
  - doc ページ: タイトル見出し+本文
  - ライブラリページ: `# library 名前` 見出し+本文
  - クラスページ: `# class Array < Object` 形式の見出し+本文+HTML と同じく
    メソッドリンク一覧(種別ごとのセクション。見出し名は doctree の md と同じ)
  - メソッドページ: メソッド名見出し+シグネチャ行込みの本文
  - 関数ページ(capi): 関数名見出し+シグネチャ+本文
- 参照記法は相対 `.md` リンクへ解決します
  - 単一ブラケット参照(`m:`/`c:`/`lib:`/`d:`/`f:`/`url:`/`ref:`)と、
    参照 scheme を宛先にしたラベル付きリンク
  - コードスパン・コードフェンス内は変換しません
  - 解決できない参照(未対応の種別・不正な指定)は書かれたまま残し、エラーにしません
- Markdown ツリー由来でない DB(凍結版の RD など)では警告を出して何も出力しません
- オプション未指定時の出力は従来と完全に同一です(sitemap.xml にも .md は載せません)

## 出力例(ミニツリーでの E2E 実走結果から)

```markdown
# class Array < Object

配列クラス。[Enumerable](../class/Enumerable.md) と [Array#index](../method/Array/i/index.md) も参照。

## Class Methods

- [new](../method/Array/s/new.md)

## Instance Methods

- [find_index](../method/Array/i/find_index.md)
- [index](../method/Array/i/index.md)
```

## 今後の課題(このリリースには含めない)

- `man:`/`rfc:` などの外部参照種別のリンク化(現状は書かれたまま)
- インデント形式のコードブロック内の変換除外(フェンスとコードスパンは除外済み)
- クラスページのライブラリ別グルーピング・継承メソッド一覧(HTML 相当の再現)
- 各種 index ページの md 版
- `ref:` のセクションラベル解決(現状はラベルに書かれた対象名を使用)

## テスト

- MarkdownExporter 単体 26 件(参照変換の各種別・コードスパン/フェンス除外・
  エスケープ・各ページ組み立て)+statichtml 統合 7 件(オプション・パス計算・
  md DB 判定・警告)を追加。全テストパス・`steep check` 型エラーなし
- ミニ md ツリー(builtin+capi+doc)で `init`→`update --markdowntree`→
  `statichtml --markdown-output` を実走し、全ページ種別の .md 生成とリンク解決を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
