### PR TITLE
extract/htmlfile: Markdown ソースを渡されたら未対応である旨を案内する

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -278,7 +278,8 @@ bitclust methods --ruby=3.4 --diff=../doctree/refm/api/src/_builtin/Object Objec
 ```
 
 --diff に渡せるのは旧 RD ソース(refm)のみで、Markdown ソース(manual/)には
-未対応です(htmlfile と同じ)。
+未対応です(htmlfile と同じ)。extract も同様に旧 RD ソース専用で、
+`.md` を渡すと未対応である旨のエラーになります。
 
 ### パッケージ作成者向け
 

--- a/lib/bitclust/subcommands/extract_command.rb
+++ b/lib/bitclust/subcommands/extract_command.rb
@@ -25,6 +25,7 @@ module BitClust
       def exec(argv, options)
         success = true
         argv.each do |path|
+          reject_markdown_source(path)
           begin
             lib = RRDParser.parse_stdlib_file(path)
             if @check_only
@@ -39,6 +40,13 @@ module BitClust
           end
         end
         exit success
+      end
+
+      # 旧 RD ソース(refm)専用。Markdown を渡されたときは無関係なパースエラー
+      # にせず、未対応であることを案内する
+      def reject_markdown_source(path)
+        return unless path.end_with?('.md')
+        error "#{path}: extract は旧 RD ソース(refm)専用で、Markdown(manual/ の .md)には未対応です。manual/ の内容は doctree の rake generate:X.Y と bitclust server で確認してください"
       end
 
       def show_library(lib)

--- a/lib/bitclust/subcommands/htmlfile_command.rb
+++ b/lib/bitclust/subcommands/htmlfile_command.rb
@@ -47,6 +47,7 @@ module BitClust
         end
         @capi = options[:capi]
         target_file = argv[0]
+        reject_markdown_source(target_file)
         if /refm\/doc\// =~ target_file
           @rd_file = true if @rd_file.nil?
         end
@@ -87,6 +88,13 @@ module BitClust
       end
 
       private
+
+      # 旧 RD ソース(refm)専用。Markdown を渡されたときは無関係なパースエラー
+      # にせず、未対応であることを案内する
+      def reject_markdown_source(path)
+        return unless path && path.end_with?('.md')
+        error "#{path}: htmlfile は旧 RD ソース(refm)専用で、Markdown(manual/ の .md)には未対応です。manual/ の内容は doctree の rake generate:X.Y と bitclust server(または rake statichtml:X.Y)で確認してください"
+      end
 
       def lookup(lib, key)
         case

--- a/sig/bitclust/subcommands/extract_command.rbs
+++ b/sig/bitclust/subcommands/extract_command.rbs
@@ -9,6 +9,8 @@ module BitClust
 
       def exec: (Subcommand::argv argv, Subcommand::options options) -> void
 
+      def reject_markdown_source: (String path) -> void
+
       def show_library: (LibraryEntry lib) -> void
     end
   end

--- a/sig/bitclust/subcommands/htmlfile_command.rbs
+++ b/sig/bitclust/subcommands/htmlfile_command.rbs
@@ -21,6 +21,8 @@ module BitClust
 
       private
 
+      def reject_markdown_source: (String? path) -> void
+
       def lookup: (Array[FunctionEntry] | LibraryEntry lib, String key) -> (FunctionEntry | ClassEntry | Array[MethodEntry] | bot)
     end
   end

--- a/test/test_extract_command.rb
+++ b/test/test_extract_command.rb
@@ -1,0 +1,48 @@
+require 'test/unit'
+require 'stringio'
+require 'tmpdir'
+require 'bitclust'
+require 'bitclust/subcommands/extract_command'
+require 'bitclust/subcommands/htmlfile_command'
+
+# extract / htmlfile は旧 RD ソース(refm)専用(rurema/bitclust の出力監査 2026-09):
+# Markdown(manual/ の .md)を渡すと無関係なパースエラーになっていたので、
+# 未対応であることを案内して失敗する
+class TestRdOnlyCommandsRejectMarkdown < Test::Unit::TestCase
+  def with_md_file
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'Array.md')
+      File.write(path, "---\nlibrary: _builtin\n---\n# class Array < Object\n")
+      yield path
+    end
+  end
+
+  def capture_stderr
+    err = StringIO.new
+    orig, $stderr = $stderr, err
+    yield
+    err.string
+  ensure
+    $stderr = orig
+  end
+
+  def test_extract_explains_markdown_is_unsupported
+    with_md_file do |path|
+      cmd = BitClust::Subcommands::ExtractCommand.new
+      cmd.parse([path])
+      msg = capture_stderr { assert_raise(SystemExit) { cmd.exec([path], {:prefix => nil, :capi => false}) } }
+      assert_match(/Markdown/, msg)
+      assert_match(/refm/, msg)
+    end
+  end
+
+  def test_htmlfile_explains_markdown_is_unsupported
+    with_md_file do |path|
+      cmd = BitClust::Subcommands::HtmlfileCommand.new
+      cmd.parse([path])
+      msg = capture_stderr { assert_raise(SystemExit) { cmd.exec([path], {:prefix => nil, :capi => false}) } }
+      assert_match(/Markdown/, msg)
+      assert_match(/rake generate|bitclust server/, msg)
+    end
+  end
+end


### PR DESCRIPTION
Refs #335(不具合 7)

## 概要

`extract` と `htmlfile` は旧 RD ソース(refm)専用ですが、manual/ の `.md` を渡すと「met bare method entry in library document ...」という無関係なパースエラーで失敗していました(htmlfile は usage.md に RD 専用と明記済み、extract は明記なし)。

## 変更点

- `.md` を渡されたときは、未対応であることと manual/ の確認手段(doctree の `rake generate:X.Y` と `bitclust server`)を案内して終了する(extract・htmlfile とも)
- `doc/usage.md` に extract も RD 専用であることを追記

## 検証

- 新規 `test/test_extract_command.rb`(2 件)・全テスト green・`steep check` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
