### PR TITLE
server: /opensearchdescription が 500 になるのを直す

### DIFF
--- a/lib/bitclust/screen.rb
+++ b/lib/bitclust/screen.rb
@@ -654,7 +654,8 @@ module BitClust
     attr_reader :search_full_url
 
     def body
-      run_template('opensearchdescription')
+      # XML なので HTML の layout は通さない
+      run_template('opensearchdescription', false)
     end
 
     def content_type

--- a/test/test_opensearchdescription_screen.rb
+++ b/test/test_opensearchdescription_screen.rb
@@ -1,0 +1,43 @@
+require 'test/unit'
+require 'uri'
+require 'bitclust'
+require 'bitclust/screen'
+
+# bitclust server の /opensearchdescription(rurema/bitclust の出力監査 2026-09):
+# OpenSearchDescriptionScreen が HTML の layout を通っていたため、layout が呼ぶ
+# charset() が無く NoMethodError で 500 になっていた。XML なので layout を
+# 通さずテンプレートだけを描画する
+class TestOpenSearchDescriptionScreen < Test::Unit::TestCase
+  SRC = <<'HERE'
+= class Foo
+description
+HERE
+
+  def screen
+    _lib, db = BitClust::RRDParser.parse(SRC, 'testlib', {'version' => '3.4'})
+    datadir = File.expand_path('../data/bitclust', __dir__)
+    manager = BitClust::ScreenManager.new(
+      :templatedir => "#{datadir}/template",
+      :catalogdir => "#{datadir}/catalog",
+      :encoding => 'utf-8',
+      :default_encoding => 'utf-8',
+      :base_url => '',
+      :cgi_url => '/view',
+      :target_version => '3.4'
+    )
+    manager.opensearchdescription_screen(URI.parse('http://example.com/view/opensearchdescription'),
+                                         :database => db)
+  end
+
+  def test_body_is_bare_xml_without_html_layout
+    body = screen.body
+    assert_match(/\A<\?xml/, body)
+    assert_not_include(body, '<html')
+    assert_match(%r{\A<\?xml[^>]*\?>\s*<OpenSearchDescription\b.*</OpenSearchDescription>\s*\z}m, body)
+    assert_include(body, 'http://example.com/view/search')
+  end
+
+  def test_content_type_is_opensearch_xml
+    assert_equal 'application/opensearchdescription+xml; charset=utf-8', screen.content_type
+  end
+end


### PR DESCRIPTION
Refs #335(不具合 4)

## 概要

`bitclust server` の `/opensearchdescription` が 500 になっていました。`OpenSearchDescriptionScreen#body` が `run_template` の既定(layout あり)で HTML の layout を通しており、layout が呼ぶ `charset()` がこのクラスに無い(`alias charset encoding` は他のクラスだけ)ため `NoMethodError` でした。そもそも XML を HTML の layout で包むのもおかしいので、layout を通さずテンプレートだけを描画します。

## 検証

- 新規 `test/test_opensearchdescription_screen.rb`(2 件: 本文が `<?xml` で始まり `<html` を含まないこと・Content-Type)・全テスト green
- 実 DB(3.4)で `/view/opensearchdescription` が 200・`application/opensearchdescription+xml; charset=utf-8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
