### PR TITLE
RBS 型シグネチャをメソッド見出しの下に表示する(4.0 以降)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
       nkf
       progressbar (>= 1.9.0, < 2.0)
       rack
+      rbs (>= 3.10)
       rouge
       webrick
     bitclust-dev (1.6.1)

--- a/bitclust-core.gemspec
+++ b/bitclust-core.gemspec
@@ -37,4 +37,7 @@ EOD
   s.add_runtime_dependency "drb"
   s.add_runtime_dependency "nkf"
   s.add_runtime_dependency "json"
+  # rbssig サブコマンド(RBS シグネチャの取り込み)が使う。描画側は
+  # 使わないので、閲覧だけなら無くても動くが依存としては通常どおり宣言する
+  s.add_runtime_dependency "rbs", ">= 3.10"
 end

--- a/lib/bitclust/mdcompiler.rb
+++ b/lib/bitclust/mdcompiler.rb
@@ -126,6 +126,12 @@ module BitClust
           break
         end
       end
+      # RBS シグネチャは最後の <dt> の直後・説明 <dd> の直前に独立した
+      # <dd> として出す(rd 側 entry_chunk と同じ。rbs_sig property が
+      # 無ければ何も出ない)
+      if @method and (rbs_dd = rbs_signatures_dd(@method))
+        @out.puts rbs_dd
+      end
       @out.puts %Q(<dd class="#{@type.to_s}-description">)
       undef_message if attrs.include?('undef')
       while @f.next?

--- a/lib/bitclust/methodentry.rb
+++ b/lib/bitclust/methodentry.rb
@@ -10,6 +10,7 @@
 
 require 'bitclust/entry'
 require 'bitclust/exception'
+require 'json'
 
 module BitClust
 
@@ -118,6 +119,11 @@ module BitClust
       # 現れない前提。fill_since/fill_until で検査する）
       property :since_by_name,   '[String]'
       property :until_by_name,   '[String]'
+      # RBS シグネチャ表示。セグメント行列(RbsSigImporter 参照)の JSON
+      # 1 行を持つ。型シグネチャは ',' を普通に含むので [String] 型(','
+      # 区切り)は使えない。JSON は改行を含まず、property ファイルの
+      # key=value 1 行形式は値中の '=' を許す(split('=', 2))ので安全
+      property :rbs_sig,         'String'
     }
 
     def inspect
@@ -164,6 +170,19 @@ module BitClust
 
     def index_id
       "#{methodid2typechar(@id)}_#{encodename_fs(name).gsub(/=/, '--')}".upcase
+    end
+
+    # rbs_sig(JSON)をセグメント行列に戻す。property が無い古い DB(nil)・
+    # シグネチャ無しで保存された空文字列・未保存エントリの "(uninitialized)"
+    # センチネル・壊れた JSON はすべて nil(= 表示しない)に落として
+    # 描画側を守る
+    def rbs_signature_segments
+      json = rbs_sig()
+      return nil unless json && json.start_with?('[')
+      segments = JSON.parse(json)
+      segments.empty? ? nil : segments
+    rescue JSON::ParserError
+      nil
     end
 
     def labels

