### PR TITLE
RBS シグネチャ表示を dd+pre から dt+code の行に変更

### DIFF
--- a/lib/bitclust/mdcompiler.rb
+++ b/lib/bitclust/mdcompiler.rb
@@ -126,11 +126,11 @@ module BitClust
           break
         end
       end
-      # RBS シグネチャは最後の <dt> の直後・説明 <dd> の直前に独立した
-      # <dd> として出す(rd 側 entry_chunk と同じ。rbs_sig property が
-      # 無ければ何も出ない)
-      if @method and (rbs_dd = rbs_signatures_dd(@method))
-        @out.puts rbs_dd
+      # RBS シグネチャは見出し <dt> 群の直後・説明 <dd> の直前に <dt> 行と
+      # して出す(rd 側 entry_chunk と同じ。rbs_sig property が無ければ
+      # 何も出ない)
+      if @method and (rbs_dts = rbs_signature_dts(@method))
+        @out.puts rbs_dts
       end
       @out.puts %Q(<dd class="#{@type.to_s}-description">)
       undef_message if attrs.include?('undef')

--- a/lib/bitclust/rbs_signatures.rb
+++ b/lib/bitclust/rbs_signatures.rb
@@ -4,8 +4,10 @@
 #
 # メソッドエントリの RBS 型シグネチャ(rbs_sig property。RbsSigImporter が
 # DB 構築後に書き込む)を、シグネチャ見出し(<dt> 群)の直後・説明 <dd> の
-# 直前の独立した <dd class="rbs-signatures"> として描画する。property が
-# 無いエントリでは何も出さないので、出力は従来とバイト一致のまま。
+# 直前に 1 オーバーロード 1 行の <dt class="rbs-signature"> として描画する。
+# dd だと字下げで説明の一部に見え、pre だと theme/script.js が COPY ボタンを
+# 付けてしまうため、見出しと同じ dt+code の並びにする。property が無い
+# エントリでは何も出さないので、出力は従来とバイト一致のまま。
 #
 # RDCompiler(md は MDCompiler が継承)に include される。escape_html /
 # class_link(いずれも HTMLUtils)と @option[:database] にだけ依存し、
@@ -15,15 +17,15 @@ module BitClust
 
   module RbsSignatures
 
-    # entry の <dd class="rbs-signatures"> ブロック(1 行 = 1 オーバーロード)。
-    # シグネチャが無ければ nil
-    def rbs_signatures_dd(entry)
+    # entry の <dt class="rbs-signature"> 行(1 オーバーロード = 1 <dt>)を
+    # 改行で連結して返す。シグネチャが無ければ nil
+    def rbs_signature_dts(entry)
       segments = entry.rbs_signature_segments
       return nil unless segments
