### PR TITLE
RBS オーバーロードを引数パターンごとの説明チャンクへ振り分ける

### DIFF
--- a/lib/bitclust/mdcompiler.rb
+++ b/lib/bitclust/mdcompiler.rb
@@ -126,10 +126,10 @@ module BitClust
           break
         end
       end
-      # RBS シグネチャは見出し <dt> 群の直後・説明 <dd> の直前に <dt> 行と
-      # して出す(rd 側 entry_chunk と同じ。rbs_sig property が無ければ
-      # 何も出ない)
-      if @method and (rbs_dts = rbs_signature_dts(@method))
+      # RBS シグネチャは見出し <dt> 群の直後・説明 <dd> の直前に、この
+      # チャンクへ振り分けられたぶんだけ <dt> 行として出す(rd 側
+      # entry_chunk と同じ。rbs_sig property が無ければ何も出ない)
+      if (rbs_dts = rbs_signature_dts_for_chunk())
         @out.puts rbs_dts
       end
       @out.puts %Q(<dd class="#{@type.to_s}-description">)
@@ -188,6 +188,12 @@ module BitClust
     # （MethodSignature.parse・permalink・edit link）を継承する
     def method_signature(sig_line, first)
       super(sig_line.sub(signature_re, '--- '), first)
+    end
+
+    # RBS シグネチャのチャンク走査（RbsSignatures）用: md のシグネチャ行を
+    # rd の正規形にして返す（method_signature と同じ変換）
+    def rbs_signature_line(line)
+      line.sub(signature_re, '--- ') if signature_re =~ line
     end
 
     def headline(line)

--- a/lib/bitclust/methodentry.rb
+++ b/lib/bitclust/methodentry.rb
@@ -119,9 +119,9 @@ module BitClust
       # 現れない前提。fill_since/fill_until で検査する）
       property :since_by_name,   '[String]'
       property :until_by_name,   '[String]'
-      # RBS シグネチャ表示。セグメント行列(RbsSigImporter 参照)の JSON
-      # 1 行を持つ。型シグネチャは ',' を普通に含むので [String] 型(','
-      # 区切り)は使えない。JSON は改行を含まず、property ファイルの
+      # RBS シグネチャ表示。オーバーロード配列(RbsSigImporter 参照)の
+      # JSON 1 行を持つ。型シグネチャは ',' を普通に含むので [String] 型
+      # (',' 区切り)は使えない。JSON は改行を含まず、property ファイルの
       # key=value 1 行形式は値中の '=' を許す(split('=', 2))ので安全
       property :rbs_sig,         'String'
     }
@@ -172,15 +172,20 @@ module BitClust
       "#{methodid2typechar(@id)}_#{encodename_fs(name).gsub(/=/, '--')}".upcase
     end
 
-    # rbs_sig(JSON)をセグメント行列に戻す。property が無い古い DB(nil)・
+    # rbs_sig(JSON)をオーバーロード配列に戻す。現行形式は
+    # {"overloads":[{"segments":..., "params":..., "arity":..., "block":...}]}
+    # で、セグメント行列そのものの配列だった旧形式の DB は segments だけの
+    # オーバーロード列に読み替える。property が無い古い DB(nil)・
     # シグネチャ無しで保存された空文字列・未保存エントリの "(uninitialized)"
     # センチネル・壊れた JSON はすべて nil(= 表示しない)に落として
     # 描画側を守る
-    def rbs_signature_segments
+    def rbs_signature_overloads
       json = rbs_sig()
-      return nil unless json && json.start_with?('[')
-      segments = JSON.parse(json)
-      segments.empty? ? nil : segments
+      return nil unless json && (json.start_with?('{') || json.start_with?('['))
+      data = JSON.parse(json)
+      overloads = data.is_a?(Hash) ? data['overloads']
+                                   : data.map {|segments| {'segments' => segments} }
+      overloads.is_a?(Array) && !overloads.empty? ? overloads : nil
     rescue JSON::ParserError
       nil
     end

--- a/lib/bitclust/rbs_overload_matcher.rb
+++ b/lib/bitclust/rbs_overload_matcher.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+#
+# bitclust/rbs_overload_matcher.rb
+#
+# RBS のオーバーロードを、引数パターンごとに分かれた説明チャンク
+# (Array.new / Array#[] のように同名メソッドの `---` 見出し+説明の組が
+# 複数あるもの)へ振り分ける。RBS の引数名は rdoc の call-seq 由来で
+# rurema のシグネチャの引数名とよく一致するため、
+# 「ブロック有無 → 引数名の一致 → アリティ範囲の重なり」のスコアで
+# 最も近いチャンクを選ぶ。1:1 対応は原理的に保証されない
+# (RBS の () と (int size, ?Elem val) が rurema では同一チャンク等)ので、
+# 多対 1 の割り当てとし、確実な対応が取れないオーバーロードは先頭チャンクに
+# 寄せる(どのチャンクにも重複しては出さない)。
+#
+# オーバーロードのメタ情報(params/arity/block)は RbsSigImporter が
+# rbs_sig property の JSON に書き込んだものをそのまま(文字列キーの Hash で)
+# 受け取る。チャンク側は正規化済みシグネチャ行("--- " 始まり)を
+# MethodSignature.parse で解析する。
+
+require 'bitclust/methodsignature'
+require 'bitclust/exception'
+
+module BitClust
+
+  module RbsOverloadMatcher
+
+    module_function
+
+    # overloads: rbs_sig JSON の overloads 配列(文字列キー Hash の配列)
+    # chunks: チャンクごとの正規化済みシグネチャ行("--- " 始まり)の配列
+    # 返り値: チャンクごとのオーバーロード添字の配列(chunks と同じ長さ)
+    def assign(overloads, chunks)
+      result = Array.new(chunks.size) { [] } #: Array[Array[Integer]]
+      return result if chunks.empty?
+      if chunks.size == 1
+        result[0] = (0...overloads.size).to_a
+        return result
+      end
+      features = chunks.map {|lines| chunk_features(lines) }
+      overloads.each_index do |i|
+        ov = overload_features(overloads[i])
+        result[ov ? best_chunk(ov, features) : 0] << i
+      end
+      result
+    end
+
+    # チャンクのシグネチャ行群から照合用の特徴を合算する。
+    # 1 行も解析できなければ nil(振り分け先にしない)
+    def chunk_features(sig_lines)
+      names = [] #: Array[String]
+      min = nil #: Integer?
+      max = 0 #: Integer?
+      block = false
+      parsed = false
+      sig_lines.each do |line|
+        begin
+          sig = MethodSignature.parse(line)
+        rescue ParseError
+          next
+        end
+        parsed = true
+        block ||= !sig.block.nil?
+        pmin, pmax, pnames, pblock = params_features(sig.params)
+        block ||= pblock
+        names.concat(pnames)
+        min = pmin if min.nil? || pmin < min
+        max = (max && pmax) ? [max, pmax].max : nil
+      end
+      return nil unless parsed
+      { names: names, min: min || 0, max: max, block: block }
+    end
+
+    # rbs_sig JSON のオーバーロード 1 個からスコア用の特徴を取り出す。
+    # メタ情報が無いもの(#322 以前の旧形式・attr・(?) 型)は nil
+    def overload_features(overload)
+      arity = overload['arity']
+      params = overload['params']
+      block = overload['block']
+      return nil unless arity || params || block
+      { names: params || [],
+        min: arity && arity[0],
+        max: arity && arity[1],
+        block: block }
+    end
+
+    # ---- 以下は実装詳細(module_function なので呼べてしまうが非公開扱い) ----
+
+    def best_chunk(overload, features)
+      best = 0
+      best_score = nil #: Integer?
+      features.each_with_index do |chunk, i|
+        next unless chunk
+        s = score(overload, chunk)
+        if best_score.nil? || s > best_score
+          best = i
+          best_score = s
+        end
+      end
+      best
+    end
+
+    # ブロックの一致(または矛盾)を最優先に、引数名の一致 > アリティ範囲の
+    # 重なりで加点する。同点は先頭チャンク優先(best_chunk が > で更新)
+    def score(overload, chunk)
+      s = 0
+      case overload[:block]
+      when 'req'
+        s += chunk[:block] ? 2 : -3
+      when 'opt'
+        s += 1
+      else
+        s += chunk[:block] ? -3 : 2
+      end
+      s += 2 * (overload[:names] & chunk[:names]).size
+      if overload[:min] && chunk[:min]
+        omax = overload[:max] || Float::INFINITY
+        cmax = chunk[:max] || Float::INFINITY
+        s += (overload[:min] <= cmax && chunk[:min] <= omax) ? 1 : -2
+      end
+      s
+    end
+
+    # シグネチャの引数リスト文字列 → [最小アリティ, 最大アリティ(nil=無制限),
+    # 引数名(位置引数+キーワード名。**kwrest 名も含む), ブロック有無(&引数)]
+    def params_features(params)
+      return [0, 0, [], false] if params.nil? || params.strip.empty?
+      required = 0
+      optional = 0
+      rest = false
+      block = false
+      names = [] #: Array[String]
+      split_top_level(params).each do |token|
+        token = token.strip
+        next if token.empty?
+        name = token[/[A-Za-z_]\w*/]
+        case token
+        when /\A&/
+          block = true
+        when /\A\*\*/
+          names << name if name
+        when /\A\*/, '...'
+          rest = true
+          names << name if name
+        when /\A[A-Za-z_]\w*:/
+          names << (name || raise)
+        when /=/
+          optional += 1
+          names << name if name
+        else
+          required += 1
+          names << name if name
+        end
+      end
+      [required, rest ? nil : required + optional, names, block]
+    end
+
+    # 括弧((), [], {})のネストを無視して最上位の ',' で分割する
+    # (デフォルト値の中の ',' で切らないため)
+    def split_top_level(str)
+      tokens = [+''] #: Array[String]
+      depth = 0
+      str.each_char do |c|
+        case c
+        when '(', '[', '{' then depth += 1
+        when ')', ']', '}' then depth -= 1
+        when ','
+          if depth == 0
+            tokens << +''
+            next
+          end
+        end
+        tokens.last << c
+      end
+      tokens
+    end
+
+  end
+
+end