--- a/lib/bitclust/rbs_sig_importer.rb
+++ b/lib/bitclust/rbs_sig_importer.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+#
+# bitclust/rbs_sig_importer.rb
+#
+# RBS 型シグネチャ(.rbs)を読み込み、"Class#method"/"Class.method" キー →
+# セグメント行列の対応表を作って MethodEntry の rbs_sig property に書き込む
+# (rbssig サブコマンドが DB 構築後に呼ぶ)。
+#
+# セグメント行列は行(オーバーロードごと)の配列で、行は [種別, テキスト] の
+# 組の配列。種別 "t" は素のテキスト、"c" はクラス/モジュール名(描画側=
+# RbsSignatures が DB に存在するものだけリンク化する)。型名の位置は RBS
+# パーサの location で厳密に取り、行のテキストを連結すると元のシグネチャ
+# 文字列に戻る。rbs gem が必要なのは書き込み側のこのファイルだけで、描画側は
+# property を読むだけで動く。
+
+require 'rbs'
+require 'json'
+require 'pathname'
+
+module BitClust
+
+  class RbsSigImporter
+
+    # core_root: ruby/rbs チェックアウトの core/(組み込みクラスの型)
+    # repository_root: 同 stdlib/(core_root を与えると rbs が stringio を
+    #                  暗黙に要求するので、core_root とセットで渡す)
+    # sig_dirs: 素の .rbs ディレクトリ(テスト・追加分)
+    def initialize(core_root: nil, repository_root: nil, sig_dirs: [])
+      @core_root = core_root
+      @repository_root = repository_root
+      @sig_dirs = sig_dirs
+      @signatures = nil
+    end
+
+    # "Class#method"/"Class.method" → セグメント行列
+    def signatures
+      @signatures ||= build_signatures
+    end
+
+    # bitclust の typechar('i'/'s'/'m')と名前の並び(別名)で対応表を引く。
+    # モジュール関数(m)は def self?. 由来の # キーを先に、new は
+    # Class.new → Class#initialize の順で引く。見つからなければ nil
+    def lookup(class_name, typechar, names)
+      names.each do |name|
+        case typechar
+        when 'i'
+          sig = signatures["#{class_name}##{name}"]
+        when 's'
+          sig = signatures["#{class_name}.#{name}"]
+          sig ||= signatures["#{class_name}#initialize"] if name == 'new'
+        when 'm'
+          sig = signatures["#{class_name}##{name}"] || signatures["#{class_name}.#{name}"]
+        else
+          return nil
+        end
+        return sig if sig
+      end
+      nil
+    end
+
+    # DB の全メソッドエントリに対応表を引き、ヒットしたものへ rbs_sig
+    # property(JSON 1 行)を書き込む。書き方は MethodSinceCalculator#apply と
+    # 同じ(変更があったエントリだけ save)
+    def apply(db)
+      stats = { entries_updated: 0, sigs_matched: 0, methods_missed: 0 } #: stats
+      db.classes.each do |c|
+        c.entries.each do |m|
+          next if m.kind == :undefined
+          next unless %w[i s m].include?(m.typechar)
+          lines = lookup(c.name, m.typechar, m.names)
+          unless lines
+            stats[:methods_missed] += 1
+            next
+          end
+          stats[:sigs_matched] += 1
+          json = JSON.generate(lines)
+          next if m.rbs_sig == json
+          m.rbs_sig = json
+          m.save
+          stats[:entries_updated] += 1
+        end
+      end
+      stats
+    end
+
+    private
+
+    def build_signatures
+      env = load_environment
+      sigs = {} #: signatures
+      aliases = [] #: Array[[String, untyped]]
+      env.class_decls.each do |type_name, entry|
+        class_name = type_name.to_s.delete_prefix('::')
+        each_decl(entry) do |decl|
+          decl.members.each do |member|
+            case member
+            when RBS::AST::Members::MethodDefinition
+              lines = member.overloads.map {|o| method_type_segments(o.method_type.to_s) }
+              method_keys(class_name, member.name, member.kind).each do |key|
+                sigs[key] ||= lines
+              end
+            when RBS::AST::Members::AttrReader
+              sigs[attr_key(class_name, member, member.name)] ||= [type_segments(member.type.to_s)]
+            when RBS::AST::Members::AttrWriter
+              sigs[attr_key(class_name, member, "#{member.name}=")] ||= [type_segments(member.type.to_s)]
+            when RBS::AST::Members::AttrAccessor
+              line = [type_segments(member.type.to_s)]
+              sigs[attr_key(class_name, member, member.name)] ||= line
+              sigs[attr_key(class_name, member, "#{member.name}=")] ||= line
+            when RBS::AST::Members::Alias
+              aliases << [class_name, member]
+            end
+          end
+        end
+      end
+      resolve_aliases(sigs, aliases)
+      sigs
+    end
+
+    def load_environment
+      repository = RBS::Repository.new(no_stdlib: true)
+      if (repository_root = @repository_root)
+        repository.add(Pathname(repository_root))
+      end
+      core_root = @core_root
+      loader = RBS::EnvironmentLoader.new(
+        core_root: core_root && Pathname(core_root),
+        repository: repository)
+      @sig_dirs.each {|dir| loader.add(path: Pathname(dir)) }
+      env = RBS::Environment.new
+      loader.load(env: env)
+      env
+    end
+
+    # rbs 3.x は MultiEntry#decls、rbs 4.x は entry.each_decl
+    def each_decl(entry, &block)
+      if entry.respond_to?(:each_decl)
+        entry.each_decl(&block)
+      else
+        entry.decls.each {|d| block.call(d.decl) }
+      end
+    end
+
+    # def self?.(kind :singleton_instance)は Class.name と Class#name の
+    # 両方を定義する(bitclust のモジュール関数に対応)ので両キーに登録する
+    def method_keys(class_name, name, kind)
+      case kind
+      when :singleton
+        ["#{class_name}.#{name}"]
+      when :singleton_instance
+        ["#{class_name}.#{name}", "#{class_name}##{name}"]
+      else
+        ["#{class_name}##{name}"]
+      end
+    end
+
+    def attr_key(class_name, member, name)
+      member.kind == :singleton ? "#{class_name}.#{name}" : "#{class_name}##{name}"
+    end
+
+    # alias メンバーは元メソッドのシグネチャを共有する。alias が alias を
+    # 指すこともあるので、解決が進まなくなるまで繰り返す
+    def resolve_aliases(sigs, aliases)
+      until aliases.empty?
+        resolved, aliases = aliases.partition {|class_name, member|
+          sigs.key?(alias_key(class_name, member, member.old_name))
+        }
+        break if resolved.empty?
+        resolved.each do |class_name, member|
+          sigs[alias_key(class_name, member, member.new_name)] ||=
+            sigs[alias_key(class_name, member, member.old_name)]
+        end
+      end
+    end
+
+    def alias_key(class_name, member, name)
+      member.kind == :singleton ? "#{class_name}.#{name}" : "#{class_name}##{name}"
+    end
+
+    # メソッド型シグネチャ 1 行をセグメント列にする
+    def method_type_segments(sig)
+      method_type = RBS::Parser.parse_method_type(sig, require_eof: true)
+      locs = [] #: Array[[String, Integer]]
+      collect_function_type_names(method_type.type, locs)
+      collect_function_type_names(method_type.block.type, locs) if method_type.block
+      build_segments(sig, locs)
+    end
+
+    # attr 用: 型だけの文字列をセグメント列にする
+    def type_segments(sig)
+      type = RBS::Parser.parse_type(sig, require_eof: true)
+      locs = [] #: Array[[String, Integer]]
+      collect_type_names(type, locs)
+      build_segments(sig, locs)
+    end
+
+    def collect_function_type_names(fun, locs)
+      fun.each_param {|param| collect_type_names(param.type, locs) }
+      collect_type_names(fun.return_type, locs)
+    end
+
+    # クラス/モジュール参照(ClassInstance)の名前とその開始位置を集める。
+    # location の :name 子は "::String" のように名前空間プレフィクスを含む
+    # ので、end_pos から正規化名の長さを引いて名前本体の開始位置にする
+    # (:: はテキストセグメント側に残る)
+    def collect_type_names(type, locs)
+      case type
+      when RBS::Types::ClassInstance
+        name = type.name.to_s.delete_prefix('::')
+        if (loc = type.location)
+          name_loc = loc[:name] || loc
+          locs << [name, name_loc.end_pos - name.length]
+        end
+        type.args.each {|t| collect_type_names(t, locs) }
+      when RBS::Types::Union, RBS::Types::Intersection, RBS::Types::Tuple
+        type.types.each {|t| collect_type_names(t, locs) }
+      when RBS::Types::Optional
+        collect_type_names(type.type, locs)
+      when RBS::Types::Record
+        type.all_fields.each_value {|t, _required| collect_type_names(t, locs) }
+      when RBS::Types::Alias
+        # エイリアス型(string, hash 等)自体はクラスではないのでテキストの
+        # ままにするが、ジェネリクス引数の中のクラス名は拾う
+        type.args.each {|t| collect_type_names(t, locs) }
+      when RBS::Types::Proc
+        collect_function_type_names(type.type, locs)
+      end
+    end
+
+    def build_segments(sig, locs)
+      segments = [] #: segment_line
+      pos = 0
+      locs.sort_by {|_name, start| start }.each do |name, start|
+        # 位置が既出セグメントと重なる・実文字列と一致しない型は
+        # リンク化を諦めてテキストのまま残す(取りこぼしても表示は壊れない)
+        next if start < pos || sig[start, name.length] != name
+        segments << ['t', sig[pos...start] || raise] if start > pos
+        segments << ['c', name]
+        pos = start + name.length
+      end
+      segments << ['t', sig[pos..] || raise] if pos < sig.length
+      segments
+    end
+
+  end
+
+end

