### PR TITLE
server: -d/--database をサブコマンド側でもグローバル側でも受け付ける

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -135,7 +135,10 @@ setup し直してください（DB はキャッシュなので消して問題�
 
 ```
 bitclust server -d ./db-3_4 --baseurl="" --port=30080 --debug
+bitclust -d ./db-3_4 server --baseurl="" --port=30080 --debug   # グローバル側の -d でも可
 ```
+
+`--debug` を付けないとデーモンとして起動します（端末には戻ってきます）。
 
 <dl>
 <dt>bitclust init</dt>

--- a/lib/bitclust/subcommands/server_command.rb
+++ b/lib/bitclust/subcommands/server_command.rb
@@ -51,7 +51,7 @@ module BitClust
         @parser.on('--baseurl=URL', 'The base URL to host.') {|url|
           @baseurl = url
         }
-        @parser.on('--database=PATH', 'MethodDatabase root directory.') {|path|
+        @parser.on('-d', '--database=PATH', 'MethodDatabase root directory.') {|path|
           @dbpath = path
         }
         @parser.on('--srcdir=PATH', 'BitClust source directory.') {|path|
@@ -86,6 +86,13 @@ module BitClust
         }
       end
 
+      # DB はサブコマンド自身の -d/--database か、グローバル --database
+      # (options[:prefix])のどちらでも受ける。runner にはグローバル側を
+      # 要求させない(ancestors と同じ扱い)
+      def needs_database?
+        false
+      end
+
       def parse(argv)
         super
         load_config_file
@@ -93,10 +100,6 @@ module BitClust
 
         unless @baseurl
           $stderr.puts "missing base URL.  Use --baseurl or check the config file (bitclust setup)"
-          exit 1
-        end
-        unless @dbpath || @autop
-          $stderr.puts "missing database path.  Use --database"
           exit 1
         end
         unless @datadir
@@ -117,6 +120,7 @@ module BitClust
       end
 
       def exec(argv, options)
+        @dbpath = resolve_dbpath(options)
         begin
           require 'webrick'
         rescue LoadError
@@ -209,6 +213,17 @@ module BitClust
         @srcdir ||= dir
         @datadir ||= "#{@srcdir}/data/bitclust"
         @themedir ||= "#{@srcdir}/theme"
+      end
+
+      # サブコマンド側の --database が無ければグローバル --database
+      # (runner の options[:prefix])を使う。--auto のときは不要
+      def resolve_dbpath(options)
+        dbpath = @dbpath || options[:prefix]
+        unless dbpath || @autop
+          $stderr.puts "missing database path.  Use --database (-d)"
+          exit 1
+        end
+        dbpath
       end
 
       def load_config_file

--- a/sig/bitclust/subcommands/server_command.rbs
+++ b/sig/bitclust/subcommands/server_command.rbs
@@ -40,9 +40,13 @@ module BitClust
 
       def initialize: () -> void
 
+      def needs_database?: () -> bool
+
       def parse: (Array[String] argv) -> void
 
       def exec: (Subcommand::argv argv, Subcommand::options options) -> void
+
+      def resolve_dbpath: (Subcommand::options options) -> String?
 
       private
 

--- a/test/test_server_command.rb
+++ b/test/test_server_command.rb
@@ -1,0 +1,47 @@
+require 'test/unit'
+require 'stringio'
+require 'bitclust'
+require 'bitclust/subcommands/server_command'
+
+# bitclust server の DB 指定(rurema/bitclust の出力監査 2026-09):
+# runner の DB 必須チェックはグローバル --database を見るが、server は自前の
+# --database を見ていたため、片方だけでは起動できなかった。
+# - server は DB を自前で受けるので runner に要求させない(needs_database? false)
+# - サブコマンド側の -d/--database と、グローバル --database(options[:prefix])の
+#   どちらでも起動できる
+class TestServerCommand < Test::Unit::TestCase
+  def build(argv)
+    cmd = BitClust::Subcommands::ServerCommand.new
+    cmd.parse(argv)
+    cmd
+  end
+
+  def test_does_not_require_global_database
+    assert_false BitClust::Subcommands::ServerCommand.new.needs_database?
+  end
+
+  def test_parse_accepts_short_option
+    cmd = build(['--baseurl=', '-d', '/tmp/db-x'])
+    assert_equal '/tmp/db-x', cmd.__send__(:resolve_dbpath, {:prefix => nil, :capi => false})
+  end
+
+  def test_parse_accepts_long_option
+    cmd = build(['--baseurl=', '--database=/tmp/db-y'])
+    assert_equal '/tmp/db-y', cmd.__send__(:resolve_dbpath, {:prefix => '/tmp/global', :capi => false})
+  end
+
+  def test_global_database_is_used_as_fallback
+    cmd = build(['--baseurl='])
+    assert_equal '/tmp/global', cmd.__send__(:resolve_dbpath, {:prefix => '/tmp/global', :capi => false})
+  end
+
+  def test_missing_database_aborts_with_guidance
+    cmd = build(['--baseurl='])
+    err = StringIO.new
+    orig, $stderr = $stderr, err
+    assert_raise(SystemExit) { cmd.__send__(:resolve_dbpath, {:prefix => nil, :capi => false}) }
+    assert_match(/--database/, err.string)
+  ensure
+    $stderr = orig
+  end
+end


### PR DESCRIPTION
Refs #335(不具合 1)

## 概要

`bitclust server` は runner の DB 必須チェック(`needs_database?`)が**グローバル** `--database` を見る一方、`ServerCommand#parse` は**自前の** `--database` を見ていたため、片方だけでは「no database given」か「missing database path」で止まり、両方に書かないと起動できませんでした。`doc/usage.md` の例 `bitclust server -d ./db-3_4 ...` も server 側に `-d` が無く `ambiguous option` でした(`bitclust setup` 済みで設定ファイルがあると既定 DB が入るので気づきにくい状態でした)。

## 変更点

- `ServerCommand#needs_database?` を false にして runner にグローバル側を要求させない(`ancestors` と同じ扱い)
- DB パスの解決を `exec` 時の `resolve_dbpath` に移し、サブコマンド側の `-d`/`--database` が無ければグローバル `--database`(`options[:prefix]`)を使う。どちらも無く `--auto` でもなければ従来どおり案内して終了
- server に短縮形 `-d` を追加(usage.md の例がそのまま動く)
- usage.md にグローバル側で指定する例と、`--debug` なしはデーモン化することを追記

## 検証

- 新規 `test/test_server_command.rb`(5 件)・全テスト green・`steep check` OK
- 実 DB(3.4)で `server -d DB` / `-d DB server` / `server --database=DB` の 3 形式とも起動し `/view/class/Array` が 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
