### PR TITLE
バージョン 1.7.0 に上げる

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,11 @@ name: Release
 # タグ push で起動し、RubyGems.org への公開に成功してから GitHub release を
 # 作成する(immutable releases 対応のため、release 作成をトリガーにしない)。
 # 認証は rubygems.org の trusted publishing(OIDC)。事前に rubygems.org 側で
-# bitclust-core / bitclust-dev / refe2 の 3 gem それぞれに、このリポジトリの
-# release.yml(environment: release)を trusted publisher として登録しておくこと。
+# bitclust-core / bitclust-dev / bitclust-irb / refe2 の 4 gem それぞれに、
+# このリポジトリの release.yml(environment: release)を trusted publisher
+# として登録しておくこと。未公開の gem を新たに増やしたときは、タグを push
+# する前に pending trusted publisher(未公開 gem 名の事前登録。有効期限あり)
+# として登録する。
 on:
   push:
     tags:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bitclust-core (1.6.1)
+    bitclust-core (1.7.0)
       drb
       json
       nkf
@@ -10,10 +10,10 @@ PATH
       rbs (>= 3.10)
       rouge
       webrick
-    bitclust-dev (1.6.1)
-      bitclust-core (= 1.6.1)
-    refe2 (1.6.1)
-      bitclust-core (= 1.6.1)
+    bitclust-dev (1.7.0)
+      bitclust-core (= 1.7.0)
+    refe2 (1.7.0)
+      bitclust-core (= 1.7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -145,8 +145,8 @@ CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
-  bitclust-core (1.6.1)
-  bitclust-dev (1.6.1)
+  bitclust-core (1.7.0)
+  bitclust-dev (1.7.0)
   concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
@@ -181,7 +181,7 @@ CHECKSUMS
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
   rbs (3.10.3) sha256=70627f3919016134d554e6c99195552ae3ef6020fe034c8e983facc9c192daa6
-  refe2 (1.6.1)
+  refe2 (1.7.0)
   rouge (5.0.0) sha256=e2de9bba2f9cb88f8a73bca3643b560b2b398f32f91bf716f584477bc0175ebc
   rr (3.1.2) sha256=cc4a5cc91f012327d317dc661154419f9d36d8f9c05031ac46accd89ceb0ff1b
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1

--- a/bitclust-dev.gemspec
+++ b/bitclust-dev.gemspec
@@ -16,11 +16,10 @@ EOD
 
   s.metadata = {
     "bug_tracker_uri"   => "https://github.com/rurema/bitclust/issues",
-    "documentation_uri" => "https://github.com/rurema/doctree/wiki",
+    "documentation_uri" => "https://github.com/rurema/bitclust/blob/master/doc/usage.md",
     "homepage_uri"      => s.homepage,
     "source_code_uri"   => "https://github.com/rurema/bitclust",
     "github_repo"       => "https://github.com/rurema/bitclust",
-    "wiki_uri"          => "https://github.com/rurema/doctree/wiki",
   }
 
   s.files         = Dir["tools/*"]

--- a/lib/bitclust/version.rb
+++ b/lib/bitclust/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module BitClust
-  VERSION = "1.6.1"
+  VERSION = "1.7.0"
 end

--- a/refe2.gemspec
+++ b/refe2.gemspec
@@ -16,11 +16,10 @@ EOD
 
   s.metadata = {
     "bug_tracker_uri"   => "https://github.com/rurema/bitclust/issues",
-    "documentation_uri" => "https://github.com/rurema/doctree/wiki",
+    "documentation_uri" => "https://github.com/rurema/bitclust/blob/master/doc/usage.md",
     "homepage_uri"      => s.homepage,
     "source_code_uri"   => "https://github.com/rurema/bitclust",
     "github_repo"       => "https://github.com/rurema/bitclust",
-    "wiki_uri"          => "https://github.com/rurema/doctree/wiki",
   }
 
   s.files         = Dir["bin/refe"]


### PR DESCRIPTION
bitclust 1.7.0 のリリース準備です。

- `version.rb` を 1.7.0 に(`Gemfile.lock` の自 gem 8 箇所も更新)
- `release.yml` のコメントを 4 gem に更新(#326 で bitclust-irb gem が増えたため)。未公開 gem の初回リリースに pending trusted publisher の事前登録が必要なことも書き添え
- refe2 / bitclust-dev の gem メタデータの `documentation_uri` を、退役予定の doctree wiki から [doc/usage.md](https://github.com/rurema/bitclust/blob/master/doc/usage.md) に差し替え(`wiki_uri` は削除。bitclust-core と同じ構成に)

## 同梱範囲

v1.6.1 以降の 17 PR(#306〜#328)。主なもの:

- #321 #322 #323 #324 RBS 型シグネチャ表示(4.0 以降のメソッド見出し下)
- #325 statichtml の版切り替えドロップダウン
- #326 irb から るりま を引く refe コマンド(**新 gem: bitclust-irb**)
- #327 検索結果に説明文(snippet)を表示
- #315 `#%version` にドットなしの単一版指定を追加
- #309 #312 md 形式のクラスメソッド記法(`def Klass.name`)対応とプレフィクス必須化
- #317 statichtml に Markdown 出力オプション

詳細はタグ push 後の GitHub release(自動生成ノート)を参照。

## マージ後のリリース手順

1. rubygems.org で **bitclust-irb の pending trusted publisher を登録**(新規 gem のため。登録には有効期限があるのでタグ push の直前に)
2. このマージコミットに v1.7.0 タグを付けて push → release.yml が 4 gem を公開し GitHub release を作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)
