### PR TITLE
コンテンツ表に罫線と余白を付けて読みやすくする

### DIFF
--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -365,6 +365,28 @@ td {
     vertical-align: top;
 }
 
+/* 本文中のコンテンツ表(Markdown のテーブル)。メソッド一覧などの
+   レイアウト表(table.entries)はカード状の現行スタイルのままとし、
+   ここではセルに罫線と余白を付けて読みやすくする。:not() 非対応の
+   古い環境(CHM ビューア等)では従来の見た目に落ちるだけで壊れない */
+table:not(.entries) {
+    margin: 0.5em 0 1em;
+}
+
+table:not(.entries) th,
+table:not(.entries) td {
+    border: 1px solid #bbb;
+    padding: 0.3em 0.8em;
+}
+
+table:not(.entries) th {
+    background-color: #dde;
+}
+
+table:not(.entries) tbody tr:nth-child(even) {
+    background-color: #f5f5f5;
+}
+
 table.entries {
     width: 100%;
     height: 100%;


### PR DESCRIPTION
rurema/doctree#3447 のレビューで挙がったコンテンツ表の見やすさ改善です。Markdown のテーブルはセルに罫線も余白もなく、詰まって見えていました。

## 内容

- `table:not(.entries)`(本文中のコンテンツ表)に限定して、セルに 1px の罫線と余白、淡いヘッダ背景(#AAC → #dde)、tbody 偶数行の縞を付けます
- `table.entries`(メソッド一覧・ライブラリ一覧などのカード状レイアウト表)は現行スタイルのまま変わりません(セレクタで除外。entries セルの個別ルールにも影響しません)
- `:not()` 非対応の古い環境(CHM ビューア等)ではルールが無視され、従来の見た目に落ちるだけで壊れません

## 検証

- mini md ツリー(IO.md)で statichtml を実走し、本文のコンテンツ表 4 つが素の `<table>`、レイアウト表(library/function の index とライブラリページのクラス一覧)が `class="entries ..."` で分離されていることを確認
- 生成物の style.css に新ルールが反映されることを確認
- 変更前後の比較ページで、IO の実マークアップ(空ヘッダセルの表・コードスパン入り 11 行の表)と entries 表の描画を確認(スクリーンショットは後述コメント参照)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