--- a/lib/bitclust/rbs_signatures.rb
+++ b/lib/bitclust/rbs_signatures.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+#
+# bitclust/rbs_signatures.rb
+#
+# メソッドエントリの RBS 型シグネチャ(rbs_sig property。RbsSigImporter が
+# DB 構築後に書き込む)を、シグネチャ見出し(<dt> 群)の直後・説明 <dd> の
+# 直前の独立した <dd class="rbs-signatures"> として描画する。property が
+# 無いエントリでは何も出さないので、出力は従来とバイト一致のまま。
+#
+# RDCompiler(md は MDCompiler が継承)に include される。escape_html /
+# class_link(いずれも HTMLUtils)と @option[:database] にだけ依存し、
+# rbs gem は使わない(型名の位置は property 側で解決済み)。
+
+module BitClust
+
+  module RbsSignatures
+
+    # entry の <dd class="rbs-signatures"> ブロック(1 行 = 1 オーバーロード)。
+    # シグネチャが無ければ nil
+    def rbs_signatures_dd(entry)
+      segments = entry.rbs_signature_segments
+      return nil unless segments
+      lines = segments.map {|line|
+        line.map {|kind, text| rbs_segment_html(kind, text) }.join
+      }
+      %Q(<dd class="rbs-signatures"><pre><code>#{lines.join("\n")}</code></pre></dd>)
+    end
+
+    private
+
+    def rbs_segment_html(kind, text)
+      if kind == 'c' and rbs_known_class?(text)
+        class_link(text)
+      else
+        escape_html(text).gsub('-&gt;', '&rarr;')
+      end
+    end
+
+    # DB に存在するクラス/モジュールだけリンク化する(自動生成リンクで
+    # 死リンクを作らないため。interface や型変数もここで自然に落ちる)。
+    # 同じページで同じ型名を何度も引くのでメモ化する
+    def rbs_known_class?(name)
+      @rbs_known_classes ||= {} #: Hash[String, bool]
+      @rbs_known_classes.fetch(name) {
+        db = @option[:database]
+        @rbs_known_classes[name] =
+          begin
+            db ? (db.fetch_class(name) && true) : false
+          rescue ClassNotFound
+            false
+          end
+      }
+    end
+
+  end
+
+end

--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -15,6 +15,7 @@ require 'bitclust/textutils'
 require 'bitclust/messagecatalog'
 require 'bitclust/syntax_highlighter'
 require 'bitclust/version_badges'
+require 'bitclust/rbs_signatures'
 require 'rouge'
 require 'stringio'
 
@@ -27,6 +28,7 @@ module BitClust
     include TextUtils
     include Translatable
     include VersionBadges
+    include RbsSignatures
 
     def initialize(urlmapper, hlevel = 1, opt = {})
       @urlmapper = urlmapper
@@ -135,6 +137,11 @@ module BitClust
         k, v = line.sub(/\A:/, '').split(':', 2)
         props[k&.strip] = v&.strip
       end if @type == :method
+      # RBS シグネチャは最後の <dt> の直後・説明 <dd> の直前に独立した
+      # <dd> として出す(rbs_sig property が無ければ何も出ない)
+      if @method and (rbs_dd = rbs_signatures_dd(@method))
+        @out.puts rbs_dd
+      end
       @out.puts %Q(<dd class="#{@type.to_s}-description">)
       undef_message if attrs.include?('undef')
       while @f.next?

--- a/lib/bitclust/runner.rb
+++ b/lib/bitclust/runner.rb
@@ -62,6 +62,7 @@ Subcommands(for developers):
     classes     Display defined classes for all ruby.
     methods     Display defined methods for all ruby.
     methodsince Fill per-name since/until from a version ladder of DBs.
+    rbssig      Fill RBS type signatures into a 4.0+ DB from .rbs files.
     checklink   Report broken [[c:]]/[[m:]]/[[lib:]]/[[d:]]/[[f:]] links.
 
 Subcommands(for packagers):
@@ -110,6 +111,7 @@ Global Options:
         'classes'     => BitClust::Subcommands::ClassesCommand.new,
         'methods'     => BitClust::Subcommands::MethodsCommand.new,
         'methodsince' => BitClust::Subcommands::MethodsinceCommand.new,
+        'rbssig'      => BitClust::Subcommands::RbssigCommand.new,
         'checklink'   => BitClust::Subcommands::ChecklinkCommand.new,
       }
     end

--- a/lib/bitclust/subcommands/rbssig_command.rb
+++ b/lib/bitclust/subcommands/rbssig_command.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+#
+# bitclust/subcommands/rbssig_command.rb
+#
+# RBS 型シグネチャを DB のメソッドエントリに書き込む(rbs_sig property):
+#
+#   bitclust rbssig --sig-root=RBS_CHECKOUT <dbpath>
+#   bitclust rbssig --sig-dir=DIR [--sig-dir=DIR ...] <dbpath>
+#
+# DB 構築(update)後・statichtml 前に実行する(methodsince と同じ位置)。
+# --sig-root には対象 Ruby バージョンに同梱される rbs のチェックアウト
+# (core/ と stdlib/ を含む)を渡す。表示は 4.0 以降のドキュメント専用
+# なので、DB の version が 4.0 未満ならエラーにする。
+
+require 'bitclust'
+require 'bitclust/subcommand'
+require 'bitclust/rbs_sig_importer'
+require 'tmpdir'
+require 'fileutils'
+
+module BitClust
+  module Subcommands
+    class RbssigCommand < Subcommand
+      MINIMUM_VERSION = Gem::Version.new('4.0')
+
+      def initialize
+        super
+        @sig_root = nil
+        @sig_dirs = []
+        @dry_run = false
+        @parser.banner = "Usage: #{File.basename($0, '.*')} rbssig [options] <dbpath>"
+        @parser.on('--sig-root=PATH', 'ruby/rbs checkout containing core/ and stdlib/.') {|path|
+          @sig_root = path
+        }
+        @parser.on('--sig-dir=PATH', 'Directory of extra .rbs files (repeatable).') {|path|
+          @sig_dirs.push path
+        }
+        @parser.on('--dry-run', 'Compute and print stats without saving.') {
+          @dry_run = true
+        }
+      end
+
+      # DB パスは位置引数で受けるのでグローバル --database は不要
+      def needs_database?
+        false
+      end
+
+      def exec(argv, options)
+        error('no --sig-root or --sig-dir given') if @sig_root.nil? && @sig_dirs.empty?
+        error("wrong number of arguments (#{argv.size} for 1)") unless argv.size == 1
+        path = argv.first
+        version = check_version(path)
+
+        sig_root = @sig_root
+        importer = RbsSigImporter.new(
+          core_root: sig_root && File.join(sig_root, 'core'),
+          repository_root: sig_root && File.join(sig_root, 'stdlib'),
+          sig_dirs: @sig_dirs)
+        stats =
+          if @dry_run
+            apply_dry_run(importer, path)
+          else
+            importer.apply(MethodDatabase.new(path))
+          end
+        puts "#{File.basename(path)} (version #{version}): " \
+             "entries_updated=#{stats[:entries_updated]} sigs_matched=#{stats[:sigs_matched]} " \
+             "methods_missed=#{stats[:methods_missed]}"
+      end
+
+      private
+
+      # RBS シグネチャ表示は 4.0 以降のドキュメント専用。比較は
+      # display_typemark(nameutils.rb)と同じく Gem::Version で行う
+      # (文字列比較だと "10.0" が "4.0" より小さく見える)
+      def check_version(path)
+        version = MethodDatabase.new(path).propget('version') or
+          error("#{path}: no version property (not a bitclust database?)")
+        begin
+          if Gem::Version.new(version) < MINIMUM_VERSION
+            error("#{path}: version #{version} is before 4.0; RBS signatures are only for 4.0+ databases")
+          end
+        rescue ArgumentError
+          error("#{path}: malformed version property: #{version.inspect}")
+        end
+        version
+      end
+
+      # --dry-run: 実 DB には書き込まず、複製に apply した統計だけを見せる
+      # (methodsince の apply_dry_run と同じ手口)
+      def apply_dry_run(importer, path)
+        Dir.mktmpdir do |tmp|
+          copy = File.join(tmp, 'db')
+          FileUtils.cp_r(path, copy)
+          importer.apply(MethodDatabase.new(copy))
+        end
+      end
+    end
+  end
+end

--- a/sig/bitclust/methodentry.rbs
+++ b/sig/bitclust/methodentry.rbs
@@ -47,6 +47,7 @@ module BitClust
     attr_accessor source_location: Location
     attr_accessor since_by_name: Array[String]
     attr_accessor until_by_name: Array[String]
+    attr_accessor rbs_sig: String?
 
     def inspect: () -> String
 
@@ -63,6 +64,10 @@ module BitClust
     def display_short_label: () -> String
 
     def index_id: () -> String
+
+    # rbs_sig(JSON)のデコード結果(RbsSigImporter::segment_line の配列)。
+    # 値が無い・壊れている場合は nil
+    def rbs_signature_segments: () -> Array[RbsSigImporter::segment_line]?
 
     def labels: () -> Array[String]
 

