### PR TITLE
SyntaxHighlighter: シンボルなどの span が閉じないのを直す

### DIFF
--- a/lib/bitclust/syntax_highlighter.rb
+++ b/lib/bitclust/syntax_highlighter.rb
@@ -161,9 +161,6 @@ module BitClust
         data << "<span class=\"nf\">#{token}</span>"
       when @stack.last == :embexpr
         data << "<span class=\"n\">#{token}</span>"
-      when @stack.last == :heredoc
-        style = COLORS[:heredoc_beg]
-        data << "<span class=\"#{style}\">#{token}"
       when @stack.last == :method_call
         data << "<span class=\"nf\">#{token}</span>"
         @stack.pop
@@ -384,6 +381,22 @@ module BitClust
         data << escape_html(token)
       else
         on_default(:on_tstring_content, token, data)
+      end
+      data
+    end
+
+    # "a": / 'b': 形式のシンボルキー。開いている文字列の span を
+    # 文字列終端と同じ流儀で閉じる
+    def on_label_end(token, data)
+      case @stack.last
+      when :string1
+        data << "#{escape_html(token)}</span>"
+        @stack.pop
+      when :string2
+        data << "<span class=\"s2\">#{escape_html(token)}</span>"
+        @stack.pop
+      else
+        on_default(:on_label_end, token, data)
       end
       data
     end

--- a/lib/bitclust/syntax_highlighter.rb
+++ b/lib/bitclust/syntax_highlighter.rb
@@ -192,6 +192,48 @@ module BitClust
       data
     end
 
+    # on_symbeg が開いた <span class="ss"> を、シンボルの末尾トークン
+    # (HTML エスケープ済み)を添えて閉じ、@stack の :symbol を外す。
+    # on_ident/on_const/on_kw は従来どおり自前で閉じるので、それ以外の
+    # 末尾になりうるトークン(ivar/cvar/gvar/backtick/op/文字列終端)から呼ぶ
+    def close_symbol_span(token, data)
+      data << "#{escape_html(token)}</span>"
+      @stack.pop
+      data
+    end
+
+    def on_ivar(token, data)
+      if @stack.last == :symbol
+        close_symbol_span(token, data)
+      else
+        on_default(:on_ivar, token, data)
+      end
+    end
+
+    def on_cvar(token, data)
+      if @stack.last == :symbol
+        close_symbol_span(token, data)
+      else
+        on_default(:on_cvar, token, data)
+      end
+    end
+
+    def on_gvar(token, data)
+      if @stack.last == :symbol
+        close_symbol_span(token, data)
+      else
+        on_default(:on_gvar, token, data)
+      end
+    end
+
+    def on_backtick(token, data)
+      if @stack.last == :symbol
+        close_symbol_span(token, data)
+      else
+        on_default(:on_backtick, token, data)
+      end
+    end
+
     def on_kw(token, data)
       case
       when @stack.last == :symbol
@@ -221,6 +263,8 @@ module BitClust
 
     def on_op(token, data)
       case
+      when @stack.last == :symbol
+        close_symbol_span(token, data)
       when token == "::" && [:class, :module].include?(_ = @stack.last)
         @name_buffer << token
       when token == "<<" && @stack.last == :class
@@ -312,7 +356,7 @@ module BitClust
 
     def on_symbeg(token, data)
       style = COLORS[:symbeg]
-      data << "<span class=\"#{style}\">#{token}"
+      data << "<span class=\"#{style}\">#{escape_html(token)}"
       @stack << :symbol
       data
     end
@@ -336,6 +380,8 @@ module BitClust
         data << escape_html(token)
       when @stack.last == :string2
         data << "<span class=\"s2\">#{escape_html(token)}</span>"
+      when @stack.last == :symbol
+        data << escape_html(token)
       else
         on_default(:on_tstring_content, token, data)
       end
@@ -344,6 +390,8 @@ module BitClust
 
     def on_tstring_end(token, data)
       case
+      when @stack.last == :symbol
+        data << "#{escape_html(token)}</span>"
       when token == "'"
         data << "#{token}</span>"
       when %i[qwords words qsymbols symbols].include?(_ = @stack.last)

--- a/sig/bitclust/syntax_highlighter.rbs
+++ b/sig/bitclust/syntax_highlighter.rbs
@@ -81,6 +81,8 @@ module BitClust
 
     def on_tstring_content: (String token, String data) -> String
 