--- a/lib/bitclust/rbs_sig_importer.rb
+++ b/lib/bitclust/rbs_sig_importer.rb
@@ -3,15 +3,17 @@
 # bitclust/rbs_sig_importer.rb
 #
 # RBS 型シグネチャ(.rbs)を読み込み、"Class#method"/"Class.method" キー →
-# セグメント行列の対応表を作って MethodEntry の rbs_sig property に書き込む
-# (rbssig サブコマンドが DB 構築後に呼ぶ)。
+# オーバーロード配列の対応表を作って MethodEntry の rbs_sig property に
+# 書き込む(rbssig サブコマンドが DB 構築後に呼ぶ)。
 #
-# セグメント行列は行(オーバーロードごと)の配列で、行は [種別, テキスト] の
-# 組の配列。種別 "t" は素のテキスト、"c" はクラス/モジュール名(描画側=
-# RbsSignatures が DB に存在するものだけリンク化する)。型名の位置は RBS
-# パーサの location で厳密に取り、行のテキストを連結すると元のシグネチャ
-# 文字列に戻る。rbs gem が必要なのは書き込み側のこのファイルだけで、描画側は
-# property を読むだけで動く。
+# オーバーロードは Hash 1 個: "segments" = [種別, テキスト] の組の配列
+# (種別 "t" は素のテキスト、"c" はクラス/モジュール名で、描画側=
+# RbsSignatures が DB に存在するものだけリンク化する。テキストを連結すると
+# 元のシグネチャ文字列に戻る)に加え、説明チャンクへの振り分け
+# (RbsOverloadMatcher)用のメタ情報 "params"(引数名)・"arity"
+# ([最小, 最大|nil])・"block"("req"/"opt")を持つ。型名の位置は RBS
+# パーサの location で厳密に取る。rbs gem が必要なのは書き込み側のこの
+# ファイルだけで、描画側は property を読むだけで動く。
 
 require 'rbs'
 require 'json'
@@ -32,7 +34,7 @@ module BitClust
       @signatures = nil
     end
 
-    # "Class#method"/"Class.method" → セグメント行列
+    # "Class#method"/"Class.method" → オーバーロード配列
     def signatures
       @signatures ||= build_signatures
     end
@@ -67,13 +69,13 @@ module BitClust
         c.entries.each do |m|
           next if m.kind == :undefined
           next unless %w[i s m].include?(m.typechar)
-          lines = lookup(c.name, m.typechar, m.names)
-          unless lines
+          overloads = lookup(c.name, m.typechar, m.names)
+          unless overloads
             stats[:methods_missed] += 1
             next
           end
           stats[:sigs_matched] += 1
-          json = JSON.generate(lines)
+          json = JSON.generate({'overloads' => overloads})
           next if m.rbs_sig == json
           m.rbs_sig = json
           m.save
@@ -95,18 +97,18 @@ module BitClust
           decl.members.each do |member|
             case member
             when RBS::AST::Members::MethodDefinition
-              lines = member.overloads.map {|o| method_type_segments(o.method_type.to_s) }
+              overloads = member.overloads.map {|o| method_type_overload(o.method_type.to_s) }
               method_keys(class_name, member.name, member.kind).each do |key|
-                sigs[key] ||= lines
+                sigs[key] ||= overloads
               end
             when RBS::AST::Members::AttrReader
-              sigs[attr_key(class_name, member, member.name)] ||= [type_segments(member.type.to_s)]
+              sigs[attr_key(class_name, member, member.name)] ||= [attr_overload(member.type.to_s)]
             when RBS::AST::Members::AttrWriter
-              sigs[attr_key(class_name, member, "#{member.name}=")] ||= [type_segments(member.type.to_s)]
+              sigs[attr_key(class_name, member, "#{member.name}=")] ||= [attr_overload(member.type.to_s)]
             when RBS::AST::Members::AttrAccessor
-              line = [type_segments(member.type.to_s)]
-              sigs[attr_key(class_name, member, member.name)] ||= line
-              sigs[attr_key(class_name, member, "#{member.name}=")] ||= line
+              overloads = [attr_overload(member.type.to_s)]
+              sigs[attr_key(class_name, member, member.name)] ||= overloads
+              sigs[attr_key(class_name, member, "#{member.name}=")] ||= overloads
             when RBS::AST::Members::Alias
               aliases << [class_name, member]
             end
@@ -177,21 +179,48 @@ module BitClust
       member.kind == :singleton ? "#{class_name}.#{name}" : "#{class_name}##{name}"
     end
 
-    # メソッド型シグネチャ 1 行をセグメント列にする
-    def method_type_segments(sig)
+    # メソッド型シグネチャ 1 行をオーバーロード(segments+メタ情報)にする
+    def method_type_overload(sig)
       method_type = RBS::Parser.parse_method_type(sig, require_eof: true)
       locs = [] #: Array[[String, Integer]]
       collect_function_type_names(method_type.type, locs)
       collect_function_type_names(method_type.block.type, locs) if method_type.block
-      build_segments(sig, locs)
+      overload = {'segments' => build_segments(sig, locs)} #: overload
+      add_overload_meta(overload, method_type)
+      overload
     end
 
-    # attr 用: 型だけの文字列をセグメント列にする
-    def type_segments(sig)
+    # attr 用: 型だけの文字列をオーバーロード(segments のみ)にする
+    def attr_overload(sig)
       type = RBS::Parser.parse_type(sig, require_eof: true)
       locs = [] #: Array[[String, Integer]]
       collect_type_names(type, locs)
-      build_segments(sig, locs)
+      {'segments' => build_segments(sig, locs)}
+    end
+
+    # チャンク振り分け(RbsOverloadMatcher)用のメタ情報。引数名は位置引数
+    # (rest 含む)+キーワード名。アリティは位置引数の [最小, 最大] で
+    # rest があれば最大 nil(無制限)。`(?)`(UntypedFunction)には位置引数の
+    # 概念が無いので params/arity は付けない
+    def add_overload_meta(overload, method_type)
+      fun = method_type.type
+      if fun.respond_to?(:required_positionals)
+        names = [] #: Array[String]
+        positionals = fun.required_positionals + fun.optional_positionals +
+                      fun.trailing_positionals
+        positionals.each {|p| names << p.name.to_s if p.name }
+        rest = fun.rest_positionals
+        names << rest.name.to_s if rest && rest.name
+        fun.required_keywords.each_key {|k| names << k.to_s }
+        fun.optional_keywords.each_key {|k| names << k.to_s }
+        required = fun.required_positionals.size + fun.trailing_positionals.size
+        overload['params'] = names
+        overload['arity'] =
+          [required, rest ? nil : required + fun.optional_positionals.size]
+      end
+      if (block = method_type.block)
+        overload['block'] = block.required ? 'req' : 'opt'
+      end
     end
 
     def collect_function_type_names(fun, locs)