--- a/sig/bitclust/rbs_sig_importer.rbs
+++ b/sig/bitclust/rbs_sig_importer.rbs
@@ -1,0 +1,57 @@
+module BitClust
+  # RBS 型シグネチャ(.rbs)を "Class#method"/"Class.method" キーの
+  # セグメント行列にして MethodEntry の rbs_sig property に書き込む
+  class RbsSigImporter
+    # セグメント = [種別("t" は素のテキスト / "c" はクラス名), テキスト]
+    type segment = [String, String]
+
+    # 1 行 = 1 オーバーロードのシグネチャ
+    type segment_line = Array[segment]
+
+    type signatures = Hash[String, Array[segment_line]]
+
+    type stats = { entries_updated: Integer, sigs_matched: Integer, methods_missed: Integer }
+
+    @core_root: String?
+
+    @repository_root: String?
+
+    @sig_dirs: Array[String]
+
+    @signatures: signatures?
+
+    def initialize: (?core_root: String?, ?repository_root: String?, ?sig_dirs: Array[String]) -> void
+
+    def signatures: () -> signatures
+
+    def lookup: (String class_name, String typechar, Array[String] names) -> Array[segment_line]?
+
+    def apply: (MethodDatabase db) -> stats
+
+    private
+
+    def build_signatures: () -> signatures
+
+    def load_environment: () -> RBS::Environment
+
+    def each_decl: (untyped entry) { (untyped) -> void } -> void
+
+    def method_keys: (String class_name, Symbol name, Symbol kind) -> Array[String]
+
+    def attr_key: (String class_name, untyped member, Symbol | String name) -> String
+
+    def resolve_aliases: (signatures sigs, Array[[String, untyped]] aliases) -> void
+
+    def alias_key: (String class_name, untyped member, Symbol name) -> String
+
+    def method_type_segments: (String sig) -> segment_line
+
+    def type_segments: (String sig) -> segment_line
+
+    def collect_function_type_names: (untyped fun, Array[[String, Integer]] locs) -> void
+
+    def collect_type_names: (untyped type, Array[[String, Integer]] locs) -> void
+
+    def build_segments: (String sig, Array[[String, Integer]] locs) -> segment_line
+  end
+end

--- a/sig/bitclust/rbs_signatures.rbs
+++ b/sig/bitclust/rbs_signatures.rbs
@@ -1,0 +1,16 @@
+module BitClust
+  # メソッドエントリの RBS 型シグネチャ(rbs_sig property)を
+  # <dd class="rbs-signatures"> として描画する。RDCompiler(md は
+  # MDCompiler が継承)に include される
+  module RbsSignatures : HTMLUtils
+    @rbs_known_classes: Hash[String, bool]
+
+    def rbs_signatures_dd: (MethodEntry entry) -> String?
+
+    private
+
+    def rbs_segment_html: (String kind, String text) -> String
+
+    def rbs_known_class?: (String name) -> bool
+  end
+end

--- a/sig/bitclust/rdcompiler.rbs
+++ b/sig/bitclust/rdcompiler.rbs
@@ -1,5 +1,7 @@
 module BitClust
   class RDCompiler
+    include RbsSignatures
+
     @urlmapper: URLMapper
 
     @catalog: MessageCatalog?

--- a/sig/bitclust/subcommands/rbssig_command.rbs
+++ b/sig/bitclust/subcommands/rbssig_command.rbs
@@ -1,0 +1,27 @@
+module BitClust
+  module Subcommands
+    # RBS 型シグネチャを 4.0 以降の DB のメソッドエントリに書き込む
+    # (rbs_sig property)。DB 構築後・statichtml 前に実行する
+    class RbssigCommand < Subcommand
+      MINIMUM_VERSION: Gem::Version
+
+      @sig_root: String?
+
+      @sig_dirs: Array[String]
+
+      @dry_run: bool
+
+      def initialize: () -> void
+
+      def needs_database?: () -> bool
+
+      def exec: (Subcommand::argv argv, Subcommand::options options) -> void
+
+      private
+
+      def check_version: (String path) -> String
+
+      def apply_dry_run: (RbsSigImporter importer, String path) -> RbsSigImporter::stats
+    end
+  end
+end

--- a/sig/rbs.rbs
+++ b/sig/rbs.rbs
@@ -1,0 +1,112 @@
+# rbs gem の最小 shim(rouge.rbs と同じ流儀)。rbs_collection.yaml は
+# rbs gem 自身の型定義を明示的にスキップしているので、RbsSigImporter が
+# 使う定数とメソッドだけをほぼ untyped で手書きしてある
+module RBS
+  class EnvironmentLoader
+    def initialize: (?core_root: Pathname?, ?repository: Repository) -> void
+
+    def add: (?path: Pathname, ?library: String, ?version: String?) -> void
+
+    def load: (env: Environment) -> untyped
+  end
+
+  class Repository
+    def initialize: (?no_stdlib: bool) -> void
+
+    def add: (Pathname dir) -> void
+  end
+
+  class Environment
+    def initialize: () -> void
+
+    def class_decls: () -> Hash[untyped, untyped]
+  end
+
+  class Parser
+    def self.parse_method_type: (String source, ?require_eof: bool) -> untyped
+
+    def self.parse_type: (String source, ?require_eof: bool) -> untyped
+  end
+
+  module AST
+    module Members
+      class MethodDefinition
+        def name: () -> Symbol
+
+        def kind: () -> Symbol
+
+        def overloads: () -> Array[untyped]
+      end
+
+      class AttrReader
+        def name: () -> Symbol
+
+        def kind: () -> Symbol
+
+        def type: () -> untyped
+      end
+
+      class AttrWriter
+        def name: () -> Symbol
+
+        def kind: () -> Symbol
+
+        def type: () -> untyped
+      end
+
+      class AttrAccessor
+        def name: () -> Symbol
+
+        def kind: () -> Symbol
+
+        def type: () -> untyped
+      end
+
+      class Alias
+        def new_name: () -> Symbol
+
+        def old_name: () -> Symbol
+
+        def kind: () -> Symbol
+      end
+    end
+  end
+
+  module Types
+    class ClassInstance
+      def name: () -> untyped
+
+      def location: () -> untyped
+
+      def args: () -> Array[untyped]
+    end
+
+    class Union
+      def types: () -> Array[untyped]
+    end
+
+    class Intersection
+      def types: () -> Array[untyped]
+    end
+
+    class Tuple
+      def types: () -> Array[untyped]
+    end
+
+    class Optional
+      def type: () -> untyped
+    end
+
+    class Record
+      def all_fields: () -> Hash[untyped, [untyped, bool]]
+    end
+
+    class Alias
+      def args: () -> Array[untyped]
+    end
+
+    class Proc
+      def type: () -> untyped
+    end
+  end
+end

--- a/test/test_mdcompiler.rb
+++ b/test/test_mdcompiler.rb
@@ -23,7 +23,7 @@ class TestMDCompiler < Test::Unit::TestCase
     @rd = BitClust::RDCompiler.new(@u, 1, { :database => @db })
   end
 
-  def compile_method(compiler, src)
+  def compile_method(compiler, src, rbs_signature_segments: nil)
     method_entry = Object.new
     mock(method_entry).source { src }
     mock(method_entry).index_id.any_times { "dummy" }
@@ -32,6 +32,7 @@ class TestMDCompiler < Test::Unit::TestCase
     mock(method_entry).names.any_times { [] }
     mock(method_entry).since_map.any_times { {} }
     mock(method_entry).until_map.any_times { {} }
+    mock(method_entry).rbs_signature_segments.any_times { rbs_signature_segments }
     compiler.compile_method(method_entry)
   end
 
@@ -57,6 +58,19 @@ class TestMDCompiler < Test::Unit::TestCase
   end
 
   # ---- メソッドエントリ ----
