### PR TITLE
irb から るりま を引く refe コマンドを追加(bitclust-irb gem)

### DIFF
--- a/bitclust-irb.gemspec
+++ b/bitclust-irb.gemspec
@@ -1,0 +1,34 @@
+$:.push File.expand_path("../lib", __FILE__)
+require "bitclust/version"
+
+Gem::Specification.new do |s|
+  s.name        = "bitclust-irb"
+  s.version     = BitClust::VERSION
+  s.authors     = ["https://github.com/rurema"]
+  s.email       = [""]
+  s.homepage    = "https://docs.ruby-lang.org/ja/"
+  s.summary     = %Q!irb command to look up Rurema (Japanese Ruby reference manual).!
+  s.description =<<EOD
+Rurema is a Japanese ruby documentation project, and
+bitclust is a rurema document processor.
+This gem adds a `refe` command to irb (>= 1.13) that looks up
+the Rurema reference database from your irb session:
+put `require "bitclust/irb"` in your ~/.irbrc.
+EOD
+
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/rurema/bitclust/issues",
+    "documentation_uri" => "https://github.com/rurema/bitclust/blob/master/doc/usage.md",
+    "homepage_uri"      => s.homepage,
+    "source_code_uri"   => "https://github.com/rurema/bitclust",
+    "github_repo"       => "https://github.com/rurema/bitclust",
+  }
+
+  # 実体(lib/bitclust/irb.rb)は bitclust-core 側に含まれる。この gem は
+  # irb への依存宣言と `require "bitclust-irb"` 用のスタブだけを持つ
+  s.files         = ["lib/bitclust-irb.rb"]
+  s.require_paths = ["lib"]
+
+  s.add_runtime_dependency "bitclust-core", "= #{BitClust::VERSION}"
+  s.add_runtime_dependency "irb", ">= 1.13"
+end

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -53,6 +53,21 @@ $ gem install bitclust-core bitclust-dev refe2
 <dd>BitClust データベースに対応した ReFe (ReFe2)。</dd>
 </dl>
 
+## irb から使う(bitclust-irb)
+
+bitclust-irb gem を入れて `~/.irbrc` に次の 1 行を書くと、
+irb(1.13 以降)に `refe` コマンドが追加されます。
+
+```ruby
+require "bitclust/irb"
+```
+
+irb のセッション中に `refe String#gsub` のように入力すると、
+refe コマンドと同じデータベース($HOME/.bitclust/config か
+環境変数 BITCLUST_DATADIR で指定した場所)を検索して
+結果をページャで表示します。データベースは事前に `bitclust setup`
+で作成しておいてください。
+
 ## bitclust サブコマンド
 
 ```--capi``` オプションを付けた場合，C API（doctree の manual/capi 以下）を対象とします。付けない場合，ライブラリ（manual/api 以下）と言語仕様など（manual/doc 以下）を対象とします。

--- a/lib/bitclust-irb.rb
+++ b/lib/bitclust-irb.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+require 'bitclust/irb'

--- a/lib/bitclust/irb.rb
+++ b/lib/bitclust/irb.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+#
+# irb からるりま(Ruby リファレンスマニュアル)を引く refe コマンド。
+# ~/.irbrc に `require "bitclust/irb"` と書くと irb に `refe` コマンドが
+# 登録される。検索対象の DB は refe コマンドと同じ場所
+# (bitclust setup が作る ~/.bitclust/config)から探す。
+
+require 'stringio'
+require 'bitclust'
+require 'bitclust/searcher'
+
+module BitClust
+  module Irb
+    USAGE = <<~USAGE
+      Usage: refe <pattern>
+
+      例:
+        refe String#gsub     インスタンスメソッド
+        refe Array.new       特異メソッド
+        refe Comparable      クラス・モジュール
+        refe printf          名前だけでの検索
+
+      DB が無い場合は `bitclust setup` で作成してください。
+    USAGE
+
+    # pattern を検索して整形済みテキストを io へ書く。db が nil なら
+    # 既定の場所から探す。検索の失敗は例外にせず io へメッセージを書く
+    # (irb セッションを止めないため)
+    def self.lookup(pattern, io: $stdout, db: nil)
+      words = pattern.to_s.split
+      if words.empty?
+        io.puts USAGE
+        return
+      end
+      view = TerminalView.new(Plain.new,
+                              { describe_all: false, line: false, encoding: nil },
+                              io: io)
+      Searcher.new.run_query(db, words, view)
+    rescue BitClust::UserError => err
+      io.puts err.message
+    end
+
+    begin
+      require 'irb/command'
+    rescue LoadError
+      # irb が無い(または irb < 1.13 で公開コマンド API が無い)環境では
+      # コマンド登録だけを諦め、Irb.lookup は使えるままにする
+    else
+      class RefeCommand < ::IRB::Command::Base
+        category 'Documentation'
+        description 'るりま(Ruby リファレンスマニュアル)を検索して表示します'
+        help_message USAGE
+
+        def execute(arg)
+          content = StringIO.new
+          BitClust::Irb.lookup(arg, io: content)
+          if ::IRB.const_defined?(:Pager)
+            ::IRB::Pager.page_content(content.string)
+          else
+            $stdout.puts content.string
+          end
+        end
+      end
+
+      ::IRB::Command.register(:refe, RefeCommand)
+    end
+  end
+end