--- a/lib/bitclust/rbs_signatures.rb
+++ b/lib/bitclust/rbs_signatures.rb
@@ -24,11 +24,18 @@ module BitClust
 
   module RbsSignatures
 
+    # 振り分け状態はメソッドのコンパイル専用(compile_method が
+    # prepare_rbs_signatures で作り直す)なので、他のコンパイルへ
+    # 持ち越さないよう setup(全コンパイル共通)からリセットする
+    def reset_rbs_signatures
+      @rbs_sig_by_chunk = nil
+      @rbs_chunk_index = 0
+    end
+
     # compile_method 冒頭で呼ぶ。rbs_sig property があれば、source の
     # シグネチャ行からチャンク列を作りオーバーロードを振り分けておく
     def prepare_rbs_signatures(entry, source)
-      @rbs_sig_by_chunk = nil
-      @rbs_chunk_index = 0
+      reset_rbs_signatures
       overloads = entry.rbs_signature_overloads
       return unless overloads
       chunks = rbs_scan_signature_chunks(source)

--- a/lib/bitclust/rbs_signatures.rb
+++ b/lib/bitclust/rbs_signatures.rb
@@ -9,26 +9,85 @@
 # 付けてしまうため、見出しと同じ dt+code の並びにする。property が無い
 # エントリでは何も出さないので、出力は従来とバイト一致のまま。
 #
+# Array.new / Array#[] のように引数パターンごとに説明チャンクが分かれる
+# メソッドでは、compile_method 冒頭でソースのシグネチャ行を走査して
+# チャンク列を作り、RbsOverloadMatcher で各オーバーロードを最も近い
+# チャンクへ振り分けておく(entry_chunk は自分の番のぶんだけ描画する)。
+#
 # RDCompiler(md は MDCompiler が継承)に include される。escape_html /
 # class_link(いずれも HTMLUtils)と @option[:database] にだけ依存し、
 # rbs gem は使わない(型名の位置は property 側で解決済み)。
+
+require 'bitclust/rbs_overload_matcher'
 
 module BitClust
 
   module RbsSignatures
 