+
+  # RBS シグネチャ表示: MDCompiler も entry_chunk をオーバーライドしている
+  # ので、rd 経路と同じ位置(説明 <dd> の直前)に同じ <dd> が出ること
+  def test_rbs_signatures_dd_matches_rd_output
+    rd_src = "--- index(val) -> Integer\n\n説明\n"
+    segments = [[['t', '() -> void']]]
+    md_src = BitClust::RRDToMarkdown.convert(rd_src)
+    rd_html = compile_method(@rd, rd_src, rbs_signature_segments: segments)
+    md_html = compile_method(@md, md_src, rbs_signature_segments: segments)
+    assert_include md_html,
+      '<dd class="rbs-signatures"><pre><code>() &rarr; void</code></pre></dd>'
+    assert_equal rd_html, md_html
+  end
 
   def test_method_signature_and_paragraph
     assert_equivalent_method <<~RD

--- a/test/test_methodentry.rb
+++ b/test/test_methodentry.rb
@@ -3,6 +3,7 @@ require 'bitclust'
 require 'bitclust/methoddatabase'
 require 'tmpdir'
 require 'fileutils'
+require 'json'
 
 class TestMethodEntryTitleLabels < Test::Unit::TestCase
   def test_title_labels_matches_label_when_no_alias
@@ -322,6 +323,100 @@ class TestMethodEntrySinceUntil < Test::Unit::TestCase
 
   def strip_property_line(id, key)
     path = property_file_path(id)
+    lines = File.readlines(path).reject {|l| l.start_with?("#{key}=") }
+    File.write(path, lines.join)
+  end
+end
+
+# rbs_sig property(RBS シグネチャ表示)。セグメント行列(行 = [種別, テキスト]
+# の配列)を JSON 1 行で 'String' 型 property に格納する。JSON は改行を含まず、
+# 値中の '=' や ',' も property ファイル(key=value 1 行形式)で安全。
+#
+# テストリスト:
+# [x] 既定は nil で rbs_signature_segments も nil
+# [x] JSON を入れて save → reload で round-trip する
+# [x] property 行が無い古い DB でも nil(後方互換)
+# [x] 空文字列(シグネチャ無しで save された値)も nil 扱い
+# [x] 壊れた JSON は nil 扱い(描画を落とさない)
+class TestMethodEntryRbsSig < Test::Unit::TestCase
+  SEGMENTS = [
+    [['t', '('], ['c', 'Integer'], ['t', ') -> '], ['c', 'String']],
+    [['t', '() -> void']],
+  ]
+
+  def setup
+    @dir = Dir.mktmpdir
+    @db = BitClust::MethodDatabase.new(@dir)
+    @db.init
+    @db.transaction do
+      @db.propset('version', '4.0')
+      @db.propset('encoding', 'utf-8')
+    end
+  end
+
+  def teardown
+    FileUtils.rm_rf(@dir)
+  end
+
+  # 未保存エントリの String 型 property は "(uninitialized)" センチネル
+  # なので、rbs_sig そのものではなく segments が nil であることを見る
+  def test_default_has_no_segments
+    m = build_entry('sig')
+    assert_nil m.rbs_signature_segments
+  end
+
+  def test_roundtrip
+    m = build_entry('sig')
+    m.rbs_sig = JSON.generate(SEGMENTS)
+    m.save
+
+    reloaded = reload_entry(m.id)
+    assert_equal(SEGMENTS, reloaded.rbs_signature_segments)
+  end
+
+  def test_missing_property_is_backward_compatible
+    m = build_entry('sig')
+    m.save
+    strip_property_line(m.id, 'rbs_sig')
+
+    reloaded = reload_entry(m.id)
+    assert_nil reloaded.rbs_sig
+    assert_nil reloaded.rbs_signature_segments
+  end
+
+  def test_saved_without_signature_is_treated_as_absent
+    m = build_entry('sig')
+    m.save
+
+    reloaded = reload_entry(m.id)
+    assert_nil reloaded.rbs_signature_segments
+  end
+
+  def test_broken_json_is_treated_as_absent
+    m = build_entry('sig')
+    m.rbs_sig = '{broken'
+    assert_nil m.rbs_signature_segments
+  end
+
+  private
+
+  def build_entry(name)
+    id = BitClust::NameUtils.build_method_id('_builtin', 'Foo', :instance_method, name)
+    m = BitClust::MethodEntry.new(@db, id)
+    m.names = [name]
+    m.visibility = :public
+    m.kind = :defined
+    m.source = "説明\n"
+    m
+  end
+
+  def reload_entry(id)
+    fresh_db = BitClust::MethodDatabase.new(@dir)
+    BitClust::MethodEntry.new(fresh_db, id)
+  end
+
+  def strip_property_line(id, key)
+    path = File.join(@dir, BitClust::NameUtils.encodeid("method/#{id}"))
     lines = File.readlines(path).reject {|l| l.start_with?("#{key}=") }
     File.write(path, lines.join)
   end

