### PR TITLE
statichtml のページに版切り替えドロップダウンを追加

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,7 @@ namespace :test do
     sh 'qjs', 'test/js/test_run.mjs'
     sh 'qjs', 'test/js/test_script.mjs'
     sh 'qjs', 'test/js/test_search.mjs'
+    sh 'qjs', 'test/js/test_version_switcher.mjs'
   end
 end
 

--- a/data/bitclust/template.offline/layout
+++ b/data/bitclust/template.offline/layout
@@ -21,6 +21,7 @@
 <script src="<%=h custom_js_url('js/search_ranker.js') %>"></script>
 <script src="<%=h custom_js_url('js/search_controller.js') %>"></script>
 <script src="<%=h custom_js_url('js/search_init.js') %>"></script>
+<script defer src="<%=h custom_js_url('js/version_switcher.js') %>"></script>
 <% if run_ruby_wasm_url %>
 <meta name="rurema-run-ruby-wasm" content="<%=h run_ruby_wasm_url %>">
 <meta name="rurema-run-help" content="<%=h document_url('help') %>#run">
@@ -36,6 +37,7 @@
 <% end %>
 <div id="rurema-topbar">
   <div id="rurema-brand"><%= manual_home_link %></div>
+  <div id="version-switcher"></div>
   <div id="search-section" role="search">
     <input id="search-field" type="text" autocomplete="off" spellcheck="false"
            placeholder="クラス・メソッドを検索 (/)"

--- a/lib/bitclust/subcommands/statichtml_command.rb
+++ b/lib/bitclust/subcommands/statichtml_command.rb
@@ -242,6 +242,7 @@ module BitClust
         FileUtils.cp(@manager_config[:themedir] + "script.js",
                      @outputdir.to_s, :verbose => @verbose, :preserve => true)
         copy_run_ruby_wasm_script if @run_ruby_wasm
+        copy_version_switcher_script
         FileUtils.cp(@manager_config[:themedir] + @manager_config[:favicon_url],
                      @outputdir.to_s, :verbose => @verbose, :preserve => true)
         Dir.mktmpdir do |tmpdir|
@@ -418,6 +419,19 @@ HERE
           FileUtils.mkdir_p(jsdir) unless jsdir.directory?
           FileUtils.cp(src.to_s, jsdir.to_s, :verbose => @verbose, :preserve => true)
         end
+      end
+
+      # Copy the version-switcher script. A themedir without it is
+      # tolerated: warn and skip instead of aborting the whole build.
+      def copy_version_switcher_script
+        src = @manager_config[:themedir] + "js" + "version_switcher.js"
+        unless src.file?
+          $stderr.puts "warning: #{src} not found; version switcher script not copied"
+          return
+        end
+        jsdir = @outputdir + "js"
+        FileUtils.mkdir_p(jsdir) unless jsdir.directory?
+        FileUtils.cp(src.to_s, jsdir.to_s, :verbose => @verbose, :preserve => true)
       end
 
       def create_html_file(entry, manager, outputdir, db)

--- a/sig/bitclust/subcommands/statichtml_command.rbs
+++ b/sig/bitclust/subcommands/statichtml_command.rbs
@@ -133,6 +133,8 @@ module BitClust
 
       def copy_run_ruby_wasm_script: () -> void
 
+      def copy_version_switcher_script: () -> void
+
       SEARCH_JS_FILES: Array[String]
 
       def create_search_index: (Pathname outputdir, MethodDatabase db, FunctionDatabase fdb) -> void

--- a/test/js/test_version_switcher.mjs
+++ b/test/js/test_version_switcher.mjs
@@ -133,6 +133,15 @@ assert(VS.attach({
   checkExists: () => Promise.resolve(true),
 }) === false, 'attach outside a versioned page is a no-op')
 
+// Local statichtml output (rake statichtml:X.Y opened via file:// or a
+// local server without the /ja/<version>/ prefix): no switcher, no fetch.
+assert(VS.attach({
+  document: makeDocument(makeElement('div')),
+  location: { pathname: '/tmp/html/3.4/class/Array.html' },
+  setHref() { failures++ },
+  checkExists: () => { failures++; return Promise.resolve(true) },
+}) === false, 'attach on a local statichtml path is a no-op')
+
 // Normal attachment: builds a select with the current version selected.
 let slot = makeElement('div')
 let navigated = []