-      lines = segments.map {|line|
-        line.map {|kind, text| rbs_segment_html(kind, text) }.join
-      }
-      %Q(<dd class="rbs-signatures"><pre><code>#{lines.join("\n")}</code></pre></dd>)
+      segments.map {|line|
+        html = line.map {|kind, text| rbs_segment_html(kind, text) }.join
+        %Q(<dt class="rbs-signature"><code>#{html}</code></dt>)
+      }.join("\n")
     end
 
     private

--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -137,10 +137,10 @@ module BitClust
         k, v = line.sub(/\A:/, '').split(':', 2)
         props[k&.strip] = v&.strip
       end if @type == :method
-      # RBS シグネチャは最後の <dt> の直後・説明 <dd> の直前に独立した
-      # <dd> として出す(rbs_sig property が無ければ何も出ない)
-      if @method and (rbs_dd = rbs_signatures_dd(@method))
-        @out.puts rbs_dd
+      # RBS シグネチャは見出し <dt> 群の直後・説明 <dd> の直前に <dt> 行と
+      # して出す(rbs_sig property が無ければ何も出ない)
+      if @method and (rbs_dts = rbs_signature_dts(@method))
+        @out.puts rbs_dts
       end
       @out.puts %Q(<dd class="#{@type.to_s}-description">)
       undef_message if attrs.include?('undef')

--- a/sig/bitclust/rbs_signatures.rbs
+++ b/sig/bitclust/rbs_signatures.rbs
@@ -1,11 +1,11 @@
 module BitClust
   # メソッドエントリの RBS 型シグネチャ(rbs_sig property)を
-  # <dd class="rbs-signatures"> として描画する。RDCompiler(md は
+  # <dt class="rbs-signature"> 行として描画する。RDCompiler(md は
   # MDCompiler が継承)に include される
   module RbsSignatures : HTMLUtils
     @rbs_known_classes: Hash[String, bool]
 
-    def rbs_signatures_dd: (MethodEntry entry) -> String?
+    def rbs_signature_dts: (MethodEntry entry) -> String?
 
     private
 

--- a/test/test_mdcompiler.rb
+++ b/test/test_mdcompiler.rb
@@ -60,15 +60,15 @@ class TestMDCompiler < Test::Unit::TestCase
   # ---- メソッドエントリ ----
 
   # RBS シグネチャ表示: MDCompiler も entry_chunk をオーバーライドしている
-  # ので、rd 経路と同じ位置(説明 <dd> の直前)に同じ <dd> が出ること
-  def test_rbs_signatures_dd_matches_rd_output
+  # ので、rd 経路と同じ位置(説明 <dd> の直前)に同じ <dt> が出ること
+  def test_rbs_signatures_dt_matches_rd_output
     rd_src = "--- index(val) -> Integer\n\n説明\n"
     segments = [[['t', '() -> void']]]
     md_src = BitClust::RRDToMarkdown.convert(rd_src)
     rd_html = compile_method(@rd, rd_src, rbs_signature_segments: segments)
     md_html = compile_method(@md, md_src, rbs_signature_segments: segments)
     assert_include md_html,
-      '<dd class="rbs-signatures"><pre><code>() &rarr; void</code></pre></dd>'
+      '<dt class="rbs-signature"><code>() &rarr; void</code></dt>'
     assert_equal rd_html, md_html
   end
 

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -32,11 +32,13 @@ class TestRDCompiler < Test::Unit::TestCase
     assert_equal(expected, @c.compile_method(method_entry))
   end
 
-  # RBS シグネチャ表示: rbs_sig property を持つエントリだけが、最後の
-  # </dt> の直後・説明 <dd> の直前に独立した <dd class="rbs-signatures">
-  # ブロックを出す。型名セグメントは DB に存在するクラスだけリンク化し、
-  # テキストはエスケープした上で -> を &rarr; にする。
-  def test_method_with_rbs_signatures_renders_dd_block
+  # RBS シグネチャ表示: rbs_sig property を持つエントリだけが、メソッド
+  # 見出しの <dt> 群の直後・説明 <dd> の直前に 1 オーバーロード 1 行の
+  # <dt class="rbs-signature"> を出す(dd だと説明の一部に見える。pre を
+  # 使うと script.js が COPY ボタンを付けてしまうので code のみ)。
+  # 型名セグメントは DB に存在するクラスだけリンク化し、テキストは
+  # エスケープした上で -> を &rarr; にする。
+  def test_method_with_rbs_signatures_renders_dt_lines
     stub(@db).fetch_class('String') { :exists }
     stub(@db).fetch_class('Integer') { raise BitClust::ClassNotFound, 'Integer' }
     segments = [
@@ -58,8 +60,9 @@ class TestRDCompiler < Test::Unit::TestCase
       %Q[(Integer) &rarr; <a href="dummy/class/String">String</a>]
     assert_include html, '(String &amp; Integer) &rarr; void'
     assert_match(
-      %r!</dt>\n<dd class="rbs-signatures"><pre><code>.+</code></pre></dd>\n<dd class="method-description">!m,
+      %r!</dt>\n(<dt class="rbs-signature"><code>.+</code></dt>\n){2}<dd class="method-description">!,
       html)
+    assert_not_match(/<pre|<dd class="rbs-/, html)
   end
 
   # badge のカタログ訳(「Ruby %s から」等)を検証するテストで使う、

--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -638,17 +638,17 @@ span.method-since-badge { background-color: #e6f2e6; color: #2d6a2d; }
 span.method-until-badge { background-color: #f7e6e6; color: #aa3333; }
 
 /* RBS 型シグネチャ(rbssig サブコマンドが 4.0 以降の DB に書き込み、
-   メソッド見出しの直下に <dd class="rbs-signatures"> として出る)。
-   参考情報なので、本文のコード例(背景色付きの pre)とは違う
-   控えめな見た目にする */
-dd.rbs-signatures {
-    margin: 0.3em 0 0.5em 4em;
-}
-dd.rbs-signatures pre {
-    background-color: transparent;
-    padding: 0 0 0.2em 0;
-    border-bottom: 1px dotted #ccc;
+   メソッド見出しの <dt> 群の直後に 1 オーバーロード 1 行の
+   <dt class="rbs-signature"> として出る)。参考情報なのでメソッド
+   見出しより控えめな見た目にし、インラインコードのチップ背景も外す */
+dt.rbs-signature {
+    font-weight: normal;
     font-size: 85%;
     color: #555;
     line-height: 1.4;
+}
+dt.rbs-signature code {
+    background-color: transparent;
+    padding: 0;
+    border-radius: 0;
 }

--- a/theme/lillia/style.css
+++ b/theme/lillia/style.css
@@ -318,19 +318,19 @@ span.method-since-badge { background-color: #e6f2e6; color: #2d6a2d; }
 span.method-until-badge { background-color: #f7e6e6; color: #aa3333; }
 
 /* RBS 型シグネチャ(rbssig サブコマンドが 4.0 以降の DB に書き込み、
-   メソッド見出しの直下に <dd class="rbs-signatures"> として出る)。
-   参考情報なので控えめな見た目にする */
-dd.rbs-signatures {
-  margin: 0.3em 0 0.5em 2em;
-}
-dd.rbs-signatures pre {
-  background-color: transparent;
-  padding: 0 0 0.2em 0;
-  border: none;
-  border-bottom: 1px dotted #ccc;
+   メソッド見出しの <dt> 群の直後に 1 オーバーロード 1 行の
+   <dt class="rbs-signature"> として出る)。参考情報なのでメソッド
+   見出しより控えめな見た目にし、インラインコードのチップ背景も外す */
+dt.rbs-signature {
+  font-weight: normal;
   font-size: 85%;
   color: #555;
   line-height: 1.4;
+}
+dt.rbs-signature code {
+  background-color: transparent;
+  padding: 0;
+  border-radius: 0;
 }
 
 .method-description{


### PR DESCRIPTION
#321 で入れた RBS シグネチャ表示のマークアップを `<dd><pre><code>` から、1 オーバーロード 1 行の `<dt class="rbs-signature"><code>` に変更します。

## 理由

- `<dd>` だと字下げされて説明の一部に見えてしまう。型シグネチャはメソッド見出しの一部なので、見出しの `<dt>` 群の続きとして並べる方が構造にも合う
- `<pre>` は theme/default/script.js が全 `pre` に付ける COPY ボタンの対象になってしまう。型シグネチャはコピーして使うものではないので `pre` をやめ、`dt` + `code` にする(COPY ボタンは自然に付かなくなる)

## 変更内容

出力の変化(`String#sub` の例):

```html
<!-- before -->
<dt class="method-heading" ...><code>sub(pattern, replace) -&gt; String</code>...</dt>
<dd class="rbs-signatures"><pre><code>(Regexp | string pattern, ...) &rarr; String
(Regexp | string pattern) { ... } &rarr; String</code></pre></dd>
<dd class="method-description">

<!-- after -->
<dt class="method-heading" ...><code>sub(pattern, replace) -&gt; String</code>...</dt>
<dt class="rbs-signature"><code>(Regexp | string pattern, ...) &rarr; String</code></dt>
<dt class="rbs-signature"><code>(Regexp | string pattern) { ... } &rarr; String</code></dt>
<dd class="method-description">
```

- CSS は両テーマ(default/lillia)とも `dt` の太字とインラインコードのチップ背景を打ち消し、85%・グレーの控えめな見た目にします
- `rbs_sig` property のフォーマットや rbssig サブコマンドには変更ありません(描画層のみ)

## 検証

- `ruby test/run_test.rb` 17940 tests 全パス
- `bundle exec steep check` No type error
- ミニ md ツリー + rbssig 済み DB で `lookup --html` を実行し、見出し `dt` 群の直後にオーバーロードごとの `dt` 行が出ること・`pre` が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
