### PR TITLE
query: @db が nil のまま eval していたのを直す

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -239,6 +239,7 @@ htmlfile が処理できるのは旧 RD ソース（refm）のみで、Markdown 
 
 <dl>
 <dt>bitclust query</dt>
+<dd>データベースに対して Ruby スクリプトを実行する（スクリプトからは `@db` で参照する）。</dd>
 <dt>bitclust property</dt>
 <dd>データベースプロパティを操作する。</dd>
 </dl>
@@ -246,6 +247,8 @@ htmlfile が処理できるのは旧 RD ソース（refm）のみで、Markdown 
 例
 
 ```
+bitclust -d ./db query '@db.classes.size'
+bitclust -d ./db query '@db.fetch_class("Array").superclass.name'
 bitclust -d ./db property --list
 bitclust -d ./db property --get encoding
 bitclust -d ./db property --set encoding euc-jp

--- a/lib/bitclust/subcommands/query_command.rb
+++ b/lib/bitclust/subcommands/query_command.rb
@@ -19,6 +19,7 @@ module BitClust
       end
 
       def exec(argv, options)
+        super   # @db を用意する(スクリプトからは @db で参照する)
         argv.each do |query|
           # pp eval(query)   # FIXME: causes ArgumentError
           p eval(query)

--- a/test/test_query_command.rb
+++ b/test/test_query_command.rb
@@ -1,0 +1,32 @@
+require 'test/unit'
+require 'stringio'
+require 'tmpdir'
+require 'bitclust'
+require 'bitclust/subcommands/query_command'
+
+# bitclust query(rurema/bitclust の出力監査 2026-09):
+# exec が super を呼ばず @db が nil のまま eval していたため使えなかった
+class TestQueryCommand < Test::Unit::TestCase
+  def run_query(script, capi: false)
+    Dir.mktmpdir do |dir|
+      cmd = BitClust::Subcommands::QueryCommand.new
+      cmd.parse([script])
+      out = StringIO.new
+      orig, $stdout = $stdout, out
+      begin
+        cmd.exec([script], {:prefix => dir, :capi => capi})
+      ensure
+        $stdout = orig
+      end
+      out.string
+    end
+  end
+
+  def test_db_is_available_to_the_script
+    assert_equal %Q("BitClust::MethodDatabase"\n), run_query('@db.class.name')
+  end
+
+  def test_capi_uses_function_database
+    assert_equal %Q("BitClust::FunctionDatabase"\n), run_query('@db.class.name', capi: true)
+  end
+end


### PR DESCRIPTION
Refs #335(不具合 5)

## 概要

`bitclust query` は `QueryCommand#exec` が `Subcommand#exec`(DB を開く)を呼んでいなかったため `@db` が nil のまま `eval` され、`'@db.classes.size'` でも `undefined method for nil` で使えませんでした。

## 変更点

- `super` を呼んで `@db` を用意する
- `doc/usage.md` に query の説明(スクリプトからは `@db` で参照)と例を追加

## 検証

- 新規 `test/test_query_command.rb`(2 件: MethodDatabase / `--capi` で FunctionDatabase)・全テスト green
- 実 DB(3.4)で `query '@db.classes.size'` → 1332、`'@db.fetch_class("Array").superclass.name'` → "Object"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
