### PR TITLE
RBS シグネチャをメソッド定義の見出しと明確に区別する

### DIFF
--- a/theme/default/style.css
+++ b/theme/default/style.css
@@ -639,16 +639,26 @@ span.method-until-badge { background-color: #f7e6e6; color: #aa3333; }
 
 /* RBS 型シグネチャ(rbssig サブコマンドが 4.0 以降の DB に書き込み、
    メソッド見出しの <dt> 群の直後に 1 オーバーロード 1 行の
-   <dt class="rbs-signature"> として出る)。参考情報なのでメソッド
-   見出しより控えめな見た目にし、インラインコードのチップ背景も外す */
+   <dt class="rbs-signature"> として出る)。参考情報なので rdoc の型表示の
+   ように小さく・薄く・少し字下げして、メソッド定義の見出しと明確に
+   区別する。行の大半はクラスへのリンクなので、リンクの太字(a の既定)と
+   リンク色もここで打ち消さないと見出しと同じ太字の青になってしまう。
+   インラインコードのチップ背景も外す */
 dt.rbs-signature {
     font-weight: normal;
-    font-size: 85%;
-    color: #555;
+    font-size: 80%;
+    color: #999;
     line-height: 1.4;
+    margin-left: 2em;
 }
 dt.rbs-signature code {
     background-color: transparent;
     padding: 0;
     border-radius: 0;
+    font-size: 100%;  /* code の 90% 縮小と二重に掛けない(実効 80%) */
+}
+dt.rbs-signature a:link,
+dt.rbs-signature a:visited {
+    font-weight: normal;
+    color: #8895b5;
 }

--- a/theme/lillia/style.css
+++ b/theme/lillia/style.css
@@ -319,18 +319,28 @@ span.method-until-badge { background-color: #f7e6e6; color: #aa3333; }
 
 /* RBS 型シグネチャ(rbssig サブコマンドが 4.0 以降の DB に書き込み、
    メソッド見出しの <dt> 群の直後に 1 オーバーロード 1 行の
-   <dt class="rbs-signature"> として出る)。参考情報なのでメソッド
-   見出しより控えめな見た目にし、インラインコードのチップ背景も外す */
+   <dt class="rbs-signature"> として出る)。参考情報なので rdoc の型表示の
+   ように小さく・薄く・少し字下げして、メソッド定義の見出しと明確に
+   区別する。行の大半はクラスへのリンクなので、リンクの太字(a の既定)と
+   リンク色もここで打ち消さないと見出しと同じ太字の青になってしまう。
+   インラインコードのチップ背景も外す */
 dt.rbs-signature {
   font-weight: normal;
-  font-size: 85%;
-  color: #555;
+  font-size: 80%;
+  color: #999;
   line-height: 1.4;
+  margin-left: 2em;
 }
 dt.rbs-signature code {
   background-color: transparent;
   padding: 0;
   border-radius: 0;
+  font-size: 100%;  /* code の縮小と二重に掛けない(実効 80%) */
+}
+dt.rbs-signature a:link,
+dt.rbs-signature a:visited {
+  font-weight: normal;
+  color: #8895b5;
 }
 
 .method-description{


### PR DESCRIPTION
本番反映後の RBS シグネチャ表示が、doctree のメソッド定義の見出しと区別できないというフィードバックへの対応です。rdoc の型表示のように小さく・薄く・少し字下げして、「別の情報」として読めるようにします。

## 原因

rurema/bitclust#322 で `dt.rbs-signature` に `font-weight: normal`・`color: #555` を当てていましたが、RBS 行の大半は**クラスへのリンク**で、リンクには既定の `a { font-weight: bold }` と `a:link { color: #33a }` がそのまま効きます。結果、行のほとんどが見出しと同じ「太字の青」になり、dt 側の指定が実質届いていませんでした。

## 変更(theme/default・theme/lillia の両方)

- `dt.rbs-signature`: 85% → **80%**・#555 → **#999**・**`margin-left: 2em`**(見出しの下にぶら下がる注釈として読めるように)
- **リンクの太字と色をここで打ち消し**、細字の淡色(`#8895b5`)にします(今回の実質的な修正点)
- default テーマの `code` の 90% 縮小と二重掛けにならないよう、内側の `code` は 100%(実効 80%)

## 表示イメージ

`String#sub`(見出し=太字+チップ付き `code`、その下に RBS 行):

- 変更前: `(Regexp | string pattern, ...) → String` の `Regexp`/`String` が**太字の青**で、見出しと同じ調子
- 変更後: 行全体が細字・小さめ・グレー系(リンクは淡い青灰)で 2em 字下げ

マークアップ・DB・rbssig サブコマンドに変更はありません(CSS のみ)。マージ後、次の日次 run から本番に反映されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