--- a/test/js/test_version_switcher.mjs
+++ b/test/js/test_version_switcher.mjs
@@ -1,0 +1,178 @@
+// QuickJS-based tests for theme/default/js/version_switcher.js.
+// Run with: qjs test/js/test_version_switcher.mjs   (see the "test:js" rake task)
+//
+// version_switcher.js is a classic script: evaluating it with indirect
+// eval() attaches RuremaVersionSwitcher to globalThis, as a <script> tag
+// would. DOM wiring is exercised through a minimal fake DOM via attach().
+import * as std from 'std'
+
+let failures = 0
+function assert(cond, message) {
+  if (cond) {
+    print('ok: ' + message)
+  } else {
+    failures++
+    print('FAIL: ' + message)
+  }
+}
+
+const here = import.meta.url.replace(/^file:\/\//, '').replace(/\/[^/]*$/, '')
+const jsdir = here + '/../../theme/default/js/'
+
+const indirectEval = eval
+indirectEval(std.loadFile(jsdir + 'version_switcher.js'))
+
+const VS = globalThis.RuremaVersionSwitcher
+assert(!!VS, 'RuremaVersionSwitcher is exposed on globalThis')
+
+// --- parsePath ----------------------------------------------------------
+
+let p = VS.parsePath('/ja/3.4/method/Array/i/=5b=5d.html')
+assert(p && p.base === '/ja/' && p.version === '3.4' &&
+       p.rest === '/method/Array/i/=5b=5d.html',
+       'parsePath splits a method page path')
+
+p = VS.parsePath('/mirror/ja/latest/doc/index.html')
+assert(p && p.base === '/mirror/ja/' && p.version === 'latest',
+       'parsePath accepts a deep base and the latest alias')
+
+assert(VS.parsePath('/ja/unknown/doc/index.html') === null,
+       'parsePath rejects an unknown version segment')
+assert(VS.parsePath('/en/3.4/method/Array/i/pop.html') === null,
+       'parsePath rejects non-ja paths')
+assert(VS.parsePath('/ja/3.4') === null,
+       'parsePath rejects a version segment without a page path')
+
+// --- targetUrl ----------------------------------------------------------
+
+p = VS.parsePath('/ja/3.4/class/Array.html')
+assert(VS.targetUrl(p, '2.7.0') === '/ja/2.7.0/class/Array.html',
+       'targetUrl swaps only the version segment')
+
+// --- optionVersions -----------------------------------------------------
+
+let opts = VS.optionVersions('3.4')
+assert(opts[0] === 'master', 'optionVersions puts master first')
+assert(opts[1] === VS.RELEASED_VERSIONS[0],
+       'optionVersions lists released versions after master')
+assert(opts.indexOf('latest') === -1,
+       'optionVersions omits the latest alias for a released version')
+assert(opts.indexOf('3.4') !== -1, 'optionVersions contains the current version')
+
+opts = VS.optionVersions('latest')
+assert(opts[0] === 'latest', 'optionVersions prepends latest when current')
+
+// --- resolveTarget ------------------------------------------------------
+// checkExists is injected so tests control per-URL existence.
+
+function existsFrom(map) {
+  return url => Promise.resolve(url in map ? map[url] : false)
+}
+
+p = VS.parsePath('/ja/3.4/class/Set.html')
+
+// Requested version has the page: navigate straight there.
+let url = await VS.resolveTarget(p, '3.3', existsFrom({'/ja/3.3/class/Set.html': true}))
+assert(url === '/ja/3.3/class/Set.html', 'resolveTarget uses the target when it exists')
+
+// Requested version lacks the page: fall back to the newest release that has it.
+url = await VS.resolveTarget(p, '1.8.7', existsFrom({
+  '/ja/4.0/class/Set.html': false,
+  '/ja/3.4/class/Set.html': true,
+}))
+assert(url === '/ja/3.4/class/Set.html',
+       'resolveTarget falls back to the newest existing version')
+
+// Existence unknown (network error): navigate to the target anyway.
+url = await VS.resolveTarget(p, '2.0.0', () => Promise.resolve(null))
+assert(url === '/ja/2.0.0/class/Set.html',
+       'resolveTarget keeps the target when existence is unknown')
+
+// Nothing has the page: land on the target version's root.
+url = await VS.resolveTarget(p, '1.9.3', () => Promise.resolve(false))
+assert(url === '/ja/1.9.3/', 'resolveTarget falls back to the version root')
+
+// --- attach (fake DOM) --------------------------------------------------
+
+function makeElement(tag) {
+  const listeners = {}
+  return {
+    tagName: (tag || 'div').toUpperCase(),
+    children: [],
+    value: '',
+    disabled: false,
+    selected: false,
+    textContent: '',
+    _attrs: {},
+    addEventListener(type, cb) { (listeners[type] ||= []).push(cb) },
+    dispatch(type, e) { (listeners[type] || []).forEach(cb => cb(e || {})) },
+    setAttribute(name, v) { this._attrs[name] = String(v) },
+    appendChild(child) { this.children.push(child); return child },
+  }
+}
+
+function makeDocument(slot) {
+  return {
+    createElement: makeElement,
+    getElementById(id) { return id === 'version-switcher' ? slot : null },
+  }
+}
+
+// No slot or unrecognized path: attach is a no-op and reports false.
+assert(VS.attach({
+  document: makeDocument(null),
+  location: { pathname: '/ja/3.4/class/Set.html' },
+  setHref() { failures++ },
+  checkExists: () => Promise.resolve(true),
+}) === false, 'attach without a slot is a no-op')
+
+assert(VS.attach({
+  document: makeDocument(makeElement('div')),
+  location: { pathname: '/ja/search/index.html' },
+  setHref() { failures++ },
+  checkExists: () => Promise.resolve(true),
+}) === false, 'attach outside a versioned page is a no-op')
+
+// Normal attachment: builds a select with the current version selected.
+let slot = makeElement('div')
+let navigated = []
+let probed = []
+const deps = {
+  document: makeDocument(slot),
+  location: { pathname: '/ja/3.3/class/Set.html' },
+  setHref(u) { navigated.push(u) },
+  checkExists(u) {
+    probed.push(u)
+    return Promise.resolve(!u.startsWith('/ja/1.8.7/'))
+  },
+}
+assert(VS.attach(deps) === true, 'attach wires up on a versioned page')
+const select = slot.children[0]
+assert(select && select.tagName === 'SELECT', 'attach appends a select to the slot')
+assert(select.value === '3.3', 'the current version is selected')
+const versions = select.children.map(o => o.value)
+assert(versions[0] === 'master' && versions.indexOf('1.8.7') !== -1,
+       'options cover master and released versions')
+
+// First interaction probes all other versions and disables missing ones.
+select.dispatch('focus')
+await Promise.resolve(); await Promise.resolve(); await Promise.resolve()
+const opt187 = select.children.find(o => o.value === '1.8.7')
+assert(opt187 && opt187.disabled === true, 'missing versions are disabled after probing')
+const optCurrent = select.children.find(o => o.value === '3.3')
+assert(optCurrent && optCurrent.disabled === false, 'the current version stays enabled')
+assert(probed.every(u => !u.startsWith('/ja/3.3/')), 'the current version is not probed')
+
+const probesAfterFirst = probed.length
+select.dispatch('focus')
+assert(probed.length === probesAfterFirst, 'probing happens only once')
+
+// Changing the selection navigates to the resolved URL.
+select.value = '3.0'
+select.dispatch('change')
+await Promise.resolve(); await Promise.resolve(); await Promise.resolve()
+assert(navigated.length === 1 && navigated[0] === '/ja/3.0/class/Set.html',
+       'changing the selection navigates to the same page in that version')
+
+print(failures === 0 ? 'ALL OK' : failures + ' failure(s)')
+if (failures > 0) std.exit(1)

--- a/test/test_statichtml_command.rb
+++ b/test/test_statichtml_command.rb
@@ -297,3 +297,45 @@ class TestStatichtmlMarkdownOutput < Test::Unit::TestCase
     end
   end
 end
+
+class TestStatichtmlVersionSwitcher < Test::Unit::TestCase
+  def build_command(themedir, outputdir)
+    cmd = BitClust::Subcommands::StatichtmlCommand.new
+    cmd.instance_variable_set(:@manager_config, { :themedir => Pathname.new(themedir) })
+    cmd.instance_variable_set(:@outputdir, Pathname.new(outputdir))
+    cmd.instance_variable_set(:@verbose, false)
+    cmd
+  end
+
+  def test_version_switcher_js_is_copied
+    Dir.mktmpdir do |dir|
+      themedir = File.join(dir, 'theme')
+      outputdir = File.join(dir, 'out')
+      FileUtils.mkdir_p(File.join(themedir, 'js'))
+      FileUtils.mkdir_p(outputdir)
+      File.write(File.join(themedir, 'js', 'version_switcher.js'), "// vs\n")
+      cmd = build_command(themedir, outputdir)
+      cmd.send(:copy_version_switcher_script)
+      assert_true(File.file?(File.join(outputdir, 'js', 'version_switcher.js')))
+    end
+  end
+
+  # An older themedir without the file must not abort the whole build.
+  def test_theme_without_version_switcher_js_is_tolerated
+    Dir.mktmpdir do |dir|
+      themedir = File.join(dir, 'theme')
+      outputdir = File.join(dir, 'out')
+      FileUtils.mkdir_p(themedir)
+      FileUtils.mkdir_p(outputdir)
+      cmd = build_command(themedir, outputdir)
+      orig_stderr, $stderr = $stderr, StringIO.new
+      begin
+        assert_nothing_raised { cmd.send(:copy_version_switcher_script) }
+        assert_match(/version_switcher\.js not found/, $stderr.string)
+      ensure
+        $stderr = orig_stderr
+      end
+      assert_false(File.exist?(File.join(outputdir, 'js', 'version_switcher.js')))
+    end
+  end
+end

--- a/theme/default/js/version_switcher.js
+++ b/theme/default/js/version_switcher.js
@@ -1,0 +1,147 @@
+// Version switcher for statichtml pages served under a /ja/<version>/ tree.
+//
+// Renders a <select> into the #version-switcher slot in the top bar. Picking
+// a version navigates to the same page under that version; if the page does
+// not exist there, it falls back to the newest version that has it, and as a
+// last resort to that version's top page. On the first interaction every
+// other version is probed with a HEAD request and missing ones are disabled.
+//
+// Pages not served under a versioned path (local previews, /ja/search/) get
+// no switcher: attach() is a no-op there.
+(function () {
+  'use strict';
+
+  // 公開済みの版(新しい順)。doctree の Rakefile の
+  // SUPPORTED_VERSIONS / OLD_VERSIONS と揃える。
+  var RELEASED_VERSIONS = [
+    '4.0', '3.4', '3.3', '3.2', '3.1', '3.0',
+    '2.7.0', '2.6.0', '2.5.0', '2.4.0', '2.3.0', '2.2.0', '2.1.0', '2.0.0',
+    '1.9.3', '1.8.7'
+  ];
+  var EDGE_VERSION = 'master';
+  var ALIASES = ['latest', EDGE_VERSION];
+
+  function knownVersion(version) {
+    return RELEASED_VERSIONS.indexOf(version) !== -1 ||
+      ALIASES.indexOf(version) !== -1;
+  }
+
+  function parsePath(pathname) {
+    var m = /^(.*\/ja\/)([^\/]+)(\/.+)$/.exec(pathname);
+    if (!m || !knownVersion(m[2])) return null;
+    return { base: m[1], version: m[2], rest: m[3] };
+  }
+
+  function targetUrl(parsed, version) {
+    return parsed.base + version + parsed.rest;
+  }
+
+  function optionVersions(currentVersion) {
+    var versions = [EDGE_VERSION].concat(RELEASED_VERSIONS);
+    if (versions.indexOf(currentVersion) === -1) {
+      versions.unshift(currentVersion);
+    }
+    return versions;
+  }
+
+  // true: exists / false: does not exist / null: unknown (network error)
+  function checkExists(url) {
+    return fetch(url, { method: 'HEAD' })
+      .then(function (res) { return res.ok; })
+      .catch(function () { return null; });
+  }
+
+  // Resolve where picking `version` should go. Unknown existence keeps the
+  // target so an offline or CORS-restricted page still just navigates.
+  function resolveTarget(parsed, version, exists) {
+    var target = targetUrl(parsed, version);
+    return exists(target).then(function (ok) {
+      if (ok !== false) return target;
+      var candidates = RELEASED_VERSIONS.filter(function (v) {
+        return v !== version;
+      });
+      var tryNext = function (i) {
+        if (i >= candidates.length) return parsed.base + version + '/';
+        var url = targetUrl(parsed, candidates[i]);
+        return exists(url).then(function (found) {
+          return found === true ? url : tryNext(i + 1);
+        });
+      };
+      return tryNext(0);
+    });
+  }
+
+  function attach(deps) {
+    var doc = deps.document;
+    var slot = doc.getElementById('version-switcher');
+    var parsed = parsePath(deps.location.pathname);
+    if (!slot || !parsed) return false;
+    var exists = deps.checkExists || checkExists;
+
+    var select = doc.createElement('select');
+    select.setAttribute('aria-label', '他のバージョンの同じページを表示');
+    optionVersions(parsed.version).forEach(function (version) {
+      var option = doc.createElement('option');
+      option.value = version;
+      option.textContent = version;
+      option.selected = version === parsed.version;
+      select.appendChild(option);
+    });
+    select.value = parsed.version;
+
+    var probed = false;
+    var probe = function () {
+      if (probed) return;
+      probed = true;
+      Array.prototype.forEach.call(select.children, function (option) {
+        if (option.value === parsed.version) return;
+        exists(targetUrl(parsed, option.value)).then(function (ok) {
+          if (ok === false) option.disabled = true;
+        });
+      });
+    };
+    select.addEventListener('focus', probe);
+    select.addEventListener('mousedown', probe);
+    select.addEventListener('touchstart', probe);
+
+    select.addEventListener('change', function () {
+      var version = select.value;
+      if (version === parsed.version) return;
+      resolveTarget(parsed, version, exists).then(function (url) {
+        deps.setHref(url);
+      });
+    });
+
+    slot.appendChild(select);
+    return true;
+  }
+
+  var api = {
+    RELEASED_VERSIONS: RELEASED_VERSIONS,
+    EDGE_VERSION: EDGE_VERSION,
+    parsePath: parsePath,
+    targetUrl: targetUrl,
+    optionVersions: optionVersions,
+    checkExists: checkExists,
+    resolveTarget: resolveTarget,
+    attach: attach
+  };
+  if (typeof globalThis !== 'undefined') {
+    globalThis.RuremaVersionSwitcher = api;
+  }
+
+  if (typeof document !== 'undefined' && typeof location !== 'undefined') {
+    var init = function () {
+      attach({
+        document: document,
+        location: location,
+        setHref: function (url) { location.href = url; }
+      });
+    };
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', init);
+    } else {
+      init();
+    }
+  }
+})();