--- a/lib/bitclust/searcher.rb
+++ b/lib/bitclust/searcher.rb
@@ -121,6 +121,14 @@ module BitClust
       @parser.help
     end
 
+    # irb プラグインなど組み込み利用向けの入口。argv のパターンを db から
+    # 検索し、結果を view(TerminalView)へ出力する。db が nil なら
+    # 既定の場所(~/.bitclust/config など)から探す
+    def run_query(db, argv, view)
+      @view = view
+      search_pattern db, argv
+    end
+
     private
 
     def server_mode_check(argv)
@@ -374,12 +382,14 @@ module BitClust
 
   class TerminalView
 
-    def initialize(compiler, opts)
+    # io を省略すると出力先は呼び出し時点の $stdout(従来挙動)
+    def initialize(compiler, opts, io: nil)
       @compiler = compiler
       @describe_all = opts[:describe_all]
       @line = opts[:line]
       @encoding = opts[:encoding]
       @database = nil
+      @io = io
     end
 
     attr_accessor :database
@@ -546,7 +556,7 @@ module BitClust
     end
 
     def puts(*args)
-      super(*args.collect {|arg| convert(arg)})
+      (@io || $stdout).puts(*args.collect {|arg| convert(arg)})
     end
 
     def convert(string)

--- a/sig/bitclust/irb.rbs
+++ b/sig/bitclust/irb.rbs
@@ -1,0 +1,31 @@
+# irb 本体の型定義は rbs collection に無いため、bitclust/irb.rb が使う
+# 範囲だけの最小のスタブを併せて宣言する
+module IRB
+  def self.const_defined?: (Symbol) -> bool
+
+  module Command
+    def self.register: (Symbol name, untyped command_class) -> void
+
+    class Base
+      def self.category: (String category) -> void
+      def self.description: (String description) -> void
+      def self.help_message: (String help_message) -> void
+    end
+  end
+
+  module Pager
+    def self.page_content: (String content) -> void
+  end
+end
+
+module BitClust
+  module Irb
+    USAGE: String
+
+    def self.lookup: (untyped pattern, ?io: _SearcherOutput, ?db: (MethodDatabase | FunctionDatabase)?) -> void
+
+    class RefeCommand < ::IRB::Command::Base
+      def execute: (String arg) -> void
+    end
+  end
+end

--- a/sig/bitclust/searcher.rbs
+++ b/sig/bitclust/searcher.rbs
@@ -1,4 +1,9 @@
 module BitClust
+  # TerminalView の出力先($stdout や StringIO)
+  interface _SearcherOutput
+    def puts: (*untyped args) -> void
+  end
+
   # Body of bin/refe.
   class Searcher
     @dblocation: (URI::File | URI::Generic)?
@@ -30,6 +35,8 @@ module BitClust
     def exec: (Subcommand::argv argv, ?Subcommand::options options) -> void
 
     def help: () -> String
+
+    def run_query: (MethodDatabase | FunctionDatabase | nil db, Array[String] argv, TerminalView view) -> void
 
     private
 
@@ -93,7 +100,9 @@ module BitClust
 
     @encoding: String?
 
-    def initialize: (Plain compiler, { :describe_all => bool, :line => bool, :encoding => String? } opts) -> void
+    @io: _SearcherOutput?
+
+    def initialize: (Plain compiler, { :describe_all => bool, :line => bool, :encoding => String? } opts, ?io: _SearcherOutput?) -> void
 
     attr_accessor database: MethodDatabase
 

