### PR TITLE
epub: --catalog の取り違えを直し、XHTML と manifest を EPUB として妥当にする

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
     rbs (3.10.3)
       logger
       tsort
+    rexml (3.4.4)
     rouge (5.0.0)
       strscan (~> 3.1)
     rr (3.1.2)
@@ -134,6 +135,7 @@ DEPENDENCIES
   bitclust-dev!
   rake
   refe2!
+  rexml
   steep (~> 1.9.0)
   test-unit (>= 2.3.0)
   test-unit-notify
@@ -182,6 +184,7 @@ CHECKSUMS
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
   rbs (3.10.3) sha256=70627f3919016134d554e6c99195552ae3ef6020fe034c8e983facc9c192daa6
   refe2 (1.7.0)
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rouge (5.0.0) sha256=e2de9bba2f9cb88f8a73bca3643b560b2b398f32f91bf716f584477bc0175ebc
   rr (3.1.2) sha256=cc4a5cc91f012327d317dc661154419f9d36d8f9c05031ac46accd89ceb0ff1b
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1

--- a/bitclust-core.gemspec
+++ b/bitclust-core.gemspec
@@ -30,6 +30,8 @@ EOD
   s.add_development_dependency "test-unit", ">= 2.3.0"
   s.add_development_dependency "test-unit-notify"
   s.add_development_dependency "test-unit-rr"
+  # test/test_epub_generator.rb が contents.opf / 生成 XHTML の整形式検証に使う
+  s.add_development_dependency "rexml"
   s.add_runtime_dependency "rack"
   s.add_runtime_dependency "rouge"
   s.add_runtime_dependency "progressbar", ">= 1.9.0", "< 2.0"

--- a/data/bitclust/template.epub/class
+++ b/data/bitclust/template.epub/class
@@ -24,20 +24,20 @@
 <% end %>
 
 <% unless @entry.extended.empty? %>
-<br>extend: <%= @entry.extended.map {|c| class_link(c.name) }.join(', ') %>
+<br />extend: <%= @entry.extended.map {|c| class_link(c.name) }.join(', ') %>
 <% end %>
 <% unless @entry.aliases.empty? %>
-<br>aliases: <%=h @entry.aliases.map{|c| c.name}.join(', ') %>
+<br />aliases: <%=h @entry.aliases.map{|c| c.name}.join(', ') %>
 <% end %>
 <% unless @entry.dynamically_included.empty? %>
-<br> dynamic include:
+<br /> dynamic include:
  <%= @entry.dynamically_included.map{|m|
        class_link(m.name) + " (by " + library_link(m.library.name) + ")"
      }.join(", ")
  %>
 <% end %>
 <% unless @entry.dynamically_extended.empty? %>
-<br> dynamic extend:
+<br /> dynamic extend:
  <%= @entry.dynamically_extended.map{|m|
        class_link(m.name) + " (by " + library_link(m.library.name) + ")"
      }.join(", ")
@@ -72,7 +72,7 @@
   entries.each do |m|
     m.names.each do |mname|
 %>
-<a href="#<%= m.index_id %>"><%= "#{prefix}#{mname}" %></a>
+<a href="#<%= m.index_id %>"><%= escape_html "#{prefix}#{mname}" %></a>
 <%
     end
   end

--- a/data/bitclust/template.epub/class-index
+++ b/data/bitclust/template.epub/class-index
@@ -25,4 +25,3 @@
     end
     headline_pop
 %>
-</ul>

--- a/data/bitclust/template.epub/contents
+++ b/data/bitclust/template.epub/contents
@@ -8,15 +8,18 @@
   </metadata>
   <manifest>
     <item id="toc" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
-    <item id="index" href="OEBPS/doc/index.html" media-type="application/xhtml+xml" />
-<% items.each do |item| -%>
-    <item id="<%= item[:id] %>" href="<%= item[:path] %>" media-type="application/xhtml+xml" />
+    <item id="index" href="OEBPS/doc/index.xhtml" media-type="application/xhtml+xml" />
+<% class_items.each do |item| -%>
+    <item id="<%= item[:id] %>" href="<%= item[:path] %>" media-type="<%= item[:media_type] %>" />
+<% end -%>
+<% other_items.each do |item| -%>
+    <item id="<%= item[:id] %>" href="<%= item[:path] %>" media-type="<%= item[:media_type] %>" />
 <% end -%>
   </manifest>
   <spine>
     <itemref idref="toc" />
     <itemref idref="index" />