--- a/test/test_rbs_sig_importer.rb
+++ b/test/test_rbs_sig_importer.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'bitclust'
+require 'bitclust/methoddatabase'
+require 'bitclust/rbs_sig_importer'
+require 'tmpdir'
+require 'fileutils'
+require 'json'
+
+# RbsSigImporter(RBS シグネチャ表示)。.rbs 群から
+# "Class#method"/"Class.method" キー → セグメント行列の対応を作り、
+# MethodEntry の rbs_sig property に書き込む。
+#
+# セグメント行列 = 行(オーバーロードごと)の配列。行は [種別, テキスト] の
+# 配列で、種別 "t" は素のテキスト、"c" はクラス/モジュール名(描画側が
+# DB に存在すればリンク化する)。行のテキストを連結すると元の型シグネチャ
+# 文字列に戻る(往復可能)。
+#
+# テストリスト:
+# [x] instance/singleton メソッドが # / . キーになる
+# [x] overload は行ごとに分かれ、テキスト連結で元のシグネチャに戻る
+# [x] 型名は ["c", name] セグメントになる(引数・戻り値・ジェネリクスの中も)
+# [x] 名前空間付き型名は :: が直前のテキスト側に残る
+# [x] def self?. は # と . の両キーに登録される
+# [x] alias メンバーは元メソッドのシグネチャを共有する
+# [x] attr_reader/attr_writer は name / name= キーになり、型だけの行になる
+# [x] lookup: typechar i/s/m で引ける(m は # → . の順)
+# [x] lookup: new は Class.new → Class#initialize の順でフォールバック
+# [x] lookup: 別名リストの後ろの名前でもヒットする
+# [x] lookup: 対応が無ければ nil(定数・特殊変数も nil)
+# [x] apply: DB のエントリに rbs_sig(JSON)が書き込まれ、統計が返る
+# [x] apply: 対応が無いメソッドには書き込まれない
+# [x] apply: 2 回目は無変更(entries_updated=0)
+class TestRbsSigImporter < Test::Unit::TestCase
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @sig_dir = File.join(@tmpdir, 'sig')
+    FileUtils.mkdir_p(@sig_dir)
+    File.write(File.join(@sig_dir, 'foo.rbs'), <<~RBS)
+      class Foo
+        def initialize: (String) -> void
+        def bar: (Integer base) -> String
+               | (::Enumerator::Lazy) -> Array[Integer]
+        def self.build: () -> Foo
+        def self?.mf: () -> bool
+        alias car bar
+        attr_reader label: String
+        attr_writer width: Integer
+        def pairs: (hash[Symbol, String]) -> void
+      end
+    RBS
+    @importer = BitClust::RbsSigImporter.new(sig_dirs: [@sig_dir])
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_instance_and_singleton_methods_are_keyed
+    sigs = @importer.signatures
+    assert sigs.key?('Foo#bar')
+    assert sigs.key?('Foo#initialize')
+    assert sigs.key?('Foo.build')
+    assert_false sigs.key?('Foo#build')
+  end
+
+  def test_overload_lines_roundtrip_to_original_signature
+    lines = @importer.signatures['Foo#bar']
+    assert_equal 2, lines.size
+    assert_equal '(Integer base) -> String', join_text(lines[0])
+    assert_equal '(::Enumerator::Lazy) -> Array[Integer]', join_text(lines[1])
+  end
+
+  def test_type_names_become_class_segments
+    lines = @importer.signatures['Foo#bar']
+    assert_equal(
+      [['t', '('], ['c', 'Integer'], ['t', ' base) -> '], ['c', 'String']],
+      lines[0])
+  end
+
+  def test_namespace_prefix_stays_in_text_segment
+    lines = @importer.signatures['Foo#bar']
+    assert_equal(
+      [['t', '(::'], ['c', 'Enumerator::Lazy'], ['t', ') -> '],
+       ['c', 'Array'], ['t', '['], ['c', 'Integer'], ['t', ']']],
+      lines[1])
+  end
+
+  # 小文字のエイリアス型(hash 等)自体はテキストのままだが、その
+  # ジェネリクス引数の中のクラス名はリンク化候補にする
+  def test_alias_type_args_become_class_segments
+    lines = @importer.signatures['Foo#pairs']
+    assert_equal(
+      [['t', '(hash['], ['c', 'Symbol'], ['t', ', '], ['c', 'String'],
+       ['t', ']) -> void']],
+      lines[0])
+  end
+
+  def test_self_question_registers_both_keys
+    sigs = @importer.signatures
+    assert_equal sigs['Foo#mf'], sigs['Foo.mf']
+    assert_equal '() -> bool', join_text(sigs['Foo#mf'][0])
+  end
+
+  def test_alias_member_shares_signature
+    sigs = @importer.signatures
+    assert_equal sigs['Foo#bar'], sigs['Foo#car']
+  end
+
+  def test_attr_members
+    sigs = @importer.signatures
+    assert_equal 'String', join_text(sigs['Foo#label'][0])
+    assert_equal 'Integer', join_text(sigs['Foo#width='][0])
+    assert_equal [['c', 'String']], sigs['Foo#label'][0]
+  end
+
+  def test_lookup_by_typechar
+    sigs = @importer.signatures
+    assert_equal sigs['Foo#bar'], @importer.lookup('Foo', 'i', ['bar'])
+    assert_equal sigs['Foo.build'], @importer.lookup('Foo', 's', ['build'])
+    assert_equal sigs['Foo#mf'], @importer.lookup('Foo', 'm', ['mf'])
+  end
+
+  def test_lookup_new_falls_back_to_initialize
+    assert_equal @importer.signatures['Foo#initialize'],
+                 @importer.lookup('Foo', 's', ['new'])
+  end
+
+  def test_lookup_tries_every_alias_name
+    assert_equal @importer.signatures['Foo#bar'],
+                 @importer.lookup('Foo', 'i', ['zzz', 'bar'])
+  end
+
+  def test_lookup_misses_return_nil
+    assert_nil @importer.lookup('Foo', 'i', ['nope'])
+    assert_nil @importer.lookup('Bar', 'i', ['bar'])
+    assert_nil @importer.lookup('Foo', 'c', ['BAR'])
+    assert_nil @importer.lookup('Foo', 'v', ['$bar'])
+  end
+
+  def test_apply_writes_rbs_sig_property
+    prefix = build_db('4.0')
+    stats = @importer.apply(BitClust::MethodDatabase.new(prefix))
+
+    bar = find_entry(prefix, 'bar')
+    assert_equal @importer.signatures['Foo#bar'],
+                 JSON.parse(bar.rbs_sig)
+    assert_equal 1, stats[:entries_updated]
+    assert_equal 1, stats[:sigs_matched]
+    assert_equal 1, stats[:methods_missed]
+  end
+
+  def test_apply_leaves_unmatched_methods_untouched
+    prefix = build_db('4.0')
+    @importer.apply(BitClust::MethodDatabase.new(prefix))
+    assert_nil find_entry(prefix, 'nope').rbs_signature_segments
+  end
+
+  def test_apply_twice_is_idempotent
+    prefix = build_db('4.0')
+    @importer.apply(BitClust::MethodDatabase.new(prefix))
+    stats = @importer.apply(BitClust::MethodDatabase.new(prefix))
+    assert_equal 0, stats[:entries_updated]
+    assert_equal 1, stats[:sigs_matched]
+  end
+
+  private
+
+  def join_text(line)
+    line.map {|_kind, text| text }.join
+  end
+
+  def build_db(version)
+    root = "#{@tmpdir}/tree-#{version}/refm/api/src"
+    FileUtils.mkdir_p("#{root}/_builtin")
+    File.write("#{root}/LIBRARIES", "_builtin\n")
+    File.write("#{root}/_builtin.rd", <<~RD)
+      description
+
+      = class Foo < Object
+      == Instance Methods
+      --- bar(base) -> String
+
+      説明
+
+      --- nope -> nil
+
+      説明
+    RD
+    prefix = "#{@tmpdir}/db-#{version}"
+    db = BitClust::MethodDatabase.new(prefix)
+    db.init
+    db.transaction do
+      db.propset('version', version)
+      db.propset('encoding', 'utf-8')
+    end
+    db.transaction do
+      db.update_by_stdlibtree(root)
+    end
+    prefix
+  end
+
+  def find_entry(prefix, name)
+    db = BitClust::MethodDatabase.new(prefix)
+    db.get_class('Foo').entries.find {|m| m.name?(name) }
+  end
+end