+    def on_label_end: (String token, String data) -> String
+
     def on_tstring_end: (String token, String data) -> String
 
     def on_qwords_beg: (String token, String data) -> String

--- a/sig/bitclust/syntax_highlighter.rbs
+++ b/sig/bitclust/syntax_highlighter.rbs
@@ -49,6 +49,16 @@ module BitClust
 
     def on_const: (String token, String data) -> String
 
+    def close_symbol_span: (String token, String data) -> String
+
+    def on_ivar: (String token, String data) -> String
+
+    def on_cvar: (String token, String data) -> String
+
+    def on_gvar: (String token, String data) -> String
+
+    def on_backtick: (String token, String data) -> String
+
     def on_kw: (String token, String data) -> String
 
     def on_period: (String token, String data) -> String

--- a/test/test_syntax_highlighter.rb
+++ b/test/test_syntax_highlighter.rb
@@ -234,4 +234,36 @@ class TestSyntaxHighlighter < Test::Unit::TestCase
     END
     assert_equal(expected, highlight(source))
   end
+
+  sub_test_case "heredoc argument and quoted label" do
+    def assert_balanced(html)
+      assert_equal html.scan(/<span\b/).size, html.scan(%r{</span>}).size, html
+    end
+
+    test 'identifier after a heredoc argument is rendered normally' do
+      html = highlight("method(arg1, <<LABEL, arg2)\n    x\nLABEL\n")
+      assert_include(html, ', arg2<span class="p">)</span>')
+      assert_balanced(html)
+    end
+
+    test 'block argument after a heredoc argument' do
+      html = highlight("ERB.new(<<~'END_PRODUCT', eoutvar: \"@product\").result b\n  x\nEND_PRODUCT\n")
+      assert_balanced(html)
+      assert_not_include(html, '<span class="no">b')
+    end
+
+    test 'quoted symbol keys close the string span' do
+      html = highlight(%q({ "a":"A", 'b':"B" }) + "\n")
+      assert_balanced(html)
+      assert_include(html, %q(<span class="s1">'b':</span>))
+      assert_include(html, %q(<span class="s2">a</span><span class="s2">&quot;:</span>))
+    end
+
+    test 'quoted symbol key does not leak the stack' do
+      with = highlight(%q({ "a":"A" }) + "\ndef foo\nend\n")
+      without = highlight("def foo\nend\n")
+      assert_include(with, without.lines[0].chomp)
+      assert_balanced(with)
+    end
+  end
 end

--- a/test/test_syntax_highlighter.rb
+++ b/test/test_syntax_highlighter.rb
@@ -123,6 +123,98 @@ class TestSyntaxHighlighter < Test::Unit::TestCase
     assert_equal(expected, highlight(source))
   end
 