-<% items.each do |item| -%>
+<% class_items.each do |item| -%>
     <itemref idref="<%= item[:id] %>" />
 <% end -%>
   </spine>

--- a/data/bitclust/template.epub/layout
+++ b/data/bitclust/template.epub/layout
@@ -2,10 +2,10 @@
 <!DOCTYPE html>
 <html lang="ja-JP">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=<%=h charset() %>">
-  <meta http-equiv="Content-Language" content="ja-JP">
-  <link rel="stylesheet" type="text/css" href="<%=h css_url() %>">
-  <link rel="icon" type="image/png" href="<%=h favicon_url() %>">
+  <meta http-equiv="Content-Type" content="text/html; charset=<%=h charset() %>" />
+  <meta http-equiv="Content-Language" content="ja-JP" />
+  <link rel="stylesheet" type="text/css" href="<%=h css_url() %>" />
+  <link rel="icon" type="image/png" href="<%=h favicon_url() %>" />
   <title><%=h @title %> (Ruby <%=h ruby_version %>)</title>
 </head>
 <body>

--- a/data/bitclust/template.offline/class-index
+++ b/data/bitclust/template.offline/class-index
@@ -54,5 +54,4 @@
     end
     headline_pop
 %>
-</ul>
 </main>

--- a/data/bitclust/template/class-index
+++ b/data/bitclust/template/class-index
@@ -29,5 +29,4 @@
     end
     headline_pop
 %>
-</ul>
 

--- a/lib/bitclust/generators/epub.rb
+++ b/lib/bitclust/generators/epub.rb
@@ -24,11 +24,17 @@ module BitClust
 
       CONTENTS_DIR_NAME = 'OEBPS'
 
+      # StatichtmlCommand が出力ルートに書く 2 行のリダイレクト用スタブ
+      # (<meta http-equiv="refresh"> と <a>)。ルート要素が無く XHTML として
+      # 整形式でない。EPUB の入口は nav.xhtml なのでスタブは同梱せず削除する
+      INDEX_STUB_NAME = 'index.xhtml'
+
       def generate
         make_epub_directory do |epub_directory|
           contents_directory = epub_directory + CONTENTS_DIR_NAME
           copy_static_files(epub_directory)
           generate_xhtml_files(contents_directory)
+          remove_index_stub(contents_directory)
           generate_contents_opf(epub_directory)
           pack_epub(epub_directory)
         end
@@ -71,15 +77,45 @@ module BitClust
         cmd.exec(argv, options)
       end
 
+      # manifest に id="index" で固定的に載せる doc/index ページの href
+      # (epub_directory 相対)。other_items からは除いて二重掲載を避ける
+      INDEX_PATH = Pathname.new("#{CONTENTS_DIR_NAME}/doc/index.xhtml")
+
+      MEDIA_TYPES = {
+        '.xhtml' => 'application/xhtml+xml',
+        '.css'   => 'text/css',
+        '.js'    => 'application/javascript',
+        '.png'   => 'image/png',
+        '.jpg'   => 'image/jpeg',
+        '.jpeg'  => 'image/jpeg',
+        '.gif'   => 'image/gif',
+        '.svg'   => 'image/svg+xml',
+      }.freeze
+
       def generate_contents_opf(epub_directory)
-        items = [] #: Array[{:id => String, :path => Pathname}]
+        class_items = [] #: Array[{:id => String, :path => Pathname, :media_type => String}]
         glob_relative_path(epub_directory, "#{CONTENTS_DIR_NAME}/class/*.xhtml").each do |path|