--- a/test/test_rbssig_command.rb
+++ b/test/test_rbssig_command.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'bitclust'
+require 'bitclust/methoddatabase'
+require 'bitclust/subcommands/rbssig_command'
+require 'stringio'
+require 'tmpdir'
+require 'fileutils'
+require 'json'
+
+# rbssig サブコマンド(RBS シグネチャ表示)。
+#
+#   bitclust rbssig --sig-dir=DIR <dbpath>
+#   bitclust rbssig --sig-root=RBS_CHECKOUT <dbpath>
+#
+# RBS シグネチャは 4.0 以降のドキュメント専用なので、DB の version が
+# 4.0 未満ならエラーにする(比較は display_typemark と同じく Gem::Version。
+# 文字列比較だと "10.0" が "4.0" より小さく見える)。
+#
+# テストリスト:
+# [x] グローバル --database 不要(needs_database? が false)
+# [x] --sig-root/--sig-dir がどちらも無いとエラー
+# [x] dbpath がちょうど 1 個でないとエラー
+# [x] DB の version が 4.0 未満だとエラー
+# [x] version 10.0 は 4.0 以降として通る(Gem::Version 比較)
+# [x] 4.0 の DB に rbs_sig が書き込まれ、統計行が出力される
+# [x] --dry-run は統計だけ表示して実 DB には書き込まない
+# [x] --sig-root は core/ と stdlib/ を持つチェックアウトを読める
+# [x] Runner に登録されている(bitclust rbssig として呼べる)
+class TestRbssigCommand < Test::Unit::TestCase
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @sig_dir = File.join(@tmpdir, 'sig')
+    FileUtils.mkdir_p(@sig_dir)
+    File.write(File.join(@sig_dir, 'foo.rbs'), <<~RBS)
+      class Foo
+        def bar: (Integer) -> String
+      end
+    RBS
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_needs_no_global_database_option
+    cmd = BitClust::Subcommands::RbssigCommand.new
+    assert_false cmd.needs_database?
+  end
+
+  def test_no_sig_source_is_an_error
+    db = build_db('4.0')
+    assert_command_error([db])
+  end
+
+  def test_requires_exactly_one_dbpath
+    db = build_db('4.0')
+    assert_command_error(["--sig-dir=#{@sig_dir}"])
+    assert_command_error(["--sig-dir=#{@sig_dir}", db, db])
+  end
+
+  def test_old_database_version_is_an_error
+    db = build_db('3.4')
+    assert_command_error(["--sig-dir=#{@sig_dir}", db])
+  end
+
+  def test_version_10_passes_the_gate
+    db = build_db('10.0')
+    out = run_command(["--sig-dir=#{@sig_dir}", db])
+    assert_match(/version 10\.0/, out)
+    assert_equal [['t', '('], ['c', 'Integer'], ['t', ') -> '], ['c', 'String']],
+                 find_entry(db, 'bar').rbs_signature_segments[0]
+  end
+
+  def test_fills_rbs_sig_and_prints_stats
+    db = build_db('4.0')
+    out = run_command(["--sig-dir=#{@sig_dir}", db])
+    assert_equal '(Integer) -> String',
+                 find_entry(db, 'bar').rbs_signature_segments[0].map {|_k, t| t }.join
+    assert_nil find_entry(db, 'nope').rbs_signature_segments
+    assert_match(
+      /\Adb-4\.0 \(version 4\.0\): entries_updated=1 sigs_matched=1 methods_missed=1\n\z/,
+      out)
+  end
+
+  def test_dry_run_leaves_database_untouched
+    db = build_db('4.0')
+    out = run_command(["--sig-dir=#{@sig_dir}", db, '--dry-run'])
+    assert_nil find_entry(db, 'bar').rbs_signature_segments
+    assert_match(/entries_updated=1/, out)
+  end
+
+  def test_sig_root_reads_core_and_stdlib_layout
+    root = File.join(@tmpdir, 'rbs-checkout')
+    FileUtils.mkdir_p("#{root}/core")
+    File.write("#{root}/core/foo.rbs", <<~RBS)
+      class Foo
+        def bar: (String) -> Integer
+      end
+    RBS
+    # core_root を与えると rbs は stringio を暗黙に要求するので、
+    # 本物のチェックアウトと同じく stdlib/ も置く
+    FileUtils.mkdir_p("#{root}/stdlib/stringio/0")
+    File.write("#{root}/stdlib/stringio/0/stringio.rbs", "class StringIO\nend\n")
+
+    db = build_db('4.0')
+    run_command(["--sig-root=#{root}", db])
+    assert_equal '(String) -> Integer',
+                 find_entry(db, 'bar').rbs_signature_segments[0].map {|_k, t| t }.join
+  end
+
+  def test_registered_in_runner
+    require 'bitclust/runner'
+    runner = BitClust::Runner.new
+    runner.prepare
+    subcommands = runner.instance_variable_get(:@subcommands)
+    assert_kind_of BitClust::Subcommands::RbssigCommand, subcommands['rbssig']
+  end
+
+  private
+
+  def build_db(version)
+    root = "#{@tmpdir}/tree-#{version}/refm/api/src"
+    FileUtils.mkdir_p("#{root}/_builtin")
+    File.write("#{root}/LIBRARIES", "_builtin\n")
+    File.write("#{root}/_builtin.rd", <<~RD)
+      description
+
+      = class Foo < Object
+      == Instance Methods
+      --- bar(val) -> String
+
+      説明
+
+      --- nope -> nil
+
+      説明
+    RD
+    prefix = "#{@tmpdir}/db-#{version}"
+    db = BitClust::MethodDatabase.new(prefix)
+    db.init
+    db.transaction do
+      db.propset('version', version)
+      db.propset('encoding', 'utf-8')
+    end
+    db.transaction do
+      db.update_by_stdlibtree(root)
+    end
+    prefix
+  end
+
+  def find_entry(prefix, name)
+    db = BitClust::MethodDatabase.new(prefix)
+    db.get_class('Foo').entries.find {|m| m.name?(name) }
+  end
+
+  def run_command(argv)
+    cmd = BitClust::Subcommands::RbssigCommand.new
+    cmd.parse(argv)
+    out = StringIO.new
+    orig_stdout = $stdout
+    $stdout = out
+    begin
+      cmd.exec(argv, { prefix: nil, capi: false })
+    ensure
+      $stdout = orig_stdout
+    end
+    out.string
+  end
+
+  def assert_command_error(argv)
+    cmd = BitClust::Subcommands::RbssigCommand.new
+    cmd.parse(argv)
+    assert_raise(SystemExit) do
+      capture_stderr { cmd.exec(argv, { prefix: nil, capi: false }) }
+    end
+  end
+
+  def capture_stderr
+    orig = $stderr
+    $stderr = StringIO.new
+    yield
+  ensure
+    $stderr = orig
+  end
+end

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -28,7 +28,38 @@ class TestRDCompiler < Test::Unit::TestCase
     mock(method_entry).names.any_times{ names }
     mock(method_entry).since_map.any_times{ since_map }
     mock(method_entry).until_map.any_times{ until_map }
+    mock(method_entry).rbs_signature_segments.any_times{ nil }
     assert_equal(expected, @c.compile_method(method_entry))
+  end
+
+  # RBS シグネチャ表示: rbs_sig property を持つエントリだけが、最後の
+  # </dt> の直後・説明 <dd> の直前に独立した <dd class="rbs-signatures">
+  # ブロックを出す。型名セグメントは DB に存在するクラスだけリンク化し、
+  # テキストはエスケープした上で -> を &rarr; にする。
+  def test_method_with_rbs_signatures_renders_dd_block
+    stub(@db).fetch_class('String') { :exists }
+    stub(@db).fetch_class('Integer') { raise BitClust::ClassNotFound, 'Integer' }
+    segments = [
+      [['t', '('], ['c', 'Integer'], ['t', ') -> '], ['c', 'String']],
+      [['t', '(String & Integer) -> void']],
+    ]
+    method_entry = Object.new
+    mock(method_entry).source { "--- index(val) -> Integer\n\n説明\n" }
+    mock(method_entry).index_id.any_times { 'dummy' }
+    mock(method_entry).defined?.any_times { true }
+    mock(method_entry).id.any_times { 'String/i.index._builtin' }
+    mock(method_entry).names.any_times { [] }
+    mock(method_entry).since_map.any_times { {} }
+    mock(method_entry).until_map.any_times { {} }
+    mock(method_entry).rbs_signature_segments.any_times { segments }
+
+    html = @c.compile_method(method_entry)
+    assert_include html,
+      %Q[(Integer) &rarr; <a href="dummy/class/String">String</a>]
+    assert_include html, '(String &amp; Integer) &rarr; void'
+    assert_match(
+      %r!</dt>\n<dd class="rbs-signatures"><pre><code>.+</code></pre></dd>\n<dd class="method-description">!m,
+      html)
   end
 
   # badge のカタログ訳(「Ruby %s から」等)を検証するテストで使う、
@@ -230,6 +261,7 @@ HERE
     mock(method_entry).names.any_times { ['mf'] }
     mock(method_entry).since_map.any_times { {} }
     mock(method_entry).until_map.any_times { {} }
+    mock(method_entry).rbs_signature_segments.any_times { nil }
     mock(method_entry).klass.any_times { klass }
     mock(method_entry).display_typemark.any_times { '?.' }
 
@@ -250,6 +282,7 @@ HERE
     mock(method_entry).names.any_times { ['mf'] }
     mock(method_entry).since_map.any_times { {} }
     mock(method_entry).until_map.any_times { {} }