+  sub_test_case "symbol span" do
+    test 'ivar symbol' do
+      source = "x = :@records\n"
+      expected = "x <span class=\"o\">=</span> <span class=\"ss\">:@records</span>\n"
+      assert_equal(expected, highlight(source))
+    end
+
+    test 'cvar symbol' do
+      source = "x = :@@cv\n"
+      expected = "x <span class=\"o\">=</span> <span class=\"ss\">:@@cv</span>\n"
+      assert_equal(expected, highlight(source))
+    end
+
+    test 'gvar symbol' do
+      source = "x = :$stdout\n"
+      expected = "x <span class=\"o\">=</span> <span class=\"ss\">:$stdout</span>\n"
+      assert_equal(expected, highlight(source))
+    end
+
+    test 'operator symbols' do
+      source = <<~END
+        a = :+
+        b = :<<
+        c = :[]
+        d = :[]=
+        e = :<=>
+        f = :!
+      END
+      expected = <<~END
+        a <span class="o">=</span> <span class="ss">:+</span>
+        b <span class="o">=</span> <span class="ss">:&lt;&lt;</span>
+        c <span class="o">=</span> <span class="ss">:[]</span>
+        d <span class="o">=</span> <span class="ss">:[]=</span>
+        e <span class="o">=</span> <span class="ss">:&lt;=&gt;</span>
+        f <span class="o">=</span> <span class="ss">:!</span>
+      END
+      assert_equal(expected, highlight(source))
+    end
+
+    test '%s dynamic symbol literal' do
+      source = "x = %s!sym!\n"
+      expected = "x <span class=\"o\">=</span> <span class=\"ss\">%s!sym!</span>\n"
+      assert_equal(expected, highlight(source))
+    end
+
+    test 'double-quoted dynamic symbol' do
+      source = "x = :\"dyn\"\n"
+      expected = "x <span class=\"o\">=</span> <span class=\"ss\">:&quot;dyn&quot;</span>\n"
+      assert_equal(expected, highlight(source))
+    end
+
+    test 'well-formedness of mixed symbol spans' do
+      source = <<~END
+        x = :@records
+        y = :@@cv
+        z = :$stdout
+        a = :+
+        b = :<<
+        c = :[]
+        s = %s!sym!
+        d = :"dyn"
+      END
+      result = highlight(source)
+      assert_equal(result.scan('<span').size, result.scan('</span>').size)
+    end
+
+    test 'symbol does not leak the stack into later tokens' do
+      source = <<~END
+        x = :@records
+        def foo
+        end
+      END
+      baseline = highlight("def foo\nend\n")
+      result = highlight(source)
+      assert(
+        result.end_with?(baseline),
+        "expected result to end with unaffected `def foo/end` rendering:\n" \
+        "  baseline: #{baseline.inspect}\n" \
+        "  result:   #{result.inspect}"
+      )
+    end
+
+    test 'label is not treated as a symbol' do
+      source = "h = { a: 1 }\nfoo(:x, k: 2)\n"
+      result = highlight(source)
+      assert_equal(result.scan('<span').size, result.scan('</span>').size)
+      assert_match(%r{<span class="ss">a:</span>}, result)
+      assert_match(%r{<span class="ss">k:</span>}, result)
+      assert_match(%r{<span class="ss">:x</span>}, result)
+    end
+  end
+
   test 'one liner module' do
     source = <<~END
       module Foo; end


### PR DESCRIPTION
Refs #335(不具合 6)

## 概要

Ripper ベースの `SyntaxHighlighter`(ruby コードの色付け)は `on_symbeg` で `<span class="ss">` を開き、`on_ident`/`on_const`/`on_kw` でしか閉じていませんでした。そのため `:@ivar`・`:@@cvar`・`:$gvar`・`:+`/`:<<` などの演算子シンボル・`%s!x!`・`:"x"` では ss の span が閉じずに入れ子になり、statichtml を含む全出力で HTML が不正になっていました(EPUB では xhtml 23 件が XML として壊れる原因)。さらに `@stack` に `:symbol` が残り続け、後続の `def` などの描画まで崩れていました(`x = :@a` の次行の `def foo` が `def</span> foo` になる)。

## 変更点

- 末尾になりうるトークン(ivar/cvar/gvar/backtick/op/文字列内容・終端)で span を閉じて `:symbol` を外す `close_symbol_span` を追加
- `on_symbeg` のトークンもエスケープする(`:"` の描画)
- 既存のシンボル描画(`:ident`/`:Const`/`:kw`/`%i[]`)は変更なし(既存テストは無変更で通過)

## 追加修正(2 コミット目)

EPUB の全 xhtml 検査で残った 3 件の原因も同じクラスにあったので併せて直しました。

- `method(arg1, <<LABEL, arg2)` のようにヒアドキュメント開始の後に同じ行で続く識別子を、`on_ident` が閉じない `<span class="no">` で描画していた(Ruby 3 の Ripper では `heredoc_beg` が `<<LABEL` 全体なので不要な分岐)
- `{ "a": 1, 'b': 2 }` の引用符付きシンボルキーは `on_label_end` で終わるため、`on_tstring_beg` が開いた文字列の span が閉じず `@stack` にも残っていた

## 検証

- `test/test_syntax_highlighter.rb` に `sub_test_case "symbol span"` 9 件と `"heredoc argument and quoted label"` 4 件を追加(いずれも red → green)。全テスト green・`rake sig`/`steep check` OK
- EPUB の PR と組み合わせた状態で、実 DB(3.4)の xhtml 13,097 件すべてが XML として整形式
- 実 DB(3.4)の `Forwardable#def_delegators` が `<span class="ss">:@records</span>` と閉じて描画される

下書きは sonnet、査読・検証は Fable で行いました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
