### PR TITLE
setup の既定バージョンから teeny を除く

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -91,7 +91,7 @@ doctree の Markdown ツリー（manual/）から DB を構築します。
 
 ```
 bitclust setup                       # 既定のバージョン群の DB を作る
-bitclust setup --versions=3.4.0,4.0.0
+bitclust setup --versions=3.4,4.0
 bitclust setup --purge               # 生成物と設定をすべて消す
 ```
 

--- a/lib/bitclust/subcommands/setup_command.rb
+++ b/lib/bitclust/subcommands/setup_command.rb
@@ -20,7 +20,10 @@ module BitClust
         @prepare = nil
         @cleanup = nil
         @purge = nil
-        @versions = ["3.3.0", "3.4.0", "4.0.0"]
+        # teeny は付けない。#%if (version == "V") や #%version V の等値ゲートは
+        # 文字列一致なので、teeny 付きの版名で DB を作ると doctree CI・
+        # 生成済みドキュメントとゲートの判定がずれる
+        @versions = ["3.3", "3.4", "4.0"]
         @update = true
         @parser.banner = "Usage: #{File.basename($0, '.*')} setup [options]"
         @parser.on('--prepare', 'Prepare config file and checkout repository. Do not create database.') {

--- a/test/test_setup_command.rb
+++ b/test/test_setup_command.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'bitclust'
+require 'bitclust/subcommands/setup_command'
+
+# setup サブコマンドの既定バージョン。
+#
+# テストリスト:
+# [x] 既定の対象バージョンに teeny が付いていない
+#     (#%if (version == "V") や #%version V の等値ゲートは文字列一致なので、
+#     teeny 付きの版名で DB を作ると doctree CI・生成済みドキュメントと
+#     ゲートの判定がずれる)
+class TestSetupCommand < Test::Unit::TestCase
+  def test_default_versions_have_no_teeny
+    versions = BitClust::Subcommands::SetupCommand.new.instance_variable_get(:@versions)
+    assert_false(versions.empty?)
+    versions.each do |version|
+      assert_match(/\A\d+\.\d+\z/, version)
+    end
+  end
+end


### PR DESCRIPTION
`bitclust setup` の既定バージョンを `3.3.0,3.4.0,4.0.0` から `3.3,3.4,4.0` に変更します。

`#%if (version == "V")` や `#%version V`(単一版)の等値ゲートは文字列一致で評価されるため、teeny 付きの版名で DB を作ると、teeny なしで運用している doctree CI・[docs.ruby-lang.org](https://docs.ruby-lang.org/ja/) とゲートの判定がずれます(3.4/3.4.0 の両 DB で実測済み)。

- 既定 `@versions` を teeny なしに変更(理由はコメントに明記)
- `doc/usage.md` の `--versions` の例も teeny なしに
- 既定バージョンに teeny が付かないことのテストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