+    mock(method_entry).rbs_signature_segments.any_times { nil }
 
     html = @c.compile_method(method_entry)
     assert_include(html, '<code>mf</code>')
@@ -1029,6 +1062,7 @@ HERE
     mock(method_entry).names.any_times { [] }
     mock(method_entry).since_map.any_times { {} }
     mock(method_entry).until_map.any_times { {} }
+    mock(method_entry).rbs_signature_segments.any_times { nil }
     html = @c.compile_method(method_entry)
     assert_not_include(html, 'UNKNOWN_META_INFO')
     assert_not_include(html, '{:')
@@ -1052,6 +1086,7 @@ HERE
     mock(method_entry).names.any_times { [] }
     mock(method_entry).since_map.any_times { {} }
     mock(method_entry).until_map.any_times { {} }
+    mock(method_entry).rbs_signature_segments.any_times { nil }
     html = @c.compile_method(method_entry)
     assert_not_include(html, '{:')
     assert_include(html, 'to_a2')
@@ -1074,6 +1109,7 @@ HERE
     mock(method_entry).names.any_times { [] }
     mock(method_entry).since_map.any_times { {} }
     mock(method_entry).until_map.any_times { {} }
+    mock(method_entry).rbs_signature_segments.any_times { nil }
     html = @c.compile_method(method_entry)
     assert_not_include(html, '{:')
     assert_include(html, 'このメソッドは定義されていません。')

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -636,3 +636,19 @@ span.method-until-badge {
 }
 span.method-since-badge { background-color: #e6f2e6; color: #2d6a2d; }
 span.method-until-badge { background-color: #f7e6e6; color: #aa3333; }
+
+/* RBS 型シグネチャ(rbssig サブコマンドが 4.0 以降の DB に書き込み、
+   メソッド見出しの直下に <dd class="rbs-signatures"> として出る)。
+   参考情報なので、本文のコード例(背景色付きの pre)とは違う
+   控えめな見た目にする */
+dd.rbs-signatures {
+    margin: 0.3em 0 0.5em 4em;
+}
+dd.rbs-signatures pre {
+    background-color: transparent;
+    padding: 0 0 0.2em 0;
+    border-bottom: 1px dotted #ccc;
+    font-size: 85%;
+    color: #555;
+    line-height: 1.4;
+}

--- a/theme/lillia/style.css
+++ b/theme/lillia/style.css
@@ -317,6 +317,22 @@ span.method-until-badge {
 span.method-since-badge { background-color: #e6f2e6; color: #2d6a2d; }
 span.method-until-badge { background-color: #f7e6e6; color: #aa3333; }
 
+/* RBS 型シグネチャ(rbssig サブコマンドが 4.0 以降の DB に書き込み、
+   メソッド見出しの直下に <dd class="rbs-signatures"> として出る)。
+   参考情報なので控えめな見た目にする */
+dd.rbs-signatures {
+  margin: 0.3em 0 0.5em 2em;
+}
+dd.rbs-signatures pre {
+  background-color: transparent;
+  padding: 0 0 0.2em 0;
+  border: none;
+  border-bottom: 1px dotted #ccc;
+  font-size: 85%;
+  color: #555;
+  line-height: 1.4;
+}
+
 .method-description{
   padding-bottom: 10px;
   margin-bottom: 90px ; 


### PR DESCRIPTION
docs.ruby-lang.org の en/master(rdoc 8.0.0)は ruby/rdoc#1665 で call-seq の下に RBS 型シグネチャを表示するようになりました。bitclust にも同等の表示を追加します。表示対象は 4.0 以降のドキュメントのみです。

## 表示例

rbs 3.10.3(Ruby 4.0 同梱系列)の core を version 4.0 のミニ DB に適用した実出力(`String#sub` のメソッドページ)です:

```html
<dt class="method-heading" id="I_SUB"><code>sub(pattern, replace) -&gt; String</code>…</dt>
<dd class="rbs-signatures"><pre><code>(Regexp | string pattern, string | hash[<a href="../../../class/String.html">String</a>, _ToS] replacement) &rarr; <a href="../../../class/String.html">String</a>
(Regexp | string pattern) { (<a href="../../../class/String.html">String</a> match) &rarr; _ToS } &rarr; <a href="../../../class/String.html">String</a></code></pre></dd>
<dd class="method-description">…
```

- オーバーロードごとに 1 行、`->` は `→` で表示します
- 型名のうち **DB に存在するクラス/モジュールだけ**をリンク化します。interface(`_ToS`)・型変数・`string` などの型エイリアスは素のテキストのままなので、死リンクは作りません(型エイリアスのジェネリクス引数の中のクラス名、上例の `hash[String, _ToS]` の `String` は拾います)
- CSS は控えめな見た目(小さめ・薄色・下破線)で default/lillia 両テーマに追加しました

## 仕組み

`methodsince`(#132)と同じ「DB 構築後の注釈フェーズ + property + 描画時は DB を読むだけ」の構成です。

1. **書き込み**: 新サブコマンド `bitclust rbssig --sig-root=<ruby/rbs チェックアウト> <dbpath>` が `RBS::EnvironmentLoader` で core/(と stdlib/)を読み、`Class#method` / `Class.method` キーで MethodEntry と突き合わせて `rbs_sig` property(JSON 1 行)に書き込みます。`def self?.` は両キー登録(bitclust のモジュール関数に対応)、`new` は `Class.new` → `Class#initialize` の順、RBS の alias メンバーとエントリの別名(names)も解決します。対応が無いメソッドは何も表示しません
2. **格納**: property には行ごとの「テキスト/クラス名」のセグメント列を格納します(型名の位置は RBS パーサの location で厳密に取得。テキストを連結すると元のシグネチャ文字列に戻ります)。**rbs gem に依存するのは書き込み側だけ**で、server / statichtml / lookup は rbs なしで動きます
3. **描画**: `RDCompiler` / `MDCompiler` の entry_chunk で、最後の `</dt>` の直後・説明 `<dd>` の直前に独立した `<dd class="rbs-signatures">` ブロックを出します

## 4.0 ゲート

`.#` → `?.`(#250)と同じ Gem::Version 比較で、`rbssig` コマンドが DB の version が 4.0 未満のときエラーにします。3.x の DB には property 自体が入らないため、**既存 DB の描画出力は従来とバイト一致**です(既存テスト群がそのまま回帰テストになっています)。

## この PR 単体では本番に影響しません

doctree の Rakefile と generated-documents の日次ビルドへの組み込み(ruby/rbs チェックアウトの取得を含む)は別 PR で行います。`--sig-root` には対象 Ruby バージョンに同梱される rbs を渡す想定です(4.0 = rbs 3.10 系、4.1 は当面 rbs 4.0 系)。

## 検証

- `ruby test/run_test.rb`: 17940 tests, 100% passed(新規テスト 3 ファイル+既存 3 ファイルに追加)
- `steep check`: No type error、`rake sig`(rbs validate 含む)クリーン。`sig/rbs.rbs` は rouge.rbs と同じ流儀の最小 shim です(rbs_collection.yaml が rbs gem の型定義を明示的にスキップしているため)
- 実走 E2E: mini md ツリー(4.0)→ `rbssig --sig-root=<rbs 3.10.3 gem>` → statichtml で、メソッドページ・クラスページへの表示、ページ深さに応じた相対リンク、CSS 配布を確認。2 回目の適用は entries_updated=0(冪等)
- gemspec に `rbs >= 3.10` を追加し Gemfile.lock を更新済み。rbs 3.x/4.x の API 差(`decls` / `each_decl`)は吸収してあります

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