--- a/test/test_irb_plugin.rb
+++ b/test/test_irb_plugin.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'tmpdir'
+require 'fileutils'
+require 'stringio'
+require 'bitclust'
+require 'bitclust/methoddatabase'
+require 'bitclust/searcher'
+
+# bitclust-irb gem の irb コマンド(refe)。
+#
+# テストリスト:
+# [x] TerminalView が io: に出力する(既定は従来どおり $stdout)
+# [x] Irb.lookup がメソッドを検索して整形結果を io へ書く
+# [x] Irb.lookup がクラスも引ける
+# [x] 空のパターンは使い方を表示して例外にしない
+# [x] 見つからないパターンはメッセージを io へ書いて例外にしない
+# [x] require で IRB::Command::Base のサブクラスとして登録される
+class TestBitClustIrbPlugin < Test::Unit::TestCase
+  FOO_MD = <<~'MD'
+    ---
+    library: foo
+    ---
+    # class Foo < Object
+
+    クラスの説明。
+
+    ## Instance Methods
+
+    ### def bar -> nil
+
+    bar の説明。
+  MD
+
+  def build_markdown_db(dir)
+    api = File.join(dir, 'manual', 'api')
+    FileUtils.mkdir_p(File.join(api, 'foo'))
+    File.write(File.join(api, 'foo.md'), "---\ntype: library\n---\nfoo ライブラリ。\n")
+    File.write(File.join(api, 'foo', 'Foo.md'), FOO_MD)
+    prefix = File.join(dir, 'db')
+    db = BitClust::MethodDatabase.new(prefix)
+    db.init
+    db.transaction do
+      db.propset('version', '3.4')
+      db.propset('encoding', 'utf-8')
+    end
+    db.transaction do
+      db.update_by_markdowntree(api)
+    end
+    BitClust::MethodDatabase.new(prefix)
+  end
+
+  def with_db(&block)
+    Dir.mktmpdir do |dir|
+      yield build_markdown_db(dir)
+    end
+  end
+
+  def test_terminal_view_writes_to_given_io
+    out = StringIO.new
+    view = BitClust::TerminalView.new(BitClust::Plain.new, {}, io: out)
+    view.send(:puts, 'hello')
+    assert_equal("hello\n", out.string)
+  end
+
+  def test_lookup_method
+    require 'bitclust/irb'
+    with_db do |db|
+      out = StringIO.new
+      BitClust::Irb.lookup('Foo#bar', db: db, io: out)
+      assert_match(/Foo#bar/, out.string)
+      assert_match(/bar の説明。/, out.string)
+    end
+  end
+
+  def test_lookup_class
+    require 'bitclust/irb'
+    with_db do |db|
+      out = StringIO.new
+      BitClust::Irb.lookup('Foo', db: db, io: out)
+      assert_match(/class Foo < Object/, out.string)
+      assert_match(/クラスの説明。/, out.string)
+    end
+  end
+
+  def test_lookup_empty_pattern_shows_usage
+    require 'bitclust/irb'
+    with_db do |db|
+      out = StringIO.new
+      assert_nothing_raised do
+        BitClust::Irb.lookup('', db: db, io: out)
+      end
+      assert_match(/refe/, out.string)
+    end
+  end
+
+  def test_lookup_not_found_reports_instead_of_raising
+    require 'bitclust/irb'
+    with_db do |db|
+      out = StringIO.new
+      assert_nothing_raised do
+        BitClust::Irb.lookup('NoSuchClass#no_such_method', db: db, io: out)
+      end
+      assert_match(/no such method/, out.string)
+    end
+  end
+
+  def test_command_is_registered_for_irb
+    begin
+      require 'irb/command'
+    rescue LoadError
+      omit 'irb >= 1.13 is not available'
+    end
+    require 'bitclust/irb'
+    assert(BitClust::Irb::RefeCommand < ::IRB::Command::Base)
+    assert_match(/るりま|リファレンス/, BitClust::Irb::RefeCommand.description)
+  end
+end


### PR DESCRIPTION
irb のセッション中に るりま を引ける `refe` コマンドを追加します(znz さんのリクエスト)。gem 名は bitclust-core / bitclust-dev と揃えた **bitclust-irb** です(将来 irb にプラグイン自動発見が入ったときに refe コマンド本体と独立に導入でき、rubygems.org で「irb」を検索したときに見つけやすい名前でもあります)。

## 使い方

```console
$ gem install bitclust-irb
$ bitclust setup   # DB が無い場合
```

`~/.irbrc` に 1 行:

```ruby
require "bitclust/irb"
```

irb(1.13 以降の公開コマンド API)で:

```
>> refe String#gsub
>> refe Array.new
>> refe Comparable
```

検索対象は refe コマンドと同じ DB(`~/.bitclust/config`・`BITCLUST_DATADIR`)で、結果は `IRB::Pager` で表示します。検索の失敗(DB 未作成・該当なし)は例外にせずメッセージ表示に留め、irb セッションを止めません。

## 実装の要点

- 実体は bitclust-core 側の `lib/bitclust/irb.rb`(irb が無い・古い環境ではコマンド登録だけを諦め、`BitClust::Irb.lookup` は使えるままにします)。bitclust-irb gem は irb `>= 1.13` への依存宣言と `require "bitclust-irb"` 用スタブだけの薄い gem です(refe2 gem と同じ構成)
- `TerminalView` に `io:` キーワードを追加しました(省略時は従来どおり呼び出し時点の `$stdout` に出力=既存挙動不変)。`Searcher` に組み込み利用向けの公開メソッド `run_query` を追加しました
- 表示は refe と同じ整形(`Plain` コンパイラ+`TerminalView`)の流用です

## テスト

- `test/test_irb_plugin.rb`: フィクスチャ DB での lookup(メソッド・クラス・空パターン・該当なし)、`TerminalView` の `io:`、コマンド登録
- 実 irb セッション(irb 1.16)で `refe Foo#bar` の表示を確認済み
- 既存テストスイート全緑・`rake sig`・`steep check`(No type error)通過

## 今後の拡張候補(この PR には含めません)

- DB 未セットアップ環境向けに、docs.ruby-lang.org の Markdown 配信から取得する HTTP フォールバック(v2)
- irb の `show_doc` との統合は現状公開フックが無いため独立コマンドにしています。将来的に ruby/irb へドキュメントプロバイダの公開フックを提案することも視野に入れています

🤖 Generated with [Claude Code](https://claude.com/claude-code)