--- a/theme/default/search.css
+++ b/theme/default/search.css
@@ -26,6 +26,27 @@
   text-overflow: ellipsis;
 }
 
+/* Version switcher: sits next to the brand; the auto margin keeps the
+   search box pinned to the right. The slot is empty until
+   version_switcher.js fills it (only on /ja/<version>/ pages). */
+#version-switcher {
+  flex: 0 0 auto;
+  margin-right: auto;
+}
+
+#version-switcher:empty {
+  display: none;
+}
+
+#version-switcher select {
+  font-size: 0.9em;
+  padding: 0.2em 0.3em;
+  border: 1px solid #99a;
+  border-radius: 4px;
+  background: #fff;
+  color: inherit;
+}
+
 #search-section {
   position: relative;
   flex: 0 0 auto;


### PR DESCRIPTION
statichtml のページに、別の Ruby バージョンの同じドキュメントへ移動するドロップダウンを追加します(znz さんのリクエスト)。

動作プレビュー(この PR の JS 実物を HEAD スタブ付きで動かしたもの): [version_switcher プレビュー](https://claude.ai/code/artifact/4cf0698e-14f8-4314-b97b-e0451ce934ab)

## 挙動

- topbar のブランドリンクと検索ボックスの間に `<select>` を表示します(`/ja/<version>/` 配下のページのみ。ローカルプレビューや `/ja/search/` では何も表示しません)
- 選択すると同じパスの別バージョンへ遷移します。ページが無い場合は**存在する最新のバージョン**へ、どこにも無い場合はそのバージョンのトップへフォールバックします([Rails ガイドの Edge フォールバック](https://edgeguides.rubyonrails.org/)と同じ体感)
- 最初にドロップダウンへ触れた時点で他バージョンの存在を HEAD リクエストで並列確認し、無いバージョンの選択肢を無効化(グレーアウト)します。存在確認に失敗する環境(オフライン等)では確認をスキップしてそのまま遷移します

## 実装の要点

- ビルド横断のデータ生成は不要です。バージョン一覧は `version_switcher.js` 内の定数で、doctree の Rakefile(SUPPORTED_VERSIONS/OLD_VERSIONS)と揃えています(年次の版追加時にあわせて更新する運用)。将来必要になれば `versions.json` の配信でランタイム上書きに拡張できます
- 凍結版のページは再生成されないため、ドロップダウンが載るのは今後生成されるバージョンのみです
- statichtml が theme の `js/version_switcher.js` を出力へコピーします(ファイルが無い旧 themedir は警告してスキップ)
- マージ後は日次ビルドから本番へ反映されます

## テスト

- `test/js/test_version_switcher.mjs`(qjs): パス解析・フォールバック解決・fake DOM でのドロップダウン配線(選択肢の無効化・一度きりの probe・遷移)
- `test/test_statichtml_command.rb`: コピー処理 2 件
- ミニ Markdown ツリーからの statichtml 生成で、全ページにスロットと `defer` スクリプトタグが入ること・js がコピーされることを確認済み
- 既存テストスイート全緑・`rake sig`・`steep check`(No type error)通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