-          items << {
-            :id => decodename_package(path.basename(".*").to_s),
-            :path => path
+          class_items << {
+            :id => "class-#{decodename_package(path.basename(".*").to_s)}",
+            :path => path,
+            :media_type => media_type_for(path),
           }
         end
-        items.sort_by!{|item| item[:path] }
+        class_items.sort_by!{|item| item[:path] }
+
+        excluded_paths = class_items.map{|item| item[:path] } + [INDEX_PATH]
+        other_items = [] #: Array[{:id => String, :path => Pathname, :media_type => String}]
+        oebps_file_paths(epub_directory).each do |path|
+          next if excluded_paths.include?(path)
+
+          other_items << {
+            :id => manifest_id_for(path),
+            :path => path,
+            :media_type => media_type_for(path),
+          }
+        end
+        other_items.sort_by!{|item| item[:path] }
+
         template = (@templatedir + "contents").read
         if ::ERB.instance_method(:initialize).parameters.last.first == :key
           erb = ::ERB.new(template, trim_mode: '-')
@@ -90,6 +126,34 @@ module BitClust
         File.open(epub_directory + "contents.opf", "w") do |f|
           f.write contents
         end
+      end
+
+      # OEBPS 配下の通常ファイル全部(method/library/doc/function ページと、
+      # statichtml がコピーした CSS・画像)を epub_directory 相対で返す。
+      # class ページも含む(呼び出し側で class_items と重複排除する)
+      def oebps_file_paths(epub_directory)
+        glob_relative_path(epub_directory, "#{CONTENTS_DIR_NAME}/**/*").select do |relative_path|
+          (epub_directory + relative_path).file?
+        end
+      end
+
+      def media_type_for(path)
+        MEDIA_TYPES[path.extname.downcase] || 'application/octet-stream'
+      end
+
+      # class ページ以外("OEBPS/method/Array/i/each.xhtml" 等)の manifest
+      # item id。XML の NCName として妥当で一意になるよう、使えない文字は "-" に
+      # 置き換え、ディレクトリ境界は "--" にして encodename 由来の "-" と
+      # 区別する
+      def manifest_id_for(path)
+        relative = path.to_s.sub(%r{\A#{Regexp.escape(CONTENTS_DIR_NAME)}/}, "")
+        segments = relative.split("/").map{|segment| segment.gsub(/[^A-Za-z0-9_.-]/, "-") }
+        "item-#{segments.join('--')}"
+      end
+
+      def remove_index_stub(contents_directory)
+        stub_path = contents_directory + INDEX_STUB_NAME
+        FileUtils.rm_f(stub_path.to_s, :verbose => @verbose) if stub_path.file?
       end
 
       def pack_epub(epub_directory)

--- a/lib/bitclust/subcommands/epub_command.rb
+++ b/lib/bitclust/subcommands/epub_command.rb
@@ -12,7 +12,7 @@ module BitClust
       def initialize
         super
         @verbose = true
-        @catalogdir = nil
+        @catalogdir = srcdir_root + "data/bitclust/catalog"
         @templatedir = srcdir_root + "data/bitclust/template.epub"
         @themedir = srcdir_root + "theme/default"
         @filename = "rurema-#{Date.today}.epub"
@@ -54,7 +54,7 @@ module BitClust
         generator = BitClust::Generators::EPUB.new(:prefix           => options[:prefix],
                                                    :capi             => options[:capi],
                                                    :outputdir        => @outputdir,
-                                                   :catalog          => @catalog,
+                                                   :catalog          => @catalogdir,
                                                    :templatedir      => @templatedir,
                                                    :themedir         => @themedir,
                                                    :fs_casesensitive => @fs_casesensitive,

--- a/sig/bitclust/generators/epub.rbs
+++ b/sig/bitclust/generators/epub.rbs
@@ -7,7 +7,7 @@ module BitClust
         :outputdir => Pathname,
         :filename => String,
         :templatedir => Pathname,
-        :catalog => nil,
+        :catalog => Pathname,
         :themedir => Pathname,
         :fs_casesensitive => true?,
         :keep => bool,
@@ -26,7 +26,7 @@ module BitClust
 
       @templatedir: Pathname
 
-      @catalog: nil
+      @catalog: Pathname
 
       @themedir: Pathname
 
@@ -40,6 +40,8 @@ module BitClust
 
       CONTENTS_DIR_NAME: "OEBPS"
 
+      INDEX_STUB_NAME: "index.xhtml"
+
       def generate: () -> void
 
       private
@@ -50,7 +52,25 @@ module BitClust
 
       def generate_xhtml_files: (Pathname contents_directory) -> void
 
+      INDEX_PATH: Pathname
+
+      MEDIA_TYPES: Hash[String, String]
+
+      type manifest_item = {
+        :id => String,
+        :path => Pathname,
+        :media_type => String,
+      }
+
       def generate_contents_opf: (Pathname epub_directory) -> void
+
+      def oebps_file_paths: (Pathname epub_directory) -> Array[Pathname]
+
+      def media_type_for: (Pathname path) -> String
+
+      def manifest_id_for: (Pathname path) -> String
+
+      def remove_index_stub: (Pathname contents_directory) -> void
 
       def pack_epub: (Pathname epub_directory) -> void
 

--- a/sig/bitclust/subcommands/epub_command.rbs
+++ b/sig/bitclust/subcommands/epub_command.rbs
@@ -3,7 +3,7 @@ module BitClust
     class EPUBCommand < Subcommand
       @verbose: bool
 
-      @catalogdir: Pathname?
+      @catalogdir: Pathname
 
       @templatedir: Pathname
 

--- a/test/test_epub_command.rb
+++ b/test/test_epub_command.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'test/unit/rr'
+require 'tmpdir'
+require 'bitclust'
+require 'bitclust/subcommands/epub_command'
+require 'bitclust/generators/epub'
+
+# `bitclust epub` は常に失敗していた:
+#
+# 1) --catalog=PATH は @catalogdir に保存されるが、exec は（定義されていない
+#    ため常に nil の）@catalog をジェネレータへ渡していた。ジェネレータは
+#    それを statichtml へ --catalog=（空文字列）として渡し、
+#    Pathname.new("").realpath が Errno::ENOENT で失敗する。
+# 2) @catalogdir の既定値が nil だったので、--catalog を指定しない限り
+#    `bitclust epub -o DIR` は必ず失敗していた
+#    （chm_command / statichtml_command と同じく、既定は同梱の
+#    data/bitclust/catalog にすべき）。
+class TestEPUBCommandCatalog < Test::Unit::TestCase
+  def test_default_catalogdir_is_the_bundled_catalog
+    cmd = BitClust::Subcommands::EPUBCommand.new
+    cmd.parse([])
+    expected = cmd.srcdir_root + "data/bitclust/catalog"
+    assert_equal(expected, cmd.instance_variable_get(:@catalogdir))
+    assert_true(expected.directory?, "#{expected} must exist so --catalog can be omitted")
+  end
+
+  def test_catalog_option_overrides_the_default
+    Dir.mktmpdir do |dir|
+      cmd = BitClust::Subcommands::EPUBCommand.new
+      cmd.parse(["--catalog=#{dir}"])
+      assert_equal(Pathname.new(dir).realpath, cmd.instance_variable_get(:@catalogdir))
+    end
+  end
+
+  def capture_generator_options(cmd)
+    captured = nil
+    fake_generator = Object.new
+    stub(fake_generator).generate { nil }
+    stub(BitClust::Generators::EPUB).new {|opts| captured = opts; fake_generator }
+    cmd.exec([], { :prefix => nil, :capi => false })
+    captured
+  end
+
+  def test_exec_passes_the_default_catalogdir_to_the_generator
+    cmd = BitClust::Subcommands::EPUBCommand.new
+    cmd.parse([])
+    opts = capture_generator_options(cmd)
+    assert_equal(cmd.instance_variable_get(:@catalogdir), opts[:catalog])
+  end
+
+  def test_exec_passes_the_overridden_catalogdir_to_the_generator
+    Dir.mktmpdir do |dir|
+      cmd = BitClust::Subcommands::EPUBCommand.new
+      cmd.parse(["--catalog=#{dir}"])
+      opts = capture_generator_options(cmd)
+      assert_equal(Pathname.new(dir).realpath, opts[:catalog])
+    end
+  end
+end

--- a/test/test_epub_generator.rb
+++ b/test/test_epub_generator.rb
@@ -1,0 +1,334 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'tmpdir'
+require 'fileutils'
+require 'rexml/document'
+require 'bitclust'
+require 'bitclust/generators/epub'
+require 'bitclust/screen'
+require 'bitclust/subcommands/statichtml_command'
+
+# contents.opf のマニフェストは、statichtml が OEBPS 以下に生成する
+# class/method/library/doc/function ページと css/image リソースを
+# すべて（ユニークな id で）列挙しなければならない（EPUB の仕様上必須）。
+# 以前は class ページと nav.xhtml、決め打ちの
+# "OEBPS/doc/index.html"（拡張子が誤り）だけしか載っていなかった。
+class TestEpubGeneratorContentsOpf < Test::Unit::TestCase
+  def build_epub_generator
+    datadir = File.expand_path('../data/bitclust', __dir__)
+    BitClust::Generators::EPUB.new(:templatedir => Pathname.new("#{datadir}/template.epub"))
+  end
+
+  def setup
+    @dir = Dir.mktmpdir
+    @epub_directory = Pathname.new(@dir)
+    @oebps = @epub_directory + "OEBPS"
+    FileUtils.mkdir_p(@oebps + "class")
+    FileUtils.mkdir_p(@oebps + "method/-array/i")
+    FileUtils.mkdir_p(@oebps + "doc")
+    FileUtils.mkdir_p(@oebps + "library")
+    FileUtils.mkdir_p(@oebps + "function")
+    FileUtils.mkdir_p(@oebps + "images")
+
+    File.write(@oebps + "class/-array.xhtml", "<html/>")
+    File.write(@oebps + "class/index.xhtml", "<html/>") # クラス一覧ページ
+    File.write(@oebps + "method/-array/i/each.xhtml", "<html/>")
+    File.write(@oebps + "doc/index.xhtml", "<html/>") # マニュアルのトップページ
+    File.write(@oebps + "doc/help.xhtml", "<html/>")
+    File.write(@oebps + "library/index.xhtml", "<html/>")
+    File.write(@oebps + "library/json.xhtml", "<html/>")
+    File.write(@oebps + "function/index.xhtml", "<html/>")
+    File.write(@oebps + "function/rb_ary_new.xhtml", "<html/>")
+    File.write(@oebps + "style.css", "body{}")
+    File.write(@oebps + "images/rurema.png", "\x89PNG\r\n")
+    File.write(@epub_directory + "nav.xhtml", "<html/>")
+
+    @generator = build_epub_generator
+    @generator.send(:generate_contents_opf, @epub_directory)
+    @opf_path = @epub_directory + "contents.opf"
+    @xml = File.read(@opf_path)
+    @doc = REXML::Document.new(@xml)
+  end
+
+  def teardown
+    FileUtils.rm_rf(@dir)
+  end
+
+  def items
+    REXML::XPath.match(@doc, "//manifest/item")
+  end
+
+  def test_contents_opf_is_well_formed_xml
+    assert_nothing_raised { REXML::Document.new(@xml) }
+  end
+
+  def test_manifest_lists_every_xhtml_page_under_oebps
+    hrefs = items.map {|item| item.attributes['href'] }
+    %w[
+      OEBPS/class/-array.xhtml
+      OEBPS/class/index.xhtml
+      OEBPS/method/-array/i/each.xhtml
+      OEBPS/doc/index.xhtml
+      OEBPS/doc/help.xhtml
+      OEBPS/library/index.xhtml
+      OEBPS/library/json.xhtml
+      OEBPS/function/index.xhtml
+      OEBPS/function/rb_ary_new.xhtml
+      nav.xhtml
+    ].each do |href|
+      assert_include(hrefs, href)
+    end
+  end
+
+  def test_manifest_lists_non_xhtml_resources_that_exist
+    hrefs = items.map {|item| item.attributes['href'] }
+    assert_include(hrefs, "OEBPS/style.css")
+    assert_include(hrefs, "OEBPS/images/rurema.png")
+    style_item = items.find {|item| item.attributes['href'] == "OEBPS/style.css" }
+    assert_equal("text/css", style_item.attributes['media-type'])
+    image_item = items.find {|item| item.attributes['href'] == "OEBPS/images/rurema.png" }
+    assert_equal("image/png", image_item.attributes['media-type'])
+  end
+
+  def test_manifest_item_ids_are_unique
+    ids = items.map {|item| item.attributes['id'] }
+    assert_equal(ids.size, ids.uniq.size, "duplicate manifest item ids: #{ids}")
+  end
+
+  def test_manifest_item_ids_are_valid_xml_ncnames
+    ids = items.map {|item| item.attributes['id'] }
+    assert_false(ids.empty?)
+    ids.each do |id|
+      assert_match(/\A[A-Za-z_][A-Za-z0-9_.-]*\z/, id, "not a valid NCName: #{id.inspect}")
+    end
+  end
+
+  # doc/index.xhtml はマニフェスト中に決め打ちの id="index" として
+  # 一度だけ登場し、doc 以下を走査する側から重複登録されない。
+  def test_doc_index_is_listed_exactly_once_with_the_index_id
+    index_items = items.select {|item| item.attributes['href'] == "OEBPS/doc/index.xhtml" }
+    assert_equal(1, index_items.size)
+    assert_equal("index", index_items.first.attributes['id'])
+  end
+
+  def test_manifest_references_xhtml_not_html_for_the_index
+    hrefs = items.map {|item| item.attributes['href'] }
+    assert_not_include(hrefs, "OEBPS/doc/index.html")
+  end
+
+  # 目次ページ (nav) ・マニュアルのトップページ・クラスページだけが
+  # spine（読み進める順序）に載る。約 11,700 あるメソッドページなどを
+  # spine に加えると読書順序が壊れるので、マニフェストには載るが spine
+  # には載らない。
+  def test_spine_still_excludes_method_library_doc_and_function_pages
+    spine_idrefs = REXML::XPath.match(@doc, "//spine/itemref").map {|el| el.attributes['idref'] }
+    assert_equal(%w[toc index], spine_idrefs.first(2))
+
+    class_item_ids = items.select {|item| item.attributes['href'].to_s.start_with?('OEBPS/class/') }
+                          .map {|item| item.attributes['id'] }
+    assert_equal(%w[toc index] + class_item_ids, spine_idrefs)
+
+    other_ids = items.map {|item| item.attributes['id'] } - %w[toc index] - class_item_ids
+    assert_false(other_ids.empty?)
+    other_ids.each do |id|
+      assert_not_include(spine_idrefs, id)
+    end
+  end
+end
+
+# EPUB のパッケージ（contents.opf）に載る前に、statichtml が出力ルートへ
+# 書く 2 行のリダイレクトスタブ（<meta http-equiv=refresh> + <a>、
+# ルート要素を持たず XML として整形式でない）を消す。
+class TestEpubGeneratorIndexStub < Test::Unit::TestCase
+  def build_epub_generator
+    datadir = File.expand_path('../data/bitclust', __dir__)
+    BitClust::Generators::EPUB.new(:templatedir => Pathname.new("#{datadir}/template.epub"))
+  end
+
+  def setup
+    @dir = Dir.mktmpdir
+    @contents_directory = Pathname.new(@dir) + "OEBPS"
+    FileUtils.mkdir_p(@contents_directory)
+    @generator = build_epub_generator
+  end
+
+  def teardown
+    FileUtils.rm_rf(@dir)
+  end
+
+  def test_removes_the_redirect_stub_statichtml_writes_at_the_root
+    stub_path = @contents_directory + "index.xhtml"
+    File.write(stub_path, "<meta http-equiv=\"refresh\" content=\"0; URL=doc/index.xhtml\">\n<a href=\"doc/index.xhtml\">Go</a>\n")
+    assert_raise(REXML::ParseException) { REXML::Document.new(File.read(stub_path)) }
+
+    @generator.send(:remove_index_stub, @contents_directory)
+
+    assert_false(stub_path.exist?)
+  end
+
+  def test_is_a_noop_when_the_stub_is_absent
+    stub_path = @contents_directory + "index.xhtml"
+    assert_nothing_raised { @generator.send(:remove_index_stub, @contents_directory) }
+    assert_false(stub_path.exist?)
+  end
+
+  # doc/index.xhtml (マニュアルのトップページ) と紛れないことを確認する
+  def test_does_not_touch_the_doc_index_page
+    doc_dir = @contents_directory + "doc"
+    FileUtils.mkdir_p(doc_dir)
+    doc_index = doc_dir + "index.xhtml"
+    File.write(doc_index, "<html/>")
+    @generator.send(:remove_index_stub, @contents_directory)
+    assert_true(doc_index.exist?)
+  end
+end
+
+# data/bitclust/template.epub/layout の <meta>/<link> が自己終了しておらず
+# XHTML として整形式でなかった（bug 2）。また template.epub/class の
+# インデックス一覧が escape_html を通さずメソッド名を出力していたため、
+# "<=>" や "&" のようなメソッド名を含むページが整形式 XML にならなかった
+# （bug 3、template.offline はエスケープ済み: commit 95e1475）。
+#
+# Screen#run_template は ERB 化したテンプレート本体をレシーバの
+# self.class（ClassScreen / MethodScreen そのもの）に「respond_to? なら
+# コンパイルしない」というガード付きでキャッシュする。同一プロセス内で
+# template.offline 用の別テスト（例: test_class_screen.rb）が先に走ると、
+# そちらのコンパイル結果を再利用してしまい、このテストが実際には
+# template.epub を検証できなくなる（test_method_screen.rb に既知の注記
+# あり）。
+#
+# 専用のサブクラスに分けるだけでは防げない: respond_to? は継承した
+# メソッドにも true を返すので、スーパークラス（本物の ClassScreen /
+# MethodScreen）側で他のテストが先に class_template 等をコンパイル済みだと、
+# このサブクラスの run_template はガードに阻まれて自分の
+# @template_repository（= template.epub）で再コンパイルしない。
+# そこで、最初の render より前に明示的に def_method して
+# class_template / method_template / layout をこのサブクラス自身に
+# 直接定義しておく。直接定義されたメソッドは継承したものより優先されるので、
+# 他のテストの実行順序に関係なく template.epub の内容を使わせられる。
+class EpubTestClassScreen < BitClust::ClassScreen; end
+class EpubTestMethodScreen < BitClust::MethodScreen; end
+class EpubTestClassIndexScreen < BitClust::ClassIndexScreen; end
+
+epub_template_repository = BitClust::TemplateRepository.new(
+  "#{File.expand_path('../data/bitclust', __dir__)}/template.epub"
+)
+[
+  [EpubTestClassScreen, 'class', 'class_template'],
+  [EpubTestMethodScreen, 'method', 'method_template'],
+  [EpubTestClassIndexScreen, 'class-index', 'class_index_template'],
+].each do |klass, id, method_name|
+  ERB.new(epub_template_repository.load(id)).def_method(klass, method_name, "#{id}.erb")
+end
+[EpubTestClassScreen, EpubTestMethodScreen, EpubTestClassIndexScreen].each do |klass|
+  ERB.new(epub_template_repository.load('layout')).def_method(klass, 'layout', 'layout.erb')
+end
+
+class TestEpubTemplateWellFormedness < Test::Unit::TestCase
+  SRC = <<'HERE'
+= module Helper
+比較演算子を提供するヘルパーモジュール
+= class Spaceship < Object
+extend Helper
+比較演算子とビット演算子を持つサンプルクラス
+== Instance Methods
+--- <=>(other) -> Integer
+
+比較する。
+
+--- &(other) -> Spaceship
+
+論理積を返す。
+HERE
+
+  def setup
+    datadir = File.expand_path('../data/bitclust', __dir__)
+    @lib, @db = BitClust::RRDParser.parse(SRC, 'testlib', { 'version' => '3.4' })
+    urlmapper = BitClust::Subcommands::StatichtmlCommand::URLMapperEx.new(
+      :suffix => '.xhtml',
+      :css_url => 'style.css',
+      :favicon_url => 'rurema.png'
+    )
+    urlmapper.bitclust_html_base = '..'
+    @manager = BitClust::ScreenManager.new(
+      :templatedir => "#{datadir}/template.epub",
+      :catalogdir => "#{datadir}/catalog",
+      :encoding => 'utf-8',
+      :default_encoding => 'utf-8',
+      :urlmapper => urlmapper,
+      :target_version => '3.4'
+    )
+  end
+
+  def class_entry
+    @lib.fetch_class('Spaceship')
+  end
+
+  def method_entry(name)
+    class_entry.fetch_method(BitClust::MethodSpec.parse("Spaceship##{name}"))
+  end
+
+  def render_class_page
+    @manager.send(:new_screen, EpubTestClassScreen, class_entry, :database => @db).body
+  end
+
+  def render_method_page(name)
+    @manager.send(:new_screen, EpubTestMethodScreen, [method_entry(name)], :database => @db).body
+  end
+
+  def render_class_index_page
+    @manager.send(:new_screen, EpubTestClassIndexScreen, [class_entry], :database => @db).body
+  end
+
+  def test_class_page_escapes_spaceship_operator_in_the_index_list
+    html = render_class_page
+    assert_include(html, '&lt;=&gt;')
+  end
+
+  def test_class_page_escapes_ampersand_operator_in_the_index_list
+    html = render_class_page
+    # "&" 単体がエスケープされて "&amp;" として出る（リンクテキストの終端）
+    assert_match(/&amp;<\/a>/, html)
+  end
+
+  def test_class_page_is_well_formed_xml
+    html = render_class_page
+    assert_nothing_raised { REXML::Document.new(html) }
+  end
+
+  def test_method_page_for_spaceship_operator_is_well_formed_xml
+    html = render_method_page('<=>')
+    assert_nothing_raised { REXML::Document.new(html) }
+  end
+
+  def test_method_page_for_ampersand_operator_is_well_formed_xml
+    html = render_method_page('&')
+    assert_nothing_raised { REXML::Document.new(html) }
+  end
+
+  def test_layout_void_elements_are_self_closing
+    html = render_class_page
+    assert_not_match(%r{<meta[^>]*[^/]>}, html)
+    assert_not_match(%r{<link[^>]*[^/]>}, html)
+  end
+
+  # template.epub/class の "extend:" 行も <br>（非自己終了）を出しており、
+  # そのクラスページ全体が整形式 XML にならなかった（実データベースの
+  # Array・CSV クラスで再現した。どちらも extend/aliases 行を持つ）。
+  def test_class_page_extend_line_uses_a_self_closing_br
+    html = render_class_page
+    assert_include(html, 'extend: ')
+    assert_not_match(%r{<br[^>]*[^/]>}, html)
+    assert_nothing_raised { REXML::Document.new(html) }
+  end
+
+  # template.epub/class-index には対応する <ul> の無い孤立した </ul> が
+  # あり、実データベースで OEBPS/class/index.xhtml が整形式にならなかった
+  # （template.offline/class-index にも同じ孤立タグがあるが、HTML5 として
+  # 読まれる分には実害がないため未修正のまま。EPUB の XHTML では致命的）。
+  def test_class_index_page_has_no_orphaned_closing_tag
+    html = render_class_index_page
+    assert_not_include(html, '</ul>')
+    assert_nothing_raised { REXML::Document.new(html) }
+  end
+end


### PR DESCRIPTION
Refs #335(不具合 3)

## 概要

`bitclust epub` は `--catalog` を `@catalogdir` に保存しながら generator へは `@catalog`(常に nil)を渡していたため、statichtml に `--catalog=`(空)が渡り `File.realpath` で `Errno::ENOENT` になり、2013 年の骨組み以来 CLI からは常に失敗していました。直した後も EPUB としての妥当性が壊れていたので併せて直します。

## 変更点

- `@catalogdir` を渡し、既定値を同梱の `data/bitclust/catalog` にする(`bitclust -d DB epub -o DIR` だけで動く)
- `template.epub/layout` の `<meta>`/`<link>`、`template.epub/class` の `<br>` を自己閉鎖にする(全 xhtml が XML として整形式でなかった)
- `template.epub/class` の目次でメソッド名を `escape_html` する(`<=>` や `&` が生のまま出ていた。`template.offline` は 95e1475 で修正済み)
- `contents.opf` の manifest に OEBPS 配下の全ファイル(method/library/doc/function ページと CSS・画像)を載せる(class ページと nav だけだった)。id は NCName として妥当で一意なものにし、doc/index の参照を `.html` から `.xhtml` に直す。spine は従来どおり nav・doc index・class ページのみ
- statichtml が出力ルートに書くリダイレクト用スタブ `index.xhtml`(ルート要素なし)は EPUB では不要なので削除する
- class-index テンプレートの対応する `<ul>` が無い余分な `</ul>` を除く(epub/offline/server の 3 テンプレートとも同じ余りがあったので揃えて除去。statichtml の `class/index.html` は 1 行減るだけ)
- テストの整形式検証に rexml(Ruby 3.4 では bundled gem)を development dependency として追加

## 検証

- 新規 `test/test_epub_command.rb`(4 件)・`test/test_epub_generator.rb`(19 件)。全テスト green・`rake sig`/`steep check` OK
- 実 DB(3.4)で `bitclust -d DB epub -o DIR` が完走(約 46 秒・19MB・xhtml 13,095 件)。zip 検証 OK・manifest 13,108 件で未掲載/欠損ゼロ。REXML で全 xhtml を検査し、SyntaxHighlighter の修正 PR と組み合わせた状態で**整形式でないファイル 0 件**(単体では highlighter 起因の 3 件が残る)

下書きは sonnet、査読・検証は Fable で行いました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