-    # entry の <dt class="rbs-signature"> 行(1 オーバーロード = 1 <dt>)を
-    # 改行で連結して返す。シグネチャが無ければ nil
-    def rbs_signature_dts(entry)
-      segments = entry.rbs_signature_segments
-      return nil unless segments
-      segments.map {|line|
+    # compile_method 冒頭で呼ぶ。rbs_sig property があれば、source の
+    # シグネチャ行からチャンク列を作りオーバーロードを振り分けておく
+    def prepare_rbs_signatures(entry, source)
+      @rbs_sig_by_chunk = nil
+      @rbs_chunk_index = 0
+      overloads = entry.rbs_signature_overloads
+      return unless overloads
+      chunks = rbs_scan_signature_chunks(source)
+      if chunks.empty?
+        no_signatures = [] #: Array[String]
+        chunks = [no_signatures]
+      end
+      assignment = RbsOverloadMatcher.assign(overloads, chunks)
+      @rbs_sig_by_chunk = assignment.map {|indexes|
+        indexes.filter_map {|i| overloads[i]['segments'] }
+      }
+    end
+
+    # 現在のチャンクに割り当てられたオーバーロードの <dt> 行(改行連結)を
+    # 返し、チャンクカウンタを進める。メソッド以外のコンパイル
+    # (prepare が呼ばれていない)や割り当てが無いチャンクでは nil
+    def rbs_signature_dts_for_chunk
+      by_chunk = @rbs_sig_by_chunk
+      return nil unless by_chunk
+      lines = by_chunk[@rbs_chunk_index]
+      @rbs_chunk_index += 1
+      return nil unless lines && !lines.empty?
+      lines.map {|line|
         html = line.map {|kind, text| rbs_segment_html(kind, text) }.join
         %Q(<dt class="rbs-signature"><code>#{html}</code></dt>)
       }.join("\n")
     end
 
     private
+
+    # entry_chunk と同じ規則でシグネチャ行の並び(チャンク)を数える。
+    # 属性行({: ...})はシグネチャの並びを切らない
+    def rbs_scan_signature_chunks(source)
+      chunks = [] #: Array[Array[String]]
+      current = nil #: Array[String]?
+      source.each_line do |line|
+        line = line.chomp
+        if (sig = rbs_signature_line(line))
+          if current
+            current << sig
+          else
+            fresh = [sig] #: Array[String]
+            current = fresh
+            chunks << fresh
+          end
+        elsif current && RDCompiler::METHOD_ATTRIBUTE_LINE_RE =~ line
+          # シグネチャの並びを継続
+        else
+          current = nil
+        end
+      end
+      chunks
+    end
+
+    # シグネチャ行なら "--- " 始まりの正規形にして返す(rd はそのまま)。
+    # md のシグネチャ行(### def ...)は MDCompiler がオーバーライドする
+    def rbs_signature_line(line)
+      line if line.start_with?('---')
+    end
 
     def rbs_segment_html(kind, text)
       if kind == 'c' and rbs_known_class?(text)

--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -75,11 +75,7 @@ module BitClust
     def setup(src, entry = nil)
       @f = LineInput.new(StringIO.new(src), entry)
       @out = StringIO.new
-      # RBS シグネチャの振り分け状態はメソッドのコンパイル専用
-      # (compile_method が prepare_rbs_signatures で作り直す)なので、
-      # 他のコンパイルへ持ち越さないようここでリセットする
-      @rbs_sig_by_chunk = nil
-      @rbs_chunk_index = 0
+      reset_rbs_signatures
       yield
       @out.string
     end

--- a/lib/bitclust/rdcompiler.rb
+++ b/lib/bitclust/rdcompiler.rb
@@ -61,7 +61,9 @@ module BitClust
       @opt = opt
       @type = :method
       @method = m
-      setup(m.source, m) {
+      source = m.source
+      setup(source, m) {
+        prepare_rbs_signatures(m, source)
         entry
       }
     ensure
@@ -73,6 +75,11 @@ module BitClust
     def setup(src, entry = nil)
       @f = LineInput.new(StringIO.new(src), entry)
       @out = StringIO.new
+      # RBS シグネチャの振り分け状態はメソッドのコンパイル専用
+      # (compile_method が prepare_rbs_signatures で作り直す)なので、
+      # 他のコンパイルへ持ち越さないようここでリセットする
+      @rbs_sig_by_chunk = nil
+      @rbs_chunk_index = 0
       yield
       @out.string
     end
@@ -137,9 +144,10 @@ module BitClust
         k, v = line.sub(/\A:/, '').split(':', 2)
         props[k&.strip] = v&.strip
       end if @type == :method
-      # RBS シグネチャは見出し <dt> 群の直後・説明 <dd> の直前に <dt> 行と
-      # して出す(rbs_sig property が無ければ何も出ない)
-      if @method and (rbs_dts = rbs_signature_dts(@method))
+      # RBS シグネチャは見出し <dt> 群の直後・説明 <dd> の直前に、この
+      # チャンクへ振り分けられたぶんだけ <dt> 行として出す(rbs_sig
+      # property が無ければ何も出ない)
+      if (rbs_dts = rbs_signature_dts_for_chunk())
         @out.puts rbs_dts
       end
       @out.puts %Q(<dd class="#{@type.to_s}-description">)

--- a/sig/bitclust/mdcompiler.rbs
+++ b/sig/bitclust/mdcompiler.rbs
@@ -59,6 +59,9 @@ module BitClust
     # md シグネチャ行を rd 形式（--- ...）へ落とし、既存のシグネチャ処理を継承する
     def method_signature: (String sig_line, bool first) -> void
 
+    # RBS シグネチャのチャンク走査用: md のシグネチャ行を rd の正規形にして返す
+    def rbs_signature_line: (String line) -> String?
+
     def headline: (String line) -> void
 
     def read_paragraph: (LineInput f) -> Array[String]

--- a/sig/bitclust/methodentry.rbs
+++ b/sig/bitclust/methodentry.rbs
@@ -65,9 +65,9 @@ module BitClust
 
     def index_id: () -> String
 
-    # rbs_sig(JSON)のデコード結果(RbsSigImporter::segment_line の配列)。
+    # rbs_sig(JSON)のデコード結果(RbsSigImporter::overload の配列)。
     # 値が無い・壊れている場合は nil
-    def rbs_signature_segments: () -> Array[RbsSigImporter::segment_line]?
+    def rbs_signature_overloads: () -> Array[RbsSigImporter::overload]?
 
     def labels: () -> Array[String]
 

--- a/sig/bitclust/rbs_overload_matcher.rbs
+++ b/sig/bitclust/rbs_overload_matcher.rbs
@@ -1,0 +1,24 @@
+module BitClust
+  # RBS のオーバーロードを、引数パターンごとに分かれた説明チャンクへ
+  # 「ブロック有無 → 引数名の一致 → アリティ範囲の重なり」のスコアで
+  # 振り分ける
+  module RbsOverloadMatcher
+    type chunk_features = { names: Array[String], min: Integer, max: Integer?, block: bool }
+
+    type overload_features = { names: Array[String], min: Integer?, max: Integer?, block: String? }
+
+    def self?.assign: (Array[RbsSigImporter::overload] overloads, Array[Array[String]] chunks) -> Array[Array[Integer]]
+
+    def self?.chunk_features: (Array[String] sig_lines) -> chunk_features?
+
+    def self?.overload_features: (RbsSigImporter::overload overload) -> overload_features?
+
+    def self?.best_chunk: (overload_features overload, Array[chunk_features?] features) -> Integer
+
+    def self?.score: (overload_features overload, chunk_features chunk) -> Integer
+
+    def self?.params_features: (String? params) -> [Integer, Integer?, Array[String], bool]
+
+    def self?.split_top_level: (String str) -> Array[String]
+  end
+end

--- a/sig/bitclust/rbs_sig_importer.rbs
+++ b/sig/bitclust/rbs_sig_importer.rbs
@@ -1,6 +1,6 @@
 module BitClust
   # RBS 型シグネチャ(.rbs)を "Class#method"/"Class.method" キーの
-  # セグメント行列にして MethodEntry の rbs_sig property に書き込む
+  # オーバーロード配列にして MethodEntry の rbs_sig property に書き込む
   class RbsSigImporter
     # セグメント = [種別("t" は素のテキスト / "c" はクラス名), テキスト]
     type segment = [String, String]
@@ -8,7 +8,11 @@ module BitClust
     # 1 行 = 1 オーバーロードのシグネチャ
     type segment_line = Array[segment]
 
-    type signatures = Hash[String, Array[segment_line]]
+    # オーバーロード: "segments"(segment_line)に加えて、チャンク振り分け
+    # (RbsOverloadMatcher)用のメタ情報 "params"/"arity"/"block" を持ちうる
+    type overload = Hash[String, untyped]
+
+    type signatures = Hash[String, Array[overload]]
 
     type stats = { entries_updated: Integer, sigs_matched: Integer, methods_missed: Integer }
 
@@ -24,7 +28,7 @@ module BitClust
 
     def signatures: () -> signatures
 
-    def lookup: (String class_name, String typechar, Array[String] names) -> Array[segment_line]?
+    def lookup: (String class_name, String typechar, Array[String] names) -> Array[overload]?
 
     def apply: (MethodDatabase db) -> stats
 
@@ -44,9 +48,11 @@ module BitClust
 
     def alias_key: (String class_name, untyped member, Symbol name) -> String
 
-    def method_type_segments: (String sig) -> segment_line
+    def method_type_overload: (String sig) -> overload
 
-    def type_segments: (String sig) -> segment_line
+    def attr_overload: (String sig) -> overload
+
+    def add_overload_meta: (overload overload, untyped method_type) -> void
 
     def collect_function_type_names: (untyped fun, Array[[String, Integer]] locs) -> void
 

--- a/sig/bitclust/rbs_signatures.rbs
+++ b/sig/bitclust/rbs_signatures.rbs
@@ -11,6 +11,8 @@ module BitClust
 
     @rbs_chunk_index: Integer
 
+    def reset_rbs_signatures: () -> void
+
     def prepare_rbs_signatures: (MethodEntry entry, String source) -> void
 
     def rbs_signature_dts_for_chunk: () -> String?

--- a/sig/bitclust/rbs_signatures.rbs
+++ b/sig/bitclust/rbs_signatures.rbs
@@ -1,13 +1,25 @@
 module BitClust
   # メソッドエントリの RBS 型シグネチャ(rbs_sig property)を
-  # <dt class="rbs-signature"> 行として描画する。RDCompiler(md は
-  # MDCompiler が継承)に include される
+  # <dt class="rbs-signature"> 行として描画する。オーバーロードは
+  # compile_method 冒頭で説明チャンクへ振り分けておき、entry_chunk が
+  # 自分の番のぶんだけ描画する。RDCompiler(md は MDCompiler が継承)に
+  # include される
   module RbsSignatures : HTMLUtils
     @rbs_known_classes: Hash[String, bool]
 
-    def rbs_signature_dts: (MethodEntry entry) -> String?
+    @rbs_sig_by_chunk: Array[Array[RbsSigImporter::segment_line]]?
+
+    @rbs_chunk_index: Integer
+
+    def prepare_rbs_signatures: (MethodEntry entry, String source) -> void
+
+    def rbs_signature_dts_for_chunk: () -> String?
 
     private
+
+    def rbs_scan_signature_chunks: (String source) -> Array[Array[String]]
+
+    def rbs_signature_line: (String line) -> String?
 
     def rbs_segment_html: (String kind, String text) -> String
 

--- a/test/test_mdcompiler.rb
+++ b/test/test_mdcompiler.rb
@@ -23,7 +23,7 @@ class TestMDCompiler < Test::Unit::TestCase
     @rd = BitClust::RDCompiler.new(@u, 1, { :database => @db })
   end
 
-  def compile_method(compiler, src, rbs_signature_segments: nil)
+  def compile_method(compiler, src, rbs_signature_overloads: nil)
     method_entry = Object.new
     mock(method_entry).source { src }
     mock(method_entry).index_id.any_times { "dummy" }
@@ -32,7 +32,7 @@ class TestMDCompiler < Test::Unit::TestCase
     mock(method_entry).names.any_times { [] }
     mock(method_entry).since_map.any_times { {} }
     mock(method_entry).until_map.any_times { {} }
-    mock(method_entry).rbs_signature_segments.any_times { rbs_signature_segments }
+    mock(method_entry).rbs_signature_overloads.any_times { rbs_signature_overloads }
     compiler.compile_method(method_entry)
   end
 
@@ -63,12 +63,40 @@ class TestMDCompiler < Test::Unit::TestCase
   # ので、rd 経路と同じ位置(説明 <dd> の直前)に同じ <dt> が出ること
   def test_rbs_signatures_dt_matches_rd_output
     rd_src = "--- index(val) -> Integer\n\n説明\n"
-    segments = [[['t', '() -> void']]]
+    overloads = [{'segments' => [['t', '() -> void']]}]
     md_src = BitClust::RRDToMarkdown.convert(rd_src)
-    rd_html = compile_method(@rd, rd_src, rbs_signature_segments: segments)
-    md_html = compile_method(@md, md_src, rbs_signature_segments: segments)
+    rd_html = compile_method(@rd, rd_src, rbs_signature_overloads: overloads)
+    md_html = compile_method(@md, md_src, rbs_signature_overloads: overloads)
     assert_include md_html,
       '<dt class="rbs-signature"><code>() &rarr; void</code></dt>'
+    assert_equal rd_html, md_html
+  end
+
+  # チャンク振り分けは md 側のシグネチャ行(### def ...)でも rd と同じに
+  # 動くこと(MDCompiler は行を "--- " に正規化してから照合する)
+  def test_rbs_signatures_chunk_assignment_matches_rd_output
+    rd_src = <<~RD
+      --- index(sub) -> Integer | nil
+
+      文字列で探す。
+
+      --- index(pattern) {|s| ... } -> Integer | nil
+
+      ブロックで探す。
+    RD
+    overloads = [
+      {'segments' => [['t', '(String sub) -> Integer?']],
+       'params' => ['sub'], 'arity' => [1, 1]},
+      {'segments' => [['t', '(Regexp pattern) { (String) -> bool } -> Integer?']],
+       'params' => ['pattern'], 'arity' => [1, 1], 'block' => 'req'},
+    ]
+    md_src = BitClust::RRDToMarkdown.convert(rd_src)
+    rd_html = compile_method(@rd, rd_src, rbs_signature_overloads: overloads)
+    md_html = compile_method(@md, md_src, rbs_signature_overloads: overloads)
+    assert_match(
+      %r!<code>index\(pattern\).*?</dt>\n<dt class="rbs-signature"><code>\(Regexp pattern\) \{ \(String\) &rarr; bool \} &rarr; Integer\?</code></dt>\n<dd!m,
+      md_html)
+    assert_equal 2, md_html.scan('rbs-signature').size
     assert_equal rd_html, md_html
   end
 

--- a/test/test_methodentry.rb
+++ b/test/test_methodentry.rb
@@ -328,20 +328,26 @@ class TestMethodEntrySinceUntil < Test::Unit::TestCase
   end
 end
 
-# rbs_sig property(RBS シグネチャ表示)。セグメント行列(行 = [種別, テキスト]
-# の配列)を JSON 1 行で 'String' 型 property に格納する。JSON は改行を含まず、
-# 値中の '=' や ',' も property ファイル(key=value 1 行形式)で安全。
+# rbs_sig property(RBS シグネチャ表示)。オーバーロード配列
+# ({"segments" => 行, "params"/"arity"/"block" => メタ情報} の配列)を
+# {"overloads": [...]} の JSON 1 行で 'String' 型 property に格納する。
+# JSON は改行を含まず、値中の '=' や ',' も property ファイル
+# (key=value 1 行形式)で安全。
 #
 # テストリスト:
-# [x] 既定は nil で rbs_signature_segments も nil
+# [x] 既定は nil で rbs_signature_overloads も nil
 # [x] JSON を入れて save → reload で round-trip する
+# [x] 旧形式(セグメント行列そのものの配列)は segments だけの
+#     オーバーロード列に読み替える(#322 以前の DB)
 # [x] property 行が無い古い DB でも nil(後方互換)
 # [x] 空文字列(シグネチャ無しで save された値)も nil 扱い
 # [x] 壊れた JSON は nil 扱い(描画を落とさない)
 class TestMethodEntryRbsSig < Test::Unit::TestCase
-  SEGMENTS = [
-    [['t', '('], ['c', 'Integer'], ['t', ') -> '], ['c', 'String']],
-    [['t', '() -> void']],
+  OVERLOADS = [
+    {'segments' => [['t', '('], ['c', 'Integer'], ['t', ') -> '], ['c', 'String']],
+     'params' => ['base'], 'arity' => [1, 1]},
+    {'segments' => [['t', '() -> void']],
+     'params' => [], 'arity' => [0, 0], 'block' => 'req'},
   ]
 
   def setup
@@ -359,19 +365,29 @@ class TestMethodEntryRbsSig < Test::Unit::TestCase
   end
 
   # 未保存エントリの String 型 property は "(uninitialized)" センチネル
-  # なので、rbs_sig そのものではなく segments が nil であることを見る
-  def test_default_has_no_segments
+  # なので、rbs_sig そのものではなく overloads が nil であることを見る
+  def test_default_has_no_overloads
     m = build_entry('sig')
-    assert_nil m.rbs_signature_segments
+    assert_nil m.rbs_signature_overloads
   end
 
   def test_roundtrip
     m = build_entry('sig')
-    m.rbs_sig = JSON.generate(SEGMENTS)
+    m.rbs_sig = JSON.generate({'overloads' => OVERLOADS})
     m.save
 
     reloaded = reload_entry(m.id)
-    assert_equal(SEGMENTS, reloaded.rbs_signature_segments)
+    assert_equal(OVERLOADS, reloaded.rbs_signature_overloads)
+  end
+
+  def test_old_array_format_is_read_as_segments_only
+    m = build_entry('sig')
+    m.rbs_sig = JSON.generate(OVERLOADS.map {|o| o['segments'] })
+    m.save
+
+    reloaded = reload_entry(m.id)
+    assert_equal(OVERLOADS.map {|o| {'segments' => o['segments']} },
+                 reloaded.rbs_signature_overloads)
   end
 
   def test_missing_property_is_backward_compatible
@@ -381,7 +397,7 @@ class TestMethodEntryRbsSig < Test::Unit::TestCase
 
     reloaded = reload_entry(m.id)
     assert_nil reloaded.rbs_sig
-    assert_nil reloaded.rbs_signature_segments
+    assert_nil reloaded.rbs_signature_overloads
   end
 
   def test_saved_without_signature_is_treated_as_absent
@@ -389,13 +405,13 @@ class TestMethodEntryRbsSig < Test::Unit::TestCase
     m.save
 
     reloaded = reload_entry(m.id)
-    assert_nil reloaded.rbs_signature_segments
+    assert_nil reloaded.rbs_signature_overloads
   end
 
   def test_broken_json_is_treated_as_absent
     m = build_entry('sig')
     m.rbs_sig = '{broken'
-    assert_nil m.rbs_signature_segments
+    assert_nil m.rbs_signature_overloads
   end
 
   private

--- a/test/test_rbs_overload_matcher.rb
+++ b/test/test_rbs_overload_matcher.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'bitclust/rbs_overload_matcher'
+
+# RbsOverloadMatcher(RBS シグネチャ表示)。引数パターンごとに説明チャンクが
+# 分かれているメソッド(Array.new / Array#[] 等)で、RBS の各オーバーロードを
+# 「ブロック有無 → 引数名の一致 → アリティ範囲の重なり」のスコアで最も近い
+# チャンクへ振り分ける。RBS の引数名は rdoc の call-seq 由来で rurema の
+# 引数名とよく一致するのが根拠。確実な対応が取れない場合は先頭チャンクに
+# 寄せる(重複表示はしない)。
+#
+# オーバーロードは rbs_sig property の JSON をそのまま(文字列キーの Hash)
+# 受け取る。チャンクは正規化済みシグネチャ行("--- " 始まり)の配列の配列。
+#
+# テストリスト:
+# [x] チャンクが 1 つなら全オーバーロードをそこへ(スコア不要)
+# [x] メタの無いオーバーロード(旧形式・attr・(?))は先頭チャンクへ
+# [x] Array#[] 型: 引数名 range / start+length で振り分け・名前が合わない
+#     ものはアリティ同点 → 先頭チャンク
+# [x] Array.new 型: () はアリティで・(ary) は名前で・ブロック付きは
+#     ブロックチャンクへ
+# [x] ブロック必須オーバーロードはブロック無しチャンクより有りを選ぶ
+# [x] チャンク側の引数解析: 省略可能引数・*rest・キーワード・&block・
+#     引数リスト無し
+# [x] 解析できないシグネチャ行だけのチャンクには振り分けない
+class TestRbsOverloadMatcher < Test::Unit::TestCase
+  M = BitClust::RbsOverloadMatcher
+
+  def test_single_chunk_takes_everything
+    overloads = [
+      {'segments' => [], 'params' => ['x'], 'arity' => [1, 1]},
+      {'segments' => [], 'params' => [], 'arity' => [0, 0], 'block' => 'req'},
+    ]
+    assert_equal [[0, 1]], M.assign(overloads, [['--- foo(x) -> nil']])
+  end
+
+  def test_overload_without_meta_goes_to_first_chunk
+    overloads = [{'segments' => []}]
+    chunks = [['--- foo(x) -> nil'], ['--- foo(x, y) -> nil']]
+    assert_equal [[0], []], M.assign(overloads, chunks)
+  end
+
+  # Array#[] の実データ(rbs v3.10.0)。(int index) は nth/range どちらとも
+  # 名前が合わずアリティも同点 → 先頭の nth チャンクへ。range と
+  # start+length は引数名で決まる
+  def test_aref_like_assignment
+    chunks = [
+      ['--- [](nth) -> object | nil'],
+      ['--- [](range) -> Array | nil'],
+      ['--- [](start, length) -> Array | nil'],
+    ]
+    overloads = [
+      {'segments' => [], 'params' => ['index'], 'arity' => [1, 1]},
+      {'segments' => [], 'params' => ['start', 'length'], 'arity' => [2, 2]},
+      {'segments' => [], 'params' => ['range'], 'arity' => [1, 1]},
+    ]
+    assert_equal [[0], [2], [1]], M.assign(overloads, chunks)
+  end
+
+  # Array.new の実データ(rbs v3.10.0)。() はアリティ 0 を含む先頭チャンク
+  # だけに重なる。(ary) と (size, ?val) は引数名で分かれ、ブロック付きは
+  # ブロックチャンクへ
+  def test_new_like_assignment
+    chunks = [
+      ['--- new(size = 0, val = nil) -> Array'],
+      ['--- new(ary) -> Array'],
+      ['--- new(size) {|index| ... } -> Array'],
+    ]
+    overloads = [
+      {'segments' => [], 'params' => [], 'arity' => [0, 0]},
+      {'segments' => [], 'params' => ['ary'], 'arity' => [1, 1]},
+      {'segments' => [], 'params' => ['size', 'val'], 'arity' => [1, 2]},
+      {'segments' => [], 'params' => ['size'], 'arity' => [1, 1], 'block' => 'req'},
+    ]
+    assert_equal [[0, 2], [1], [3]], M.assign(overloads, chunks)
+  end
+
+  def test_required_block_prefers_block_chunk
+    chunks = [
+      ['--- each -> Enumerator'],
+      ['--- each {|item| ... } -> self'],
+    ]
+    overloads = [
+      {'segments' => [], 'params' => [], 'arity' => [0, 0]},
+      {'segments' => [], 'params' => [], 'arity' => [0, 0], 'block' => 'req'},
+    ]
+    assert_equal [[0], [1]], M.assign(overloads, chunks)
+  end
+
+  # 省略可能ブロック(?{ ... })はどちらのチャンクとも矛盾しない。
+  # 引数名の一致で決まる
+  def test_optional_block_is_neutral
+    chunks = [
+      ['--- open(path) -> IO'],
+      ['--- open(fd) {|io| ... } -> object'],
+    ]
+    overloads = [
+      {'segments' => [], 'params' => ['fd'], 'arity' => [1, 1], 'block' => 'opt'},
+    ]
+    assert_equal [[], [0]], M.assign(overloads, chunks)
+  end
+
+  # チャンク側の引数リスト解析。省略可能引数で最小アリティが下がり、
+  # *rest で上限が消え、キーワード名も名前照合に使われる
+  def test_chunk_parsing_of_optional_rest_and_keywords
+    chunks = [
+      ['--- foo(a, b = 1, *rest, key: 0) -> nil'],
+      ['--- foo(x, y) -> nil'],
+    ]
+    overloads = [
+      {'segments' => [], 'params' => ['key'], 'arity' => [5, 5]},
+      {'segments' => [], 'params' => ['x', 'y'], 'arity' => [2, 2]},
+    ]
+    assert_equal [[0], [1]], M.assign(overloads, chunks)
+  end
+
+  # &block 引数はブロック有りとして扱う
+  def test_chunk_block_argument_counts_as_block
+    chunks = [
+      ['--- foo -> Enumerator'],
+      ['--- foo(&block) -> object'],
+    ]
+    overloads = [
+      {'segments' => [], 'params' => [], 'arity' => [0, 0], 'block' => 'req'},
+    ]
+    assert_equal [[], [0]], M.assign(overloads, chunks)
+  end
+
+  # 引数リストの無いシグネチャはアリティ 0 扱い
+  def test_chunk_without_params_is_zero_arity
+    chunks = [
+      ['--- size -> Integer'],
+      ['--- size(n) -> Integer'],
+    ]
+    overloads = [
+      {'segments' => [], 'params' => [], 'arity' => [0, 0]},
+      {'segments' => [], 'params' => ['n'], 'arity' => [1, 1]},
+    ]
+    assert_equal [[0], [1]], M.assign(overloads, chunks)
+  end
+
+  # 同一チャンクに複数シグネチャ行(別名など)がある場合は特徴を合算する
+  def test_multiple_signature_lines_in_one_chunk
+    chunks = [
+      ['--- collect {|item| ... } -> [object]', '--- map {|item| ... } -> [object]'],
+      ['--- collect -> Enumerator', '--- map -> Enumerator'],
+    ]
+    overloads = [
+      {'segments' => [], 'params' => [], 'arity' => [0, 0], 'block' => 'req'},
+      {'segments' => [], 'params' => [], 'arity' => [0, 0]},
+    ]
+    assert_equal [[0], [1]], M.assign(overloads, chunks)
+  end
+
+  # 解析できない行だけのチャンクは振り分け先にならない
+  def test_unparseable_chunk_is_skipped
+    chunks = [
+      ['?????'],
+      ['--- foo(x) -> nil'],
+    ]
+    overloads = [
+      {'segments' => [], 'params' => [], 'arity' => [0, 0]},
+    ]
+    assert_equal [[], [0]], M.assign(overloads, chunks)
+  end
+
+  def test_empty_chunks_returns_empty
+    assert_equal [], M.assign([{'segments' => []}], [])
+  end
+end

--- a/test/test_rbs_sig_importer.rb
+++ b/test/test_rbs_sig_importer.rb
@@ -8,27 +8,32 @@ require 'fileutils'
 require 'json'
 
 # RbsSigImporter(RBS シグネチャ表示)。.rbs 群から
-# "Class#method"/"Class.method" キー → セグメント行列の対応を作り、
+# "Class#method"/"Class.method" キー → オーバーロード配列の対応を作り、
 # MethodEntry の rbs_sig property に書き込む。
 #
-# セグメント行列 = 行(オーバーロードごと)の配列。行は [種別, テキスト] の
-# 配列で、種別 "t" は素のテキスト、"c" はクラス/モジュール名(描画側が
-# DB に存在すればリンク化する)。行のテキストを連結すると元の型シグネチャ
-# 文字列に戻る(往復可能)。
+# オーバーロード = {"segments" => 行, "params" => 引数名, "arity" =>
+# [最小, 最大|nil], "block" => "req"|"opt"} の Hash(segments 以外は
+# チャンク振り分け=RbsOverloadMatcher 用のメタ情報で、無い形式もある)。
+# 行は [種別, テキスト] の配列で、種別 "t" は素のテキスト、"c" は
+# クラス/モジュール名(描画側が DB に存在すればリンク化する)。行の
+# テキストを連結すると元の型シグネチャ文字列に戻る(往復可能)。
 #
 # テストリスト:
 # [x] instance/singleton メソッドが # / . キーになる
-# [x] overload は行ごとに分かれ、テキスト連結で元のシグネチャに戻る
+# [x] overload はオーバーロードごとに分かれ、テキスト連結で元に戻る
 # [x] 型名は ["c", name] セグメントになる(引数・戻り値・ジェネリクスの中も)
 # [x] 名前空間付き型名は :: が直前のテキスト側に残る
+# [x] メタ情報: 引数名(位置+キーワード)・アリティ範囲・ブロック有無
+# [x] メタ情報: 引数の無いオーバーロードは params=[]・arity=[0,0]
 # [x] def self?. は # と . の両キーに登録される
 # [x] alias メンバーは元メソッドのシグネチャを共有する
-# [x] attr_reader/attr_writer は name / name= キーになり、型だけの行になる
+# [x] attr_reader/attr_writer は name / name= キーになり、型だけの
+#     オーバーロード(メタ無し)になる
 # [x] lookup: typechar i/s/m で引ける(m は # → . の順)
 # [x] lookup: new は Class.new → Class#initialize の順でフォールバック
 # [x] lookup: 別名リストの後ろの名前でもヒットする
 # [x] lookup: 対応が無ければ nil(定数・特殊変数も nil)
-# [x] apply: DB のエントリに rbs_sig(JSON)が書き込まれ、統計が返る
+# [x] apply: DB のエントリに rbs_sig(overloads 形式の JSON)が書き込まれる
 # [x] apply: 対応が無いメソッドには書き込まれない
 # [x] apply: 2 回目は無変更(entries_updated=0)
 class TestRbsSigImporter < Test::Unit::TestCase
@@ -47,6 +52,8 @@ class TestRbsSigImporter < Test::Unit::TestCase
         attr_reader label: String
         attr_writer width: Integer
         def pairs: (hash[Symbol, String]) -> void
+        def meta: (Integer x, ?String y, *Integer rest, size: Integer, ?name: String) { (Integer) -> void } -> void
+                | (Integer a, Integer b) ?{ () -> void } -> void
       end
     RBS
     @importer = BitClust::RbsSigImporter.new(sig_dirs: [@sig_dir])
@@ -65,35 +72,58 @@ class TestRbsSigImporter < Test::Unit::TestCase
   end
 
   def test_overload_lines_roundtrip_to_original_signature
-    lines = @importer.signatures['Foo#bar']
-    assert_equal 2, lines.size
-    assert_equal '(Integer base) -> String', join_text(lines[0])
-    assert_equal '(::Enumerator::Lazy) -> Array[Integer]', join_text(lines[1])
+    overloads = @importer.signatures['Foo#bar']
+    assert_equal 2, overloads.size
+    assert_equal '(Integer base) -> String', join_text(overloads[0])
+    assert_equal '(::Enumerator::Lazy) -> Array[Integer]', join_text(overloads[1])
   end
 
   def test_type_names_become_class_segments
-    lines = @importer.signatures['Foo#bar']
+    overloads = @importer.signatures['Foo#bar']
     assert_equal(
       [['t', '('], ['c', 'Integer'], ['t', ' base) -> '], ['c', 'String']],
-      lines[0])
+      overloads[0]['segments'])
   end
 
   def test_namespace_prefix_stays_in_text_segment
-    lines = @importer.signatures['Foo#bar']
+    overloads = @importer.signatures['Foo#bar']
     assert_equal(
       [['t', '(::'], ['c', 'Enumerator::Lazy'], ['t', ') -> '],
        ['c', 'Array'], ['t', '['], ['c', 'Integer'], ['t', ']']],
-      lines[1])
+      overloads[1]['segments'])
   end
 
   # 小文字のエイリアス型(hash 等)自体はテキストのままだが、その
   # ジェネリクス引数の中のクラス名はリンク化候補にする
   def test_alias_type_args_become_class_segments
-    lines = @importer.signatures['Foo#pairs']
+    overloads = @importer.signatures['Foo#pairs']
     assert_equal(
       [['t', '(hash['], ['c', 'Symbol'], ['t', ', '], ['c', 'String'],
        ['t', ']) -> void']],
-      lines[0])
+      overloads[0]['segments'])
+  end
+
+  # チャンク振り分け用のメタ情報。引数名は位置引数(rest 含む)+
+  # キーワード名、アリティは位置引数の [最小, 最大](rest があれば nil)、
+  # block は必須 "req" / 省略可能 "opt"(無ければキー自体無し)
+  def test_overload_meta
+    overloads = @importer.signatures['Foo#meta']
+    assert_equal %w[x y rest size name], overloads[0]['params']
+    assert_equal [1, nil], overloads[0]['arity']
+    assert_equal 'req', overloads[0]['block']
+    assert_equal %w[a b], overloads[1]['params']
+    assert_equal [2, 2], overloads[1]['arity']
+    assert_equal 'opt', overloads[1]['block']
+  end
+
+  def test_overload_meta_without_params
+    overloads = @importer.signatures['Foo.build']
+    assert_equal [], overloads[0]['params']
+    assert_equal [0, 0], overloads[0]['arity']
+    assert_nil overloads[0]['block']
+    # 名前の無い位置引数はアリティにだけ数える
+    assert_equal [], @importer.signatures['Foo#initialize'][0]['params']
+    assert_equal [1, 1], @importer.signatures['Foo#initialize'][0]['arity']
   end
 
   def test_self_question_registers_both_keys
@@ -111,7 +141,7 @@ class TestRbsSigImporter < Test::Unit::TestCase
     sigs = @importer.signatures
     assert_equal 'String', join_text(sigs['Foo#label'][0])
     assert_equal 'Integer', join_text(sigs['Foo#width='][0])
-    assert_equal [['c', 'String']], sigs['Foo#label'][0]
+    assert_equal({'segments' => [['c', 'String']]}, sigs['Foo#label'][0])
   end
 
   def test_lookup_by_typechar
@@ -143,8 +173,8 @@ class TestRbsSigImporter < Test::Unit::TestCase
     stats = @importer.apply(BitClust::MethodDatabase.new(prefix))
 
     bar = find_entry(prefix, 'bar')
-    assert_equal @importer.signatures['Foo#bar'],
-                 JSON.parse(bar.rbs_sig)
+    assert_equal({'overloads' => @importer.signatures['Foo#bar']},
+                 JSON.parse(bar.rbs_sig))
     assert_equal 1, stats[:entries_updated]
     assert_equal 1, stats[:sigs_matched]
     assert_equal 1, stats[:methods_missed]
@@ -153,7 +183,7 @@ class TestRbsSigImporter < Test::Unit::TestCase
   def test_apply_leaves_unmatched_methods_untouched
     prefix = build_db('4.0')
     @importer.apply(BitClust::MethodDatabase.new(prefix))
-    assert_nil find_entry(prefix, 'nope').rbs_signature_segments
+    assert_nil find_entry(prefix, 'nope').rbs_signature_overloads
   end
 
   def test_apply_twice_is_idempotent
@@ -166,8 +196,8 @@ class TestRbsSigImporter < Test::Unit::TestCase
 
   private
 
-  def join_text(line)
-    line.map {|_kind, text| text }.join
+  def join_text(overload)
+    overload['segments'].map {|_kind, text| text }.join
   end
 
   def build_db(version)

--- a/test/test_rbssig_command.rb
+++ b/test/test_rbssig_command.rb
@@ -69,15 +69,15 @@ class TestRbssigCommand < Test::Unit::TestCase
     out = run_command(["--sig-dir=#{@sig_dir}", db])
     assert_match(/version 10\.0/, out)
     assert_equal [['t', '('], ['c', 'Integer'], ['t', ') -> '], ['c', 'String']],
-                 find_entry(db, 'bar').rbs_signature_segments[0]
+                 find_entry(db, 'bar').rbs_signature_overloads[0]['segments']
   end
 
   def test_fills_rbs_sig_and_prints_stats
     db = build_db('4.0')
     out = run_command(["--sig-dir=#{@sig_dir}", db])
     assert_equal '(Integer) -> String',
-                 find_entry(db, 'bar').rbs_signature_segments[0].map {|_k, t| t }.join
-    assert_nil find_entry(db, 'nope').rbs_signature_segments
+                 find_entry(db, 'bar').rbs_signature_overloads[0]['segments'].map {|_k, t| t }.join
+    assert_nil find_entry(db, 'nope').rbs_signature_overloads
     assert_match(
       /\Adb-4\.0 \(version 4\.0\): entries_updated=1 sigs_matched=1 methods_missed=1\n\z/,
       out)
@@ -86,7 +86,7 @@ class TestRbssigCommand < Test::Unit::TestCase
   def test_dry_run_leaves_database_untouched
     db = build_db('4.0')
     out = run_command(["--sig-dir=#{@sig_dir}", db, '--dry-run'])
-    assert_nil find_entry(db, 'bar').rbs_signature_segments
+    assert_nil find_entry(db, 'bar').rbs_signature_overloads
     assert_match(/entries_updated=1/, out)
   end
 
@@ -106,7 +106,7 @@ class TestRbssigCommand < Test::Unit::TestCase
     db = build_db('4.0')
     run_command(["--sig-root=#{root}", db])
     assert_equal '(String) -> Integer',
-                 find_entry(db, 'bar').rbs_signature_segments[0].map {|_k, t| t }.join
+                 find_entry(db, 'bar').rbs_signature_overloads[0]['segments'].map {|_k, t| t }.join
   end
 
   def test_registered_in_runner

--- a/test/test_rdcompiler.rb
+++ b/test/test_rdcompiler.rb
@@ -28,7 +28,7 @@ class TestRDCompiler < Test::Unit::TestCase
     mock(method_entry).names.any_times{ names }
     mock(method_entry).since_map.any_times{ since_map }
     mock(method_entry).until_map.any_times{ until_map }
-    mock(method_entry).rbs_signature_segments.any_times{ nil }
+    mock(method_entry).rbs_signature_overloads.any_times { nil }
     assert_equal(expected, @c.compile_method(method_entry))
   end
 
@@ -41,19 +41,11 @@ class TestRDCompiler < Test::Unit::TestCase
   def test_method_with_rbs_signatures_renders_dt_lines
     stub(@db).fetch_class('String') { :exists }
     stub(@db).fetch_class('Integer') { raise BitClust::ClassNotFound, 'Integer' }
-    segments = [
-      [['t', '('], ['c', 'Integer'], ['t', ') -> '], ['c', 'String']],
-      [['t', '(String & Integer) -> void']],
+    overloads = [
+      {'segments' => [['t', '('], ['c', 'Integer'], ['t', ') -> '], ['c', 'String']]},
+      {'segments' => [['t', '(String & Integer) -> void']]},
     ]
-    method_entry = Object.new
-    mock(method_entry).source { "--- index(val) -> Integer\n\n説明\n" }
-    mock(method_entry).index_id.any_times { 'dummy' }
-    mock(method_entry).defined?.any_times { true }
-    mock(method_entry).id.any_times { 'String/i.index._builtin' }
-    mock(method_entry).names.any_times { [] }
-    mock(method_entry).since_map.any_times { {} }
-    mock(method_entry).until_map.any_times { {} }
-    mock(method_entry).rbs_signature_segments.any_times { segments }
+    method_entry = rbs_method_entry("--- index(val) -> Integer\n\n説明\n", overloads)
 
     html = @c.compile_method(method_entry)
     assert_include html,
@@ -63,6 +55,73 @@ class TestRDCompiler < Test::Unit::TestCase
       %r!</dt>\n(<dt class="rbs-signature"><code>.+</code></dt>\n){2}<dd class="method-description">!,
       html)
     assert_not_match(/<pre|<dd class="rbs-/, html)
+  end
+
+  # 引数パターンでチャンクが分かれるメソッド(Array.new 型)では、各
+  # オーバーロードが引数名・アリティ・ブロック有無で最も近いチャンクの
+  # 見出し直下にだけ出る(全チャンクへの重複表示をしない)
+  def test_method_with_rbs_signatures_assigns_overloads_to_chunks
+    src = <<~RD
+      --- index(sub) -> Integer | nil
+
+      文字列で探す。
+
+      --- index(pattern) {|s| ... } -> Integer | nil
+
+      ブロックで探す。
+    RD
+    overloads = [
+      {'segments' => [['t', '(String sub) -> Integer?']],
+       'params' => ['sub'], 'arity' => [1, 1]},
+      {'segments' => [['t', '(Regexp pattern) { (String) -> bool } -> Integer?']],
+       'params' => ['pattern'], 'arity' => [1, 1], 'block' => 'req'},
+    ]
+    method_entry = rbs_method_entry(src, overloads)
+
+    html = @c.compile_method(method_entry)
+    assert_match(
+      %r!<code>index\(sub\).*?</dt>\n<dt class="rbs-signature"><code>\(String sub\) &rarr; Integer\?</code></dt>\n<dd!m,
+      html)
+    assert_match(
+      %r!<code>index\(pattern\).*?</dt>\n<dt class="rbs-signature"><code>\(Regexp pattern\) \{ \(String\) &rarr; bool \} &rarr; Integer\?</code></dt>\n<dd!m,
+      html)
+    assert_equal 2, html.scan('rbs-signature').size
+  end
+
+  # 旧形式の DB(メタ情報なし)ではチャンク振り分けができないので、
+  # 先頭チャンクにまとめて出す(重複はしない)
+  def test_method_with_rbs_signatures_without_meta_falls_back_to_first_chunk
+    src = <<~RD
+      --- index(sub) -> Integer | nil
+
+      文字列で探す。
+
+      --- index(pattern) {|s| ... } -> Integer | nil
+
+      ブロックで探す。
+    RD
+    overloads = [
+      {'segments' => [['t', '(String sub) -> Integer?']]},
+      {'segments' => [['t', '(Regexp pattern) { (String) -> bool } -> Integer?']]},
+    ]
+    html = @c.compile_method(rbs_method_entry(src, overloads))
+    assert_equal 2, html.scan('rbs-signature').size
+    assert_match(
+      %r!<code>index\(sub\).*?</dt>\n(<dt class="rbs-signature">.*\n){2}<dd!,
+      html)
+  end
+
+  def rbs_method_entry(src, overloads)
+    method_entry = Object.new
+    mock(method_entry).source { src }
+    mock(method_entry).index_id.any_times { 'dummy' }
+    mock(method_entry).defined?.any_times { true }
+    mock(method_entry).id.any_times { 'String/i.index._builtin' }
+    mock(method_entry).names.any_times { [] }
+    mock(method_entry).since_map.any_times { {} }
+    mock(method_entry).until_map.any_times { {} }
+    mock(method_entry).rbs_signature_overloads.any_times { overloads }
+    method_entry
   end
 
   # badge のカタログ訳(「Ruby %s から」等)を検証するテストで使う、
@@ -264,7 +323,7 @@ HERE
     mock(method_entry).names.any_times { ['mf'] }
     mock(method_entry).since_map.any_times { {} }
     mock(method_entry).until_map.any_times { {} }
-    mock(method_entry).rbs_signature_segments.any_times { nil }
+    mock(method_entry).rbs_signature_overloads.any_times { nil }
     mock(method_entry).klass.any_times { klass }
     mock(method_entry).display_typemark.any_times { '?.' }
 
@@ -285,7 +344,7 @@ HERE
     mock(method_entry).names.any_times { ['mf'] }
     mock(method_entry).since_map.any_times { {} }
     mock(method_entry).until_map.any_times { {} }
-    mock(method_entry).rbs_signature_segments.any_times { nil }
+    mock(method_entry).rbs_signature_overloads.any_times { nil }
 
     html = @c.compile_method(method_entry)
     assert_include(html, '<code>mf</code>')
@@ -1065,7 +1124,7 @@ HERE
     mock(method_entry).names.any_times { [] }
     mock(method_entry).since_map.any_times { {} }
     mock(method_entry).until_map.any_times { {} }
-    mock(method_entry).rbs_signature_segments.any_times { nil }
+    mock(method_entry).rbs_signature_overloads.any_times { nil }
     html = @c.compile_method(method_entry)
     assert_not_include(html, 'UNKNOWN_META_INFO')
     assert_not_include(html, '{:')
@@ -1089,7 +1148,7 @@ HERE
     mock(method_entry).names.any_times { [] }
     mock(method_entry).since_map.any_times { {} }
     mock(method_entry).until_map.any_times { {} }
-    mock(method_entry).rbs_signature_segments.any_times { nil }
+    mock(method_entry).rbs_signature_overloads.any_times { nil }
     html = @c.compile_method(method_entry)
     assert_not_include(html, '{:')
     assert_include(html, 'to_a2')
@@ -1112,7 +1171,7 @@ HERE
     mock(method_entry).names.any_times { [] }
     mock(method_entry).since_map.any_times { {} }
     mock(method_entry).until_map.any_times { {} }
-    mock(method_entry).rbs_signature_segments.any_times { nil }
+    mock(method_entry).rbs_signature_overloads.any_times { nil }
     html = @c.compile_method(method_entry)
     assert_not_include(html, '{:')
     assert_include(html, 'このメソッドは定義されていません。')


### PR DESCRIPTION
#322 の続きです(このブランチは #322 の上に作ってあり、#322 マージ後は差分がこのコミットだけになります)。

`Array.new` や `Array#[]` のように引数パターンごとに説明(`---` 見出し+本文の組=チャンク)が分かれているメソッドで、これまで全チャンクに全オーバーロードが重複表示されていたのを、各オーバーロードを最も近いチャンクの見出し直下にだけ表示するようにします。

## 振り分けの仕組み

RBS の引数名は rdoc の call-seq 由来で rurema のシグネチャの引数名とよく一致します(`size`/`val`/`ary`/`start`/`length`/`range` などを実データで確認)。これを利用して、「ブロック有無 → 引数名の一致 → アリティ範囲の重なり」のスコアで最も近いチャンクを選びます(新規モジュール `RbsOverloadMatcher`)。

- RBS のオーバーロードと rurema のチャンクは 1:1 対応が保証されない(RBS の `()` と `(int size, ?Elem val)` が rurema では同一チャンク等)ので、多対 1 の割り当てにしています
- 確実な対応が取れないもの(同点など)は先頭チャンクに寄せます。どのチャンクにも重複しては出しません

実装は 2 段です:

- **rbssig(書き込み側)**: `rbs_sig` property の JSON を `{"overloads": [...]}` 形式にして、オーバーロードごとに引数名・アリティ範囲・ブロック有無のメタ情報を付与します。旧形式の DB は segments のみとして読み、振り分けなしで先頭チャンクにまとめて表示します(重複はしなくなります)
- **描画側**: `compile_method` の冒頭でソースのシグネチャ行を走査してチャンク列を作り(`entry_chunk` と同じ規則・md は `### def` 行を `--- ` に正規化)、割り当てを済ませておきます。`entry_chunk` は自分の番のぶんだけ `<dt class="rbs-signature">` を出します

## 表示例(rbs v3.10.0 実データでの E2E)

`Array.new`(RBS 4 オーバーロード → 3 チャンク):

```
new(size = 0, val = nil) -> Array
  () → void
  (int size, ?Elem val) → void
new(ary) -> Array
  (::Array[Elem] ary) → void
new(size) {|index| ... } -> Array
  (int size) { (::Integer index) → Elem } → void
```

`Array#[]`(3 → 3。`(int index)` は引数名が合いませんが、アリティ同点の先頭チャンク=`nth` に置かれます):

```
self[nth] -> object | nil
  (int index) → Elem
self[range] -> Array | nil
  (::Range[::Integer?] range) → ::Array[Elem]?
self[start, length] -> Array | nil
  (int start, int length) → ::Array[Elem]?
```

## 検証

- `ruby test/run_test.rb` 17969 tests 全パス(matcher 単体・importer のメタ情報・新旧 JSON 形式の互換・rd/md 両経路の振り分け描画のテストを追加)
- `bundle exec steep check` No type error
- ミニ md ツリー + rbs v3.10.0 チェックアウトで rbssig → `lookup --html` を実走し、上記 `Array.new`/`Array#[]` の振り分けを確認。rbssig の再実行が冪等(entries_updated=0)であることも確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
